### PR TITLE
feat: removed components defaultProps

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -22,6 +22,7 @@ import { action } from '@storybook/addon-actions'
 import { Hierarchy, IconPosition, Shape, Size, Type } from './Button.types'
 import { Button } from '.'
 import { Icon } from '../Icon'
+import { defaults } from './Button'
 
 const { Primary, Neutral, Danger } = Hierarchy
 const { Left, Right } = IconPosition
@@ -34,7 +35,7 @@ const icon = <Icon color="white" name="PiCircleHalfTiltLight" size={16} />
 const meta = {
   component: Button,
   args: {
-    ...Button.defaultProps,
+    ...defaults,
     children: 'Button',
     onClick: action('click'),
   },

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -61,7 +61,7 @@ export const Button = ({
   shape = defaults.shape,
   size = defaults.size,
   target,
-  type = Filled,
+  type = defaults.type,
 }: ButtonProps): ReactElement => {
   const buttonClassNames = useMemo(() => classnames(
     [

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -32,6 +32,16 @@ const { Square } = Shape
 const { Small, Middle, Large } = Size
 const { Filled, Ghost } = Type
 
+export const defaults = {
+  hierarchy: Primary,
+  iconPosition: Left,
+  isDisabled: false,
+  isLoading: false,
+  shape: Square,
+  size: Middle,
+  type: Filled,
+}
+
 /**
  * UI component for performing actions on the page interacting through clicks
  *
@@ -40,19 +50,18 @@ const { Filled, Ghost } = Type
  */
 export const Button = ({
   children,
-  form,
-  hierarchy,
+  hierarchy = defaults.hierarchy,
   href,
   htmlType,
   icon,
-  iconPosition,
-  isDisabled,
-  isLoading,
+  iconPosition = defaults.iconPosition,
+  isDisabled = defaults.isDisabled,
+  isLoading = defaults.isLoading,
   onClick,
-  shape,
-  size,
+  shape = defaults.shape,
+  size = defaults.size,
   target,
-  type,
+  type = Filled,
 }: ButtonProps): ReactElement => {
   const buttonClassNames = useMemo(() => classnames(
     [
@@ -86,14 +95,4 @@ export const Button = ({
       {iconPosition === Right && icon}
     </AntButton>
   )
-}
-
-Button.defaultProps = {
-  hierarchy: Primary,
-  iconPosition: Left,
-  isDisabled: false,
-  isLoading: false,
-  shape: Square,
-  size: Middle,
-  type: Filled,
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -50,6 +50,7 @@ export const defaults = {
  */
 export const Button = ({
   children,
+  form,
   hierarchy = defaults.hierarchy,
   href,
   htmlType,

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -22,10 +22,11 @@ import { actionButton, children, docLink, extra, subtitle, title } from './Card.
 import { hugeData, rowKey, scroll, scrollableColumns } from '../Table/Table.mocks'
 import { Card } from '.'
 import { Table } from '../Table'
+import { defaults } from './Card'
 
 const meta = {
   component: Card,
-  args: Card.defaultProps,
+  args: defaults,
   argTypes: {
     children: { control: false },
     extra: { control: false },

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -32,6 +32,10 @@ const { Circle } = Shape
 const { Ghost } = Type
 const { card, content, header, heading } = styles
 
+export const defaults = {
+  isLoading: false,
+}
+
 /**
  * UI component used to display content related to a single subject
  *
@@ -41,7 +45,7 @@ export const Card = ({
   children,
   docLink,
   extra,
-  isLoading,
+  isLoading = defaults.isLoading,
   subtitle,
   title,
 }: CardProps): ReactElement => {
@@ -88,8 +92,4 @@ export const Card = ({
 Card.skeletonParagraph = {
   rows: 3,
   width: ['80%', '65%', '70%'],
-}
-
-Card.defaultProps = {
-  isLoading: false,
 }

--- a/src/components/Divider/Divider.stories.tsx
+++ b/src/components/Divider/Divider.stories.tsx
@@ -20,11 +20,10 @@ import type { Meta, StoryObj } from '@storybook/react'
 
 import { Divider } from '.'
 import { Orientation } from './Divider.types'
+import { defaults } from './Divider'
 
 const meta = {
-  args: {
-    ...Divider.defaultProps,
-  },
+  args: defaults,
   argTypes: {
     text: {
       control: {

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -26,6 +26,11 @@ import { useTheme } from '../../hooks/useTheme'
 const { Horizontal } = Orientation
 const { Left } = TextOrientation
 
+export const defaults = {
+  orientation: Horizontal,
+  textOrientation: Left,
+}
+
 /**
  * A divider line to separate different content
  *
@@ -33,9 +38,9 @@ const { Left } = TextOrientation
  * @returns {Divider} Divider component
  */
 export const Divider = ({
-  orientation,
+  orientation = defaults.orientation,
   text,
-  textOrientation,
+  textOrientation = defaults.textOrientation,
 }: DividerProps): ReactElement => {
   const { spacing } = useTheme()
 
@@ -48,9 +53,4 @@ export const Divider = ({
       {text}
     </AntDivider>
   )
-}
-
-Divider.defaultProps = {
-  orientation: Horizontal,
-  textOrientation: Left,
 }

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -19,6 +19,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
 import { Icon } from '.'
+import { defaults } from './Icon'
 
 const iconsUrl = 'https://react-icons.github.io/react-icons/search'
 
@@ -27,9 +28,7 @@ const meta = {
   parameters: {
     design: { type: 'iframe', name: 'Search', url: iconsUrl },
   },
-  args: {
-    ...Icon.defaultProps,
-  },
+  args: defaults,
 } satisfies Meta<typeof Icon>
 
 export default meta

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -22,6 +22,10 @@ import { IconContext } from 'react-icons'
 import { IconProps, customIcons, reactIcons } from './Icon.props'
 import log from '../../utils/log'
 
+export const defaults = {
+  size: 24 as const,
+}
+
 /**
  * UI component for displaying different icon packs (Ant, Feather, Phosphor) and custom SVGs
  *
@@ -30,7 +34,7 @@ import log from '../../utils/log'
  */
 export const Icon = ({
   name,
-  size,
+  size = defaults.size,
   color,
 }: IconProps): ReactElement | null => {
   const { color: defaultColor, size: defaultSize, className } = useContext(IconContext)
@@ -56,8 +60,4 @@ export const Icon = ({
       width={size ?? defaultSize}
     />
   )
-}
-
-Icon.defaultProps = {
-  size: 24 as const,
 }

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -22,11 +22,12 @@ import { action } from '@storybook/addon-actions'
 import { Hierarchy, Mode } from './Menu.types'
 import { category, divider, group, item, nestedGroup } from './Menu.mocks'
 import { Menu } from './'
+import { defaults } from './Menu'
 
 const meta = {
   component: Menu,
   args: {
-    ...Menu.defaultProps,
+    ...defaults,
     items: [
       item,
       divider,

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -31,6 +31,15 @@ const { Default, Primary } = Hierarchy
 const { Inline } = Mode
 const { menu } = styles
 
+export const defaults: Partial<MenuProps> = {
+  defaultOpenKeys: [],
+  hierarchy: Default,
+  items: [],
+  isCollapsed: false,
+  isLoading: false,
+  mode: Inline,
+}
+
 /**
  * UI component for presenting nested lists of elements, organized by group or category
  *
@@ -38,13 +47,13 @@ const { menu } = styles
  * @returns {Menu} Menu component
  */
 export const Menu = ({
-  defaultOpenKeys,
+  defaultOpenKeys = defaults.defaultOpenKeys,
   defaultSelectedKey,
-  hierarchy,
-  items,
-  isCollapsed,
-  isLoading,
-  mode,
+  hierarchy = defaults.hierarchy,
+  items = defaults.items,
+  isCollapsed = defaults.isCollapsed,
+  isLoading = defaults.isLoading,
+  mode = defaults.mode,
   onClick,
   onOpenChange,
   openKeys,
@@ -99,13 +108,4 @@ export const Menu = ({
 Menu.skeletonParagraph = {
   rows: 6,
   width: ['30%', '80%', '65%', '30%', '70%', '60%'],
-}
-
-Menu.defaultProps = {
-  defaultOpenKeys: [],
-  hierarchy: Default,
-  isCollapsed: false,
-  isLoading: false,
-  items: [],
-  mode: Inline,
 }

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -24,13 +24,14 @@ import { WithOpenButton, asideFixed, asideOpenable, children, childrenFullWidth,
 import { Button } from '../Button'
 import { Modal } from '.'
 import { Size } from './Modal.types'
+import { defaults } from './Modal'
 import { useModal } from '../../hooks/useModal'
 
 const { Large, FullScreen } = Size
 const meta = {
   component: Modal,
   args: {
-    ...Modal.defaultProps,
+    ...defaults,
     children,
     docLink,
     footer,

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -35,6 +35,14 @@ const {
   modalFs,
 } = styles
 
+export const defaults = {
+  isBodyFullWidth: false,
+  isClosable: true,
+  isMaskClosable: true,
+  isVisible: false,
+  size: Small,
+}
+
 /**
  * Modal dialog that opens in overlay and allows to perform flows of actions, or to show specific
  * but less relevant information than those displayed on the underlying page.
@@ -47,12 +55,12 @@ export const Modal = ({
   children,
   docLink,
   footer,
-  isBodyFullWidth,
-  isClosable,
-  isMaskClosable,
-  isVisible,
+  isBodyFullWidth = defaults.isBodyFullWidth,
+  isClosable = defaults.isClosable,
+  isMaskClosable = defaults.isMaskClosable,
+  isVisible = defaults.isVisible,
   onCloseClick,
-  size,
+  size = defaults.size,
   title,
   destroyOnClose,
   getContainer,
@@ -87,14 +95,6 @@ export const Modal = ({
       </Modal.Body>
     </AntModal>
   )
-}
-
-Modal.defaultProps = {
-  isBodyFullWidth: false,
-  isClosable: true,
-  isMaskClosable: true,
-  isVisible: false,
-  size: Small,
 }
 
 Modal.Title = Title

--- a/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -22,6 +22,7 @@ import { action } from '@storybook/addon-actions'
 import { Hierarchy, OptionAlignment } from './SegmentedControl.types'
 import { labeledOptions, stringOptions } from './SegmentedControl.mocks'
 import { SegmentedControl } from '.'
+import { defaults } from './SegmentedControl'
 
 const meta = {
   title: 'Components/Segmented Control',
@@ -34,7 +35,7 @@ const meta = {
     value: { control: 'text' },
   },
   args: {
-    ...SegmentedControl.defaultProps,
+    ...defaults,
     onChange: action('onChange'),
     options: labeledOptions,
   },

--- a/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.tsx
@@ -28,6 +28,12 @@ const { Neutral, Primary } = Hierarchy
 const { Horizontal, Vertical } = OptionAlignment
 const { segmented, segmentedOption, primary, disabled, selected, vertical } = styles
 
+export const defaults = {
+  hierarchy: Neutral,
+  isDisabled: false,
+  optionsAlignment: Horizontal,
+}
+
 /**
  * UI component for displaying selectable segmented options
  *
@@ -35,11 +41,11 @@ const { segmented, segmentedOption, primary, disabled, selected, vertical } = st
  */
 export const SegmentedControl = ({
   defaultValue,
-  hierarchy,
-  isDisabled,
+  hierarchy = defaults.hierarchy,
+  isDisabled = defaults.isDisabled,
   onChange,
   options,
-  optionsAlignment,
+  optionsAlignment = defaults.optionsAlignment,
   value,
 }: SegmentedControlProps): ReactElement => {
   const [selectedValue, setSelectedValue] = useState(resolveKey(options, defaultValue))
@@ -101,10 +107,4 @@ export const SegmentedControl = ({
       })}
     </ul>
   )
-}
-
-SegmentedControl.defaultProps = {
-  hierarchy: Neutral,
-  isDisabled: false,
-  optionsAlignment: Horizontal,
 }

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -40,11 +40,12 @@ import {
 } from './Table.mocks'
 import { Size } from './Table.types'
 import { Table } from '.'
+import { defaults } from './Table'
 
 const meta = {
   component: Table<TableRecord>,
   args: {
-    ...Table.defaultProps,
+    ...defaults,
     columns,
     data,
     rowKey,

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -32,6 +32,33 @@ const { Middle } = Size
 const { Edit, Delete } = Action
 const { table } = styles
 
+export const defaults = {
+  actions: [],
+  pagination: {
+    defaultCurrent: 1,
+    defaultPageSize: 10,
+    hideOnSinglePage: true,
+    pageSizeOptions: [10, 20, 50],
+    responsive: true,
+    showLessItems: false,
+    showSizeChanger: true,
+    showTitle: true,
+    showTotal: (total: number): ReactElement => (
+      <span>
+        <b>{total}</b>
+        {' in total'}
+      </span>
+    ),
+  },
+  scroll: { x: true as const },
+  isBordered: false,
+  isLoading: false,
+  layout: Auto,
+  onDeleteRow: undefined,
+  onEditRow: undefined,
+  size: Middle,
+}
+
 /**
  * UI component for presenting tabular structured data
  *
@@ -41,23 +68,23 @@ const { table } = styles
 export const Table = <RecordType extends GenericRecord>({
   columns,
   data,
-  actions,
+  actions = defaults.actions,
   expandable,
   footer,
   intlLocale,
-  isBordered,
-  isLoading,
-  layout,
+  isBordered = defaults.isBordered,
+  isLoading = defaults.isLoading,
+  layout = defaults.layout,
   onChange,
   onHeaderRow,
   onRow,
-  onEditRow,
-  onDeleteRow,
+  onEditRow = defaults.onEditRow,
+  onDeleteRow = defaults.onDeleteRow,
   rowKey,
   rowSelection,
-  pagination,
-  size,
-  scroll,
+  pagination = defaults.pagination,
+  size = defaults.size,
+  scroll = defaults.scroll,
 }: TableProps<RecordType>): ReactElement => {
   const theme = useTheme()
   const iconSize = theme?.shape?.size?.lg as IconProps['size'] || 24
@@ -123,35 +150,5 @@ export const Table = <RecordType extends GenericRecord>({
   )
 }
 
-Table.scroll = {
-  x: true as const,
-}
-
-Table.pagination = {
-  defaultCurrent: 1,
-  defaultPageSize: 10,
-  hideOnSinglePage: true,
-  pageSizeOptions: [10, 20, 50],
-  responsive: true,
-  showLessItems: false,
-  showSizeChanger: true,
-  showTitle: true,
-  showTotal: (total: number): ReactElement => (
-    <span>
-      <b>{total}</b>
-      {' in total'}
-    </span>
-  ),
-}
-
-Table.defaultProps = {
-  actions: [],
-  isBordered: false,
-  isLoading: false,
-  layout: Auto,
-  onDeleteRow: undefined,
-  onEditRow: undefined,
-  pagination: Table.pagination,
-  scroll: Table.scroll,
-  size: Middle,
-}
+Table.scroll = defaults.scroll
+Table.pagination = defaults.pagination

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -40,7 +40,10 @@ export const ThemeContext = createContext(defaultTheme)
  *
  * @TODO check children wrapper div style does not clash with other divs (e.g. not full height or width)
  */
-export const ThemeProvider = ({ theme, children }: ThemeProviderProps): ReactElement => {
+export const ThemeProvider = ({
+  theme = defaultTheme,
+  children,
+}: ThemeProviderProps): ReactElement => {
   const style = useMemo(() => ({ ...themeDefaultStyle(theme), ...themeToVariables(theme) }), [theme])
 
   return (
@@ -54,9 +57,4 @@ export const ThemeProvider = ({ theme, children }: ThemeProviderProps): ReactEle
       </AntThemeProvider>
     </ThemeContext.Provider>
   )
-}
-
-ThemeProvider.defaultProps = {
-  children: undefined,
-  theme: defaultTheme,
 }

--- a/src/components/Typography/BodyX/BodyX.stories.tsx
+++ b/src/components/Typography/BodyX/BodyX.stories.tsx
@@ -18,8 +18,8 @@
 
 import type { Meta, StoryObj } from '@storybook/react'
 
+import { BodyX, defaults } from './BodyX'
 import { customCopyable, customEllipsis, displayAll, fontUrl, loremIpsum } from '../Typography.mocks'
-import { BodyX } from './BodyX'
 import { Size } from './BodyX.types'
 import { Typography } from '..'
 
@@ -46,7 +46,7 @@ const meta = {
     design: { type: 'iframe', name: 'Font Definition', url: fontUrl },
   },
   args: {
-    ...BodyX.defaultProps,
+    ...defaults,
     children: 'Text',
   },
   argTypes: {

--- a/src/components/Typography/BodyX/BodyX.tsx
+++ b/src/components/Typography/BodyX/BodyX.tsx
@@ -30,6 +30,12 @@ const { bodyS, bodyM, bodyL } = styles
 
 const { S, M, L } = Size
 
+export const defaults = {
+  copyable: false,
+  ellipsis: false,
+  isBold: false,
+}
+
 /**
  * UI component for displaying bodies (BodyS, BodyM, BodyL).
  *
@@ -38,9 +44,9 @@ const { S, M, L } = Size
  */
 export const BodyX = ({
   children,
-  copyable,
-  ellipsis,
-  isBold,
+  copyable = defaults.copyable,
+  ellipsis = defaults.ellipsis,
+  isBold = defaults.isBold,
   size,
 }: BodyXProps & BodyXSize): ReactElement => {
   const bodyClassName = useMemo(() => classnames([
@@ -60,10 +66,4 @@ export const BodyX = ({
       {children}
     </AntParagraph>
   )
-}
-
-BodyX.defaultProps = {
-  copyable: false,
-  ellipsis: false,
-  isBold: false,
 }

--- a/src/components/Typography/HX/HX.stories.tsx
+++ b/src/components/Typography/HX/HX.stories.tsx
@@ -18,8 +18,8 @@
 
 import type { Meta, StoryObj } from '@storybook/react'
 
+import { HX, defaults } from './HX'
 import { customCopyable, customEllipsis, displayAll, fontUrl, loremIpsum } from '../Typography.mocks'
-import { HX } from './HX'
 import { Typography } from '..'
 
 const h1LongText = ['H1', loremIpsum].join(' | ')
@@ -39,7 +39,7 @@ const meta = {
     design: { type: 'iframe', name: 'Font Definition', url: fontUrl },
   },
   args: {
-    ...HX.defaultProps,
+    ...defaults,
     children: 'Text',
   },
   argTypes: {

--- a/src/components/Typography/HX/HX.tsx
+++ b/src/components/Typography/HX/HX.tsx
@@ -24,6 +24,11 @@ import { HXProps } from './HX.props'
 
 const { Title: AntTitle } = AntTypography
 
+export const defaults = {
+  copyable: false,
+  ellipsis: false,
+}
+
 /**
  * UI component for displaying headers (H1, H2, H3, H4).
  *
@@ -32,8 +37,8 @@ const { Title: AntTitle } = AntTypography
  */
 export const HX = ({
   children,
-  copyable,
-  ellipsis,
+  copyable = defaults.copyable,
+  ellipsis = defaults.ellipsis,
   level,
   role,
 }: HXProps & HXLevel): ReactElement => {
@@ -48,9 +53,4 @@ export const HX = ({
       {children}
     </AntTitle>
   )
-}
-
-HX.defaultProps = {
-  copyable: false,
-  ellipsis: false,
 }


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! -->

### Description

The goal of this PR is to remove function components `defaultProps` since they are deprecated as per [official RFC](https://github.com/reactjs/rfcs/blob/createlement-rfc/text/0000-create-element-changes.md)

Involved components are `Button`, `Card`, `Divider`, `Icon`, `Menu`, `Modal`, `SegmentedControl`, `Table`, `ThemeProvider`, `BodyX`, and `HX`.

### Checklist

- [x] commit message and branch name follow conventions
- [x] you are not committing extraneous files or sensible data
- [x] the browser console does not have any logged errors
- [x] necessary labels have been applied to this pull request (enhancement, bug, ecc.)
