### PR TITLE
chore(pkg): add support for `exports` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   "main": "dist/cjs/console-design-system-react.cjs",
   "module": "dist/es/console-design-system-react.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/es/console-design-system-react.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "description": "Mia Platform Design System",
   "author": "Mia Platform Core Team <core@mia-platform.eu>",
   "license": "Apache-2.0",


### PR DESCRIPTION

### Description

To allow tree-shaking in latest vite.js versions (and other tools), it is mandatory to seek `ESM` libraries using the [`exports` field](https://nodejs.org/api/packages.html#subpath-exports).

If not specified, libraries will default back to the `main` field which is usually the `cjs` bundle, thus preventing tree-shaking.

According to the `module` field, this commit adds a meaningful support for the `exports` field

<!-- Hi, and thank you for your time dedicated to this pull request! -->

##### [INVOLVED_COMPONENT_HERE]

none

### Checklist

<!-- For further details regarding standards and conventions adopted in this repository please take a look at the CONTRIBUTING.md file. -->

- [x] commit message and branch name follow conventions
- [x] tests are included (none needed)
