### PR TITLE
feat(table): added React event as parameter in actions onClick callback

### DIFF
--- a/src/components/Table/Table.Action.tsx
+++ b/src/components/Table/Table.Action.tsx
@@ -45,7 +45,7 @@ export const getAction = <RecordType extends GenericRecord>({
           icon={icon}
           isDisabled={typeof isDisabled === 'function' ? isDisabled(record, index) : isDisabled}
           type={Ghost}
-          onClick={() => onClick?.(record, index)}
+          onClick={(event) => onClick?.(record, index, event)}
         />
       </div>
     ),

--- a/src/components/Table/Table.props.ts
+++ b/src/components/Table/Table.props.ts
@@ -185,16 +185,18 @@ export type TableProps<RecordType extends GenericRecord> = {
    *
    * @param record - The data record for the row.
    * @param index - The index of the row.
+   * @param event - The React mouse event.
    */
-  onEditRow?: (record: RecordType, index?: number) => void,
+  onEditRow?: (record: RecordType, index: number | undefined, event: React.MouseEvent<Element, MouseEvent>) => void,
 
   /**
    * Callback function for deleting each table row.
    *
    * @param record - The data record for the row.
    * @param index - The index of the row.
+   * @param event - The React mouse event.
    */
-  onDeleteRow?: (record: RecordType, index?: number) => void,
+  onDeleteRow?: (record: RecordType, index: number | undefined, event: React.MouseEvent<Element, MouseEvent>) => void,
 
   /**
    * Configuration for table pagination (disable it with `false`).

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -197,25 +197,25 @@ describe('Table Component', () => {
     expect(editButton).toBeVisible()
     fireEvent.click(editButton)
     expect(onEditRow).toHaveBeenCalledTimes(1)
-    expect(onEditRow).toHaveBeenCalledWith(props.data[0], 0)
+    expect(onEditRow).toHaveBeenCalledWith(props.data[0], 0, expect.any(Object))
 
     const [, deleteButton] = deleteButtons
     expect(deleteButton).toBeVisible()
     fireEvent.click(deleteButton)
     expect(onDeleteRow).toHaveBeenCalledTimes(1)
-    expect(onDeleteRow).toHaveBeenCalledWith(props.data[1], 1)
+    expect(onDeleteRow).toHaveBeenCalledWith(props.data[1], 1, expect.any(Object))
 
     const [, , detailButton] = detailButtons
     expect(detailButton).toBeVisible()
     fireEvent.click(detailButton)
     expect(onDetail).toHaveBeenCalledTimes(1)
-    expect(onDetail).toHaveBeenCalledWith(props.data[2], 2)
+    expect(onDetail).toHaveBeenCalledWith(props.data[2], 2, expect.any(Object))
 
     const [, , , overviewButton] = overviewButtons
     expect(overviewButton).toBeVisible()
     fireEvent.click(overviewButton)
     expect(onOverview).toHaveBeenCalledTimes(1)
-    expect(onOverview).toHaveBeenCalledWith(props.data[3], 3)
+    expect(onOverview).toHaveBeenCalledWith(props.data[3], 3, expect.any(Object))
   })
 
   test('renders pagination correctly', async() => {

--- a/src/components/Table/Table.types.ts
+++ b/src/components/Table/Table.types.ts
@@ -69,7 +69,7 @@ export type CustomAction<RecordType extends GenericRecord> = {
   icon: ReactNode,
   isDanger?: boolean,
   isDisabled?: (record: RecordType, index?: number) => boolean | boolean,
-  onClick: (record: RecordType, index?: number) => void,
+  onClick: (record: RecordType, index: number | undefined, event: React.MouseEvent<Element, MouseEvent>) => void,
   title?: ReactNode
 }
 


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! -->

### Description

This PR aims to add React mouse event as parameter in Table actions onClick callback.

##### Table

Actions onClick callback now receives React mouse event as last parameter.

### Checklist

- [x] commit message and branch name follow conventions
- [x] tests are included
- [x] changes are accessible and documented from components stories
- [x] typings are updated or integrated accordingly with your changes
- [x] you are not committing extraneous files or sensible data
- [x] the browser console does not have any logged errors
- [x] necessary labels have been applied to this pull request (enhancement, bug, ecc.)
