### PR TITLE
ci: fix storybook dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
     groups:
       storybook:
         patterns:
+        - "storybook"
         - "@storybook*"
         update-types:
         - "minor"


### PR DESCRIPTION
storybook grouping did not include storybook package 😅 

<img width="780" alt="image" src="https://github.com/mia-platform/design-system/assets/7142570/62b0ca33-195c-4aa1-8e5a-eb750d885863">
