### PR TITLE
fix: menu style on inline mode

### DIFF
--- a/src/components/Menu/Menu.module.css
+++ b/src/components/Menu/Menu.module.css
@@ -39,11 +39,17 @@
   &:global(.mia-platform-menu-inline) ul[role*=menu] {
     padding-left: var(--menu-pad) !important;
   }
+  &:global(.mia-platform-menu-inline.primary) > li[role*=presentation] > div[role*=presentation] {
+    padding: var(--menu-pad) var(--menu-pad) var(--menu-pad-sm) 0 !important;
+  }
   &:global(.mia-platform-menu-inline) > li[role*=presentation] > div[role*=presentation] {
     padding: var(--menu-pad) var(--menu-pad) var(--menu-pad-sm) var(--menu-pad-xs) !important;
   } 
-  &:global(.mia-platform-menu-inline) div[role*=presentation] {
+  &:global(.mia-platform-menu-inline.primary) div[role*=presentation] {
     padding-left: 0 !important;
+  }
+  &:global(.mia-platform-menu-inline) div[role*=presentation] {
+    padding-left: var(--menu-pad-xs) !important;
   }
 
   /* Vertical */

--- a/src/components/Menu/Menu.module.css
+++ b/src/components/Menu/Menu.module.css
@@ -19,9 +19,10 @@
 .menu {
   --menu-pad: calc(var(--spacing-padding-md, 12) * 1px);
   --menu-pad-sm: calc((var(--spacing-padding-md, 12) * 1px) / 2);
+  --menu-pad-xs: calc((var(--spacing-padding-xs, 4) * 1px));
 
   --collapsed-width: 80px;
-  --collapsed-pad: calc((var(--spacing-padding-lg, 16) * 1px));
+  --collapsed-margin: calc(var(--spacing-margin-xs, 4) * 1px);
   --collapsed-margin: calc(var(--spacing-padding-xs, 4) * 1px);
 
   :global([role*=menuitem]) {
@@ -39,7 +40,7 @@
     padding-left: var(--menu-pad) !important;
   }
   &:global(.mia-platform-menu-inline) > li[role*=presentation] > div[role*=presentation] {
-    padding: var(--menu-pad) var(--menu-pad) var(--menu-pad-sm) 0 !important;
+    padding: var(--menu-pad) var(--menu-pad) var(--menu-pad-sm) var(--menu-pad-xs) !important;
   } 
   &:global(.mia-platform-menu-inline) div[role*=presentation] {
     padding-left: 0 !important;

--- a/src/components/Menu/Menu.module.css
+++ b/src/components/Menu/Menu.module.css
@@ -46,6 +46,7 @@
   &:global(.mia-platform-menu-vertical) :global(.mia-platform-menu-submenu-popup) {
     background: none !important;
   }
+  /* The popover is generated on the left when the parent node has a width less than the popover content. In the case of the left sidebar attached to the left side of the window, this causes the node to exit outside the screen */
   &:global(.mia-platform-menu-inline-collapsed) :global(.mia-platform-menu-submenu-popup) {
     left: 100px !important;
     width: auto !important;

--- a/src/components/Menu/Menu.module.css
+++ b/src/components/Menu/Menu.module.css
@@ -23,7 +23,6 @@
 
   --collapsed-width: 80px;
   --collapsed-margin: calc(var(--spacing-margin-xs, 4) * 1px);
-  --collapsed-margin: calc(var(--spacing-padding-xs, 4) * 1px);
 
   :global([role*=menuitem]) {
     display: flex;

--- a/src/components/Menu/Menu.module.css
+++ b/src/components/Menu/Menu.module.css
@@ -22,6 +22,7 @@
   --menu-pad-xs: calc((var(--spacing-padding-xs, 4) * 1px));
 
   --collapsed-width: 80px;
+  --collapsed-pad: calc((var(--spacing-padding-lg, 12) * 1px))
   --collapsed-margin: calc(var(--spacing-margin-xs, 4) * 1px);
 
   :global([role*=menuitem]) {

--- a/src/components/Menu/Menu.module.css
+++ b/src/components/Menu/Menu.module.css
@@ -20,6 +20,10 @@
   --menu-pad: calc(var(--spacing-padding-md, 12) * 1px);
   --menu-pad-sm: calc((var(--spacing-padding-md, 12) * 1px) / 2);
 
+  --collapsed-width: 80px;
+  --collapsed-pad: calc((var(--spacing-padding-lg, 16) * 1px));
+  --collapsed-margin: calc(var(--spacing-padding-xs, 4) * 1px);
+
   :global([role*=menuitem]) {
     display: flex;
     align-items: center;
@@ -27,7 +31,7 @@
 
   :global(.mia-platform-menu-sub) {
     border-radius: calc(var(--shape-border-radius-md, 4) * 1px) !important;
-    padding: 0 4px !important
+    padding: 0 calc(var(--spacing-padding-xs, 4) * 1px) !important;
   }
 
   /* Inline */
@@ -36,8 +40,7 @@
   }
   &:global(.mia-platform-menu-inline) > li[role*=presentation] > div[role*=presentation] {
     padding: var(--menu-pad) var(--menu-pad) var(--menu-pad-sm) 0 !important;
-  }
-  
+  } 
   &:global(.mia-platform-menu-inline) div[role*=presentation] {
     padding-left: 0 !important;
   }
@@ -46,17 +49,18 @@
   &:global(.mia-platform-menu-vertical) :global(.mia-platform-menu-submenu-popup) {
     background: none !important;
   }
-  /* 
-  The popover is generated on the left when the parent node has a width less than the popover content. 
-  In the case of the left sidebar attached to the left side of the window, 
-  this causes the node to exit outside the screen 
-  */
-  &:global(.mia-platform-menu-inline-collapsed) :global(.mia-platform-menu-submenu-popup) {
-    left: 100px !important;
-    width: auto !important;
-  }
   &:global(.mia-platform-menu-vertical) div[role*=presentation] {
     padding: var(--menu-pad) var(--menu-pad) var(--menu-pad-sm) !important;
+  }
+  
+  /* 
+    The popover is generated on the left when the parent node has a width less than the popover content. 
+    In the case of the left sidebar attached to the left side of the window causes the node to exit outside the screen 
+  */
+  /* Collapsed */
+  &:global(.mia-platform-menu-inline-collapsed) :global(.mia-platform-menu-submenu-popup) {
+    left: calc(var(--collapsed-width) + var(--collapsed-pad) + var(--collapsed-margin)) !important;
+    width: auto !important;
   }
 
   &:global(:not(.mia-platform-menu-inline-collapsed)) li[role*=menuitem],

--- a/src/components/Menu/Menu.module.css
+++ b/src/components/Menu/Menu.module.css
@@ -60,9 +60,9 @@
     padding: var(--menu-pad) var(--menu-pad) var(--menu-pad-sm) !important;
   }
   
-  /* 
-    The popover is generated on the left when the parent node has a width less than the popover content. 
-    In the case of the left sidebar attached to the left side of the window causes the node to exit outside the screen 
+  /*
+    The popover is generated on the left when the parent node has a width less than the popover content.
+    In the case of the left sidebar attached to the left side of the window causes the node to exit outside the screen.
   */
   /* Collapsed */
   &:global(.mia-platform-menu-inline-collapsed) :global(.mia-platform-menu-submenu-popup) {

--- a/src/components/Menu/Menu.module.css
+++ b/src/components/Menu/Menu.module.css
@@ -46,7 +46,11 @@
   &:global(.mia-platform-menu-vertical) :global(.mia-platform-menu-submenu-popup) {
     background: none !important;
   }
-  /* The popover is generated on the left when the parent node has a width less than the popover content. In the case of the left sidebar attached to the left side of the window, this causes the node to exit outside the screen */
+  /* 
+  The popover is generated on the left when the parent node has a width less than the popover content. 
+  In the case of the left sidebar attached to the left side of the window, 
+  this causes the node to exit outside the screen 
+  */
   &:global(.mia-platform-menu-inline-collapsed) :global(.mia-platform-menu-submenu-popup) {
     left: 100px !important;
     width: auto !important;

--- a/src/components/Menu/Menu.module.css
+++ b/src/components/Menu/Menu.module.css
@@ -27,6 +27,7 @@
 
   :global(.mia-platform-menu-sub) {
     border-radius: calc(var(--shape-border-radius-md, 4) * 1px) !important;
+    padding: 0 4px !important
   }
 
   /* Inline */
@@ -34,8 +35,9 @@
     padding-left: var(--menu-pad) !important;
   }
   &:global(.mia-platform-menu-inline) > li[role*=presentation] > div[role*=presentation] {
-    padding: var(--menu-pad) var(--menu-pad) var(--menu-pad-sm) !important;
+    padding: var(--menu-pad) var(--menu-pad) var(--menu-pad-sm) 0 !important;
   }
+  
   &:global(.mia-platform-menu-inline) div[role*=presentation] {
     padding-left: 0 !important;
   }
@@ -43,6 +45,10 @@
   /* Vertical */
   &:global(.mia-platform-menu-vertical) :global(.mia-platform-menu-submenu-popup) {
     background: none !important;
+  }
+  &:global(.mia-platform-menu-inline-collapsed) :global(.mia-platform-menu-submenu-popup) {
+    left: 100px !important;
+    width: auto !important;
   }
   &:global(.mia-platform-menu-vertical) div[role*=presentation] {
     padding: var(--menu-pad) var(--menu-pad) var(--menu-pad-sm) !important;

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -50,7 +50,8 @@ export const Menu = ({
   selectedKey,
 }: MenuProps): ReactElement => {
   const theme = useTheme()
-  const menuTheme = hierarchy === Primary ? primaryTheme(theme) : defaultTheme(theme)
+  const isPrimary = hierarchy === Primary
+  const menuTheme = isPrimary ? primaryTheme(theme) : defaultTheme(theme)
 
   const [selectedItem, setSelectedItem] = useState(defaultSelectedKey)
 
@@ -66,7 +67,7 @@ export const Menu = ({
         paragraph={Menu.skeletonParagraph}
       >
         <AntMenu
-          className={menu}
+          className={`${menu}${isPrimary ? ' primary' : ''}`}
           defaultOpenKeys={defaultOpenKeys}
           defaultSelectedKeys={defaultSelectedKey ? [defaultSelectedKey] : undefined}
           // getPopupContainer is needed for nested menus to inherit CSS properties in the vertical mode

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -18,6 +18,7 @@
 
 import { Menu as AntMenu, ConfigProvider, Skeleton } from 'antd'
 import { ReactElement, useMemo, useState } from 'react'
+import classNames from 'classnames'
 
 import { Hierarchy, Mode } from './Menu.types'
 import defaultTheme, { primaryTheme } from './Menu.theme'
@@ -49,9 +50,15 @@ export const Menu = ({
   openKeys,
   selectedKey,
 }: MenuProps): ReactElement => {
-  const theme = useTheme()
   const isPrimary = hierarchy === Primary
+
+  const theme = useTheme()
   const menuTheme = isPrimary ? primaryTheme(theme) : defaultTheme(theme)
+
+  const menuClassNames = useMemo(() => classNames([
+    menu,
+    isPrimary && 'primary',
+  ]), [isPrimary])
 
   const [selectedItem, setSelectedItem] = useState(defaultSelectedKey)
 
@@ -67,7 +74,7 @@ export const Menu = ({
         paragraph={Menu.skeletonParagraph}
       >
         <AntMenu
-          className={`${menu}${isPrimary ? ' primary' : ''}`}
+          className={menuClassNames}
           defaultOpenKeys={defaultOpenKeys}
           defaultSelectedKeys={defaultSelectedKey ? [defaultSelectedKey] : undefined}
           // getPopupContainer is needed for nested menus to inherit CSS properties in the vertical mode

--- a/src/components/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/Menu.test.tsx.snap
@@ -603,7 +603,7 @@ exports[`Menu Component renders item correctly 1`] = `
 exports[`Menu Component renders primary menu correctly 1`] = `
 <DocumentFragment>
   <ul
-    class="mia-platform-menu mia-platform-menu-root mia-platform-menu-inline mia-platform-menu-light menu"
+    class="mia-platform-menu mia-platform-menu-root mia-platform-menu-inline mia-platform-menu-light menu primary"
     data-menu-list="true"
     role="menu"
     tabindex="0"


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! -->

### Description

Antd's popover menu is not generated correctly. The popover is generated on the left when the parent node has a smaller width than the popover content. In the case of the left sidebar, this causes an external output of the node. 

##### [Menu]

To fix this the specific case the CSS has been modified 

### Checklist

<!-- For further details regarding standards and conventions adopted in this repository please take a look at the CONTRIBUTING.md file. -->

- [x] added the link to the Jira task
- [x] commit message and branch name follow conventions
- [ ] tests are included
- [x] changes are accessible and documented from components stories
- [x] typings are updated or integrated accordingly with your changes
- [x] all added components are exported from index file (if necessary)
- [x] all added files include Apache 2.0 license
- [x] you are not committing extraneous files or sensible data
- [x] the browser console does not have any logged errors
- [x] necessary labels have been applied to this pull request (enhancement, bug, ecc.)
