### PR TITLE
Revert "chore(pkg): add support for `exports` field"

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,6 @@
   "main": "dist/cjs/console-design-system-react.cjs",
   "module": "dist/es/console-design-system-react.js",
   "types": "dist/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./dist/es/console-design-system-react.js",
-      "types": "./dist/index.d.ts"
-    }
-  },
   "description": "Mia Platform Design System",
   "author": "Mia Platform Core Team <core@mia-platform.eu>",
   "license": "Apache-2.0",


### PR DESCRIPTION
Reverts #358 due to an incompatibility with the manual CSS import. 
To be merged again once the CSS automatic import is implemented.