### PR TITLE
fix: segmented control disabled and vertical items

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -62,6 +62,7 @@ module.exports = {
       allowExpressions: true
     }],
     "@typescript-eslint/no-shadow": ["error"],
+    "@typescript-eslint/prefer-nullish-coalescing": "off",
 
     /**
      * Eslint plugin React Hooks

--- a/src/components/SegmentedControl/SegmentedControl.module.css
+++ b/src/components/SegmentedControl/SegmentedControl.module.css
@@ -76,12 +76,12 @@
     0 2px 4px 0 rgba(0,0,0,.02);
 }
 
-.segmentedOption.vertical {
+.segmentedOption.vertical, .segmentedOption.primary.vertical {
   flex-direction: column;
   gap: calc(var(--spacing-gap-sm, 8) * 1px);
 }
 
-.segmentedOption.disabled {
+.segmentedOption.disabled, .segmentedOption.primary.disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }

--- a/src/components/SegmentedControl/SegmentedControl.test.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.test.tsx
@@ -46,11 +46,11 @@ describe('Segmented Control Component', () => {
 
       expect(screen.getByRole('list')).toBeVisible()
 
-      labeledOptions.forEach(({ key }) => {
+      labeledOptions.forEach(({ key, isDisabled }) => {
         const option = screen.getByRole('listitem', { name: key })
 
         expect(option).toBeVisible()
-        expect(option).toHaveAttribute('aria-disabled', 'false')
+        expect(option).toHaveAttribute('aria-disabled', isDisabled ? 'true' : 'false')
       })
 
       expect(screen.getByRole('listitem', { name: selectedOption.key })).toHaveAttribute('aria-checked', 'true')
@@ -63,11 +63,11 @@ describe('Segmented Control Component', () => {
 
       expect(screen.getByRole('list')).toBeVisible()
 
-      labeledOptions.forEach(({ key }) => {
+      labeledOptions.forEach(({ key, isDisabled }) => {
         const option = screen.getByRole('listitem', { name: key })
 
         expect(option).toBeVisible()
-        expect(option).toHaveAttribute('aria-disabled', 'false')
+        expect(option).toHaveAttribute('aria-disabled', isDisabled ? 'true' : 'false')
       })
 
       expect(screen.getByRole('listitem', { name: selectedOption.key })).toHaveAttribute('aria-checked', 'true')
@@ -80,11 +80,11 @@ describe('Segmented Control Component', () => {
 
       expect(screen.getByRole('list')).toBeVisible()
 
-      labeledOptions.forEach(({ key }) => {
+      labeledOptions.forEach(({ key, isDisabled }) => {
         const option = screen.getByRole('listitem', { name: key })
 
         expect(option).toBeVisible()
-        expect(option).toHaveAttribute('aria-disabled', 'false')
+        expect(option).toHaveAttribute('aria-disabled', isDisabled ? 'true' : 'false')
       })
 
       expect(screen.getByRole('listitem', { name: selectedOption.key })).toHaveAttribute('aria-checked', 'true')

--- a/src/components/SegmentedControl/SegmentedControl.utils.ts
+++ b/src/components/SegmentedControl/SegmentedControl.utils.ts
@@ -39,7 +39,7 @@ export function isString(element: Option | number): element is string {
  * @returns {boolean} `true` if the option is disabled, `false` otherwise.
  */
 export function isDisabledOption(option: Option, isDisabled: boolean): boolean {
-  return isDisabled || (!isString(option) && option?.isDisabled)
+  return isDisabled || (!isString(option) && option?.isDisabled) || false
 }
 
 /**

--- a/src/components/SegmentedControl/SegmentedControl.utils.ts
+++ b/src/components/SegmentedControl/SegmentedControl.utils.ts
@@ -39,7 +39,7 @@ export function isString(element: Option | number): element is string {
  * @returns {boolean} `true` if the option is disabled, `false` otherwise.
  */
 export function isDisabledOption(option: Option, isDisabled: boolean): boolean {
-  return (!isString(option) && option?.isDisabled) || isDisabled
+  return isDisabled || (!isString(option) && option?.isDisabled)
 }
 
 /**

--- a/src/components/SegmentedControl/SegmentedControl.utils.ts
+++ b/src/components/SegmentedControl/SegmentedControl.utils.ts
@@ -39,7 +39,7 @@ export function isString(element: Option | number): element is string {
  * @returns {boolean} `true` if the option is disabled, `false` otherwise.
  */
 export function isDisabledOption(option: Option, isDisabled: boolean): boolean {
-  return isDisabled ?? (!isString(option) && option?.isDisabled)
+  return (!isString(option) && option?.isDisabled) || isDisabled
 }
 
 /**

--- a/src/components/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/src/components/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
@@ -224,9 +224,9 @@ exports[`Segmented Control Component labeled options renders options correctly 1
     </li>
     <li
       aria-checked="true"
-      aria-disabled="false"
+      aria-disabled="true"
       aria-label="three"
-      class="segmentedOption selected"
+      class="segmentedOption selected disabled"
     >
       <svg
         alt="AiOutlineDesktop"
@@ -400,9 +400,9 @@ exports[`Segmented Control Component labeled options renders primary options cor
     </li>
     <li
       aria-checked="true"
-      aria-disabled="false"
+      aria-disabled="true"
       aria-label="three"
-      class="segmentedOption primary selected"
+      class="segmentedOption primary selected disabled"
     >
       <svg
         alt="AiOutlineDesktop"
@@ -576,9 +576,9 @@ exports[`Segmented Control Component labeled options renders vertical options co
     </li>
     <li
       aria-checked="true"
-      aria-disabled="false"
+      aria-disabled="true"
       aria-label="three"
-      class="segmentedOption selected vertical"
+      class="segmentedOption selected vertical disabled"
     >
       <svg
         alt="AiOutlineDesktop"


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! -->

### Description

<!-- Please provide a brief description of the work you have done and the motivations linked to these modifications. -->

##### SegmentedControl

Segmented control can now correctly singularly disable options, it also renders the primary hierarchy correctly (vertical and disabled options were affected).

### Checklist

<!-- For further details regarding standards and conventions adopted in this repository please take a look at the CONTRIBUTING.md file. -->

- [ ] added the link to the Jira task
- [x] commit message and branch name follow conventions
- [x] tests are included
- [x] changes are accessible and documented from components stories
- [x] typings are updated or integrated accordingly with your changes
- [x] all added files include Apache 2.0 license
- [ ] the changelog has been updated accordingly with your changes
- [x] you are not committing extraneous files or sensible data
- [x] the browser console does not have any logged errors
