### PR TITLE
fix: small and large modal width and height updated

### DIFF
--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -165,19 +165,19 @@
 
 .modalSm {
   width: 40% !important;
-  min-width: 600px;
-  max-width: 800px;
+  min-width: 480px;
+  max-width: 640px;
   height: 50% !important;
-  min-height: 360px;
-  max-height: 480px;
+  min-height: 480px;
+  max-height: 640px;
 }
 
 .modalLg {
-  width: 70% !important;
-  min-width: 900px;
-  max-width: 1600px;
-  height: 85% !important;
-  min-height: 540px;
+  width: 55% !important;
+  min-width: 720px;
+  max-width: 1200px;
+  height: 50% !important;
+  min-height: 640px;
   max-height: 1080px;
 }
 


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! -->

### Description

<!-- Please provide a brief description of the work you have done and the motivations linked to these modifications. -->

##### [Modal]

We introduce some changes on height and width of modals, in both small and large sizes.

- Small modals will have width between 480 and 640 px (before: 600-800) and height between 480 and 640 px (before: 360-480);
- Large modals will take 55% of the viewport width (before: 75%) with limits between 720 and 1200 px (instead of 900-1600) and height of 50% viewport height, with limits between 540 and 1080 px (before: 85% and 540-1080 as limit).

### Checklist

<!-- For further details regarding standards and conventions adopted in this repository please take a look at the CONTRIBUTING.md file. -->

- [ ] added the link to the Jira task
- [X] commit message and branch name follow conventions
- [ ] tests are included
- [X] changes are accessible and documented from components stories
- [X] typings are updated or integrated accordingly with your changes
- [X] all added components are exported from index file (if necessary)
- [X] all added files include Apache 2.0 license
- [X] you are not committing extraneous files or sensible data
- [X] the browser console does not have any logged errors
- [X] necessary labels have been applied to this pull request (enhancement, bug, ecc.)
