### PR TITLE
export hook as function rather than arrow function const

### DIFF
--- a/src/hooks/useFeedbackMessage/useFeedbackMessage.tsx
+++ b/src/hooks/useFeedbackMessage/useFeedbackMessage.tsx
@@ -59,7 +59,7 @@ const BOTTOM_MESSAGE_KEY = '__BOTTOM_MESSAGE_KEY__'
  * @returns {MessageAPI} An object which includes several functions to
  * manage the rendering of feedback messages.
  */
-export const useFeedbackMessage = (): MessageAPI => {
+export function useFeedbackMessage(): MessageAPI {
   const open = useCallback((type: Type, props: UseFeedbackMessageProps): PromiseLike<boolean> => {
     const { key, duration, sticky, position, ...messageProps } = props
 


### PR DESCRIPTION
### Description

I'm having issues with the hook returned values being undefined in certain situations 

given a simple usage such as 

```
  const {loading, success, dismiss} = useFeedbackMessagezioporco()
```

I see errors telling me that `success(...) is undefined`. I'm having troubles debugging but my guess is that being this an arrow function is not having a proper scope and something is failing along the line

