### PR TITLE
fix: useFeedbackMessage methods returns a promise

### DIFF
--- a/src/hooks/useFeedbackMessage/useFeedbackMessage.test.tsx
+++ b/src/hooks/useFeedbackMessage/useFeedbackMessage.test.tsx
@@ -18,7 +18,7 @@
 
 /* eslint-disable react/no-multi-comp */
 
-import { act, fireEvent, render, screen } from '../../test-utils'
+import { act, fireEvent, render, screen, waitFor } from '../../test-utils'
 import { Position } from './useFeedbackMessage.types'
 import { useFeedbackMessage } from './useFeedbackMessage'
 
@@ -69,6 +69,29 @@ describe('useFeedbackMessage', () => {
     expect(await screen.findByRole('img', { name: 'check-circle' })).toBeVisible()
     expect(screen.getByText(message)).toBeVisible()
     expect(screen.getByRole('button', { name: 'Close' })).toBeVisible()
+  })
+
+  test('useFeedbackMessage methods return a Promise', async() => {
+    const afterCloseMockFn = jest.fn()
+
+    const Example = (): JSX.Element => {
+      const { info } = useFeedbackMessage()
+
+      const onClick = (): void => {
+        info(
+          { message: 'This is a feedback message', duration: 0.1 }
+        ).then(() => { afterCloseMockFn() })
+      }
+
+      return <button type="button" onClick={onClick}>Open</button>
+    }
+
+    render(<Example />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open' }))
+
+    act(() => jest.advanceTimersByTime(101))
+    await waitFor(() => { expect(afterCloseMockFn).toHaveBeenCalledTimes(1) })
   })
 
   test('FeedbackMessage disappears after 5 seconds', async() => {

--- a/src/hooks/useFeedbackMessage/useFeedbackMessage.tsx
+++ b/src/hooks/useFeedbackMessage/useFeedbackMessage.tsx
@@ -60,14 +60,14 @@ const BOTTOM_MESSAGE_KEY = '__BOTTOM_MESSAGE_KEY__'
  * manage the rendering of feedback messages.
  */
 export const useFeedbackMessage = (): MessageAPI => {
-  const open = useCallback((type: Type, props: UseFeedbackMessageProps): void => {
+  const open = useCallback((type: Type, props: UseFeedbackMessageProps): PromiseLike<boolean> => {
     const { key, duration, sticky, position, ...messageProps } = props
 
     const messageKey = position === Position.Bottom
       ? BOTTOM_MESSAGE_KEY
       : key
 
-    message.open({
+    return message.open({
       className: classnames([
         styles.feedbackMessage,
         position === Position.Bottom && styles.bottom,

--- a/src/hooks/useFeedbackMessage/useFeedbackMessage.types.tsx
+++ b/src/hooks/useFeedbackMessage/useFeedbackMessage.types.tsx
@@ -43,42 +43,42 @@ export type MessageAPI = {
    */
   dismiss: (key?: string) => void
 
-    /**
-     * Renders a FeedbackMessage with a spinner animation
-     *
-     * @param {UseFeedbackMessageProps} props - the configuration of the message to render
-     * @returns {PromiseLike<boolean>} a promise that the message has disappeared
-     */
-    loading: (props: UseFeedbackMessageProps) => PromiseLike<boolean>
+  /**
+   * Renders a FeedbackMessage with a spinner animation
+   *
+   * @param {UseFeedbackMessageProps} props - the configuration of the message to render
+   * @returns {PromiseLike<boolean>} a promise that the message has disappeared
+   */
+  loading: (props: UseFeedbackMessageProps) => PromiseLike<boolean>
 
-    /**
-     * Renders a FeedbackMessage with an "info" icon
-     *
-     * @param {UseFeedbackMessageProps} props - the configuration of the message to render
-     * @returns {PromiseLike<boolean>} a promise that the message has disappeared
-     */
-    info: (props: UseFeedbackMessageProps) => PromiseLike<boolean>
+  /**
+   * Renders a FeedbackMessage with an "info" icon
+   *
+   * @param {UseFeedbackMessageProps} props - the configuration of the message to render
+   * @returns {PromiseLike<boolean>} a promise that the message has disappeared
+   */
+  info: (props: UseFeedbackMessageProps) => PromiseLike<boolean>
 
-    /**
-     * Renders a FeedbackMessage with a "success" icon
-     *
-     * @param {UseFeedbackMessageProps} props - the configuration of the message to render
-     * @returns {PromiseLike<boolean>} a promise that the message has disappeared
-     */
-    success: (props: UseFeedbackMessageProps) => PromiseLike<boolean>
+  /**
+   * Renders a FeedbackMessage with a "success" icon
+   *
+   * @param {UseFeedbackMessageProps} props - the configuration of the message to render
+   * @returns {PromiseLike<boolean>} a promise that the message has disappeared
+   */
+  success: (props: UseFeedbackMessageProps) => PromiseLike<boolean>
 
-    /**
-     * Renders a FeedbackMessage with a "warning" icon
-     *
-     * @param {UseFeedbackMessageProps} props - the configuration of the message to render
-     * @returns {PromiseLike<boolean>} a promise that the message has disappeared
-     */
-    error: (props: UseFeedbackMessageProps) => PromiseLike<boolean>
+  /**
+   * Renders a FeedbackMessage with a "warning" icon
+   *
+   * @param {UseFeedbackMessageProps} props - the configuration of the message to render
+   * @returns {PromiseLike<boolean>} a promise that the message has disappeared
+   */
+  error: (props: UseFeedbackMessageProps) => PromiseLike<boolean>
 
-    /**
-     * Renders a FeedbackMessage with an "error" icon
-     *
-     * @param {UseFeedbackMessageProps} props - the configuration of the message to render
-     */
-    warning: (props: UseFeedbackMessageProps) => PromiseLike<boolean>
-  }
+  /**
+   * Renders a FeedbackMessage with an "error" icon
+   *
+   * @param {UseFeedbackMessageProps} props - the configuration of the message to render
+   */
+  warning: (props: UseFeedbackMessageProps) => PromiseLike<boolean>
+}

--- a/src/hooks/useFeedbackMessage/useFeedbackMessage.types.tsx
+++ b/src/hooks/useFeedbackMessage/useFeedbackMessage.types.tsx
@@ -47,34 +47,39 @@ export type MessageAPI = {
      * Renders a FeedbackMessage with a spinner animation
      *
      * @param {UseFeedbackMessageProps} props - the configuration of the message to render
+     * @returns {PromiseLike<boolean>} a promise that the message has disappeared
      */
-    loading: (props: UseFeedbackMessageProps) => void
+    loading: (props: UseFeedbackMessageProps) => PromiseLike<boolean>
 
     /**
      * Renders a FeedbackMessage with an "info" icon
      *
      * @param {UseFeedbackMessageProps} props - the configuration of the message to render
+     * @returns {PromiseLike<boolean>} a promise that the message has disappeared
      */
-    info: (props: UseFeedbackMessageProps) => void
+    info: (props: UseFeedbackMessageProps) => PromiseLike<boolean>
 
     /**
      * Renders a FeedbackMessage with a "success" icon
      *
      * @param {UseFeedbackMessageProps} props - the configuration of the message to render
+     * @returns {PromiseLike<boolean>} a promise that the message has disappeared
      */
-    success: (props: UseFeedbackMessageProps) => void
+    success: (props: UseFeedbackMessageProps) => PromiseLike<boolean>
 
     /**
      * Renders a FeedbackMessage with a "warning" icon
      *
      * @param {UseFeedbackMessageProps} props - the configuration of the message to render
+     * @returns {PromiseLike<boolean>} a promise that the message has disappeared
      */
-    error: (props: UseFeedbackMessageProps) => void
+    error: (props: UseFeedbackMessageProps) => PromiseLike<boolean>
 
     /**
      * Renders a FeedbackMessage with an "error" icon
      *
      * @param {UseFeedbackMessageProps} props - the configuration of the message to render
+     * @returns {PromiseLike<boolean>} a promise that the message has disappeared
      */
-    warning: (props: UseFeedbackMessageProps) => void
+    warning: (props: UseFeedbackMessageProps) => PromiseLike<boolean>
   }


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! -->

### Description

<!-- Please provide a brief description of the work you have done and the motivations linked to these modifications. -->

##### [useFeedbackMessage]

Updated the component to have the methods (`info`, `loading`, `success`, `warning`, `error`) to have return a Promise (of type `boolean`).

### Issue ticket number and link

<!-- Be sure to provide the link to the relative Jira issue, if present. -->

The issue has been notified in #331 .

### Checklist

<!-- For further details regarding standards and conventions adopted in this repository please take a look at the CONTRIBUTING.md file. -->

- [X] added the link to the Jira task
- [X] commit message and branch name follow conventions
- [X] tests are included
- [X] changes are accessible and documented from components stories
- [X] typings are updated or integrated accordingly with your changes
- [X] all added components are exported from index file (if necessary)
- [X] all added files include Apache 2.0 license
- [X] you are not committing extraneous files or sensible data
- [X] the browser console does not have any logged errors
- [X] necessary labels have been applied to this pull request (enhancement, bug, ecc.)
