### PR TITLE
feat(modal): expose getContainer and destroyOnClose props

### DIFF
--- a/src/components/Modal/Modal.props.ts
+++ b/src/components/Modal/Modal.props.ts
@@ -96,6 +96,17 @@ export type ModalProps = {
    * Title of the modal, which briefly conveys information about its contents.
    */
   title?: ReactNode,
+
+  /**
+   * Whether to unmount child components on close.
+   */
+  destroyOnClose?: boolean
+
+  /**
+   * Mount node for Modal. It can be a CSS selector, an HTML element, or a function returning an HTML element.
+   * Defaults to `document.body`.
+   */
+  getContainer?: string | HTMLElement | (() => HTMLElement) | false
 }
 
 export type TitleProps = Pick<ModalProps, 'title' | 'docLink'>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -54,6 +54,8 @@ export const Modal = ({
   onCloseClick,
   size,
   title,
+  destroyOnClose,
+  getContainer,
 }: ModalProps): ReactElement => {
   const modalClassNames = useMemo(() => classNames([
     modal,
@@ -67,7 +69,9 @@ export const Modal = ({
       centered
       className={modalClassNames}
       closable={isClosable}
+      destroyOnClose={destroyOnClose}
       footer={<Modal.Footer footer={footer} />}
+      getContainer={getContainer}
       keyboard={isClosable}
       maskClosable={isClosable && isMaskClosable}
       open={isVisible}


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! -->

### Description

This PR aims to proxy [Ant Design modal](https://ant.design/components/modal#api) properties `getContainer` and `destroyOnClose`.

##### Modal

Exposed `getContainer` and `destroyOnClose` properties.

### Checklist

- [x] commit message and branch name follow conventions
- [x] typings are updated or integrated accordingly with your changes
- [x] you are not committing extraneous files or sensible data
- [x] the browser console does not have any logged errors
- [x] necessary labels have been applied to this pull request (enhancement, bug, ecc.)
