### PR TITLE
fix(#420): support htmlType and form antd button proxy props

### DIFF
--- a/src/components/Button/Button.props.ts
+++ b/src/components/Button/Button.props.ts
@@ -18,7 +18,7 @@
 
 import { MouseEvent, ReactNode } from 'react'
 
-import { Hierarchy, IconPosition, Shape, Size, Type } from './Button.types'
+import { HTMLType, Hierarchy, IconPosition, Shape, Size, Type } from './Button.types'
 
 export type ButtonProps = {
 
@@ -26,6 +26,11 @@ export type ButtonProps = {
    * The children nodes to be rendered within the button context.
    */
   children?: ReactNode,
+
+  /**
+   * The form id the button should take care of submit or reset.
+   */
+  form?: string,
 
   /**
    * Defines the button hierarchy. Either:
@@ -41,6 +46,15 @@ export type ButtonProps = {
    * For security reasons, the attribute "rel: 'noopener noreferrer'" is always specified.
    */
   href?: string,
+
+  /**
+   * The underlying html button type. Either:
+   *
+   * - "button"
+   * - "reset"
+   * - "submit"
+   */
+  htmlType?: HTMLType
 
   /**
    * Sets an icon for the button component.

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -20,7 +20,7 @@ import { ReactElement, useMemo } from 'react'
 import { Button as AntButton } from 'antd'
 import classnames from 'classnames'
 
-import { Hierarchy, IconPosition, Shape, Size, Type } from './Button.types'
+import { HTMLType, Hierarchy, IconPosition, Shape, Size, Type } from './Button.types'
 import { ButtonProps } from './Button.props'
 import styles from './Button.module.css'
 
@@ -40,8 +40,10 @@ const { Filled, Ghost } = Type
  */
 export const Button = ({
   children,
+  form,
   hierarchy,
   href,
+  htmlType,
   icon,
   iconPosition,
   isDisabled,
@@ -69,7 +71,9 @@ export const Button = ({
       className={buttonClassNames}
       danger={hierarchy === Danger}
       disabled={isDisabled}
+      form={form}
       ghost={type !== Filled && hierarchy !== Neutral}
+      htmlType={form && !htmlType ? HTMLType.Submit : htmlType}
       loading={isLoading}
       shape={shape === Square ? 'default' : 'circle'}
       size={size}

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -22,6 +22,12 @@ export enum Hierarchy {
   Danger = 'danger',
 }
 
+export enum HTMLType {
+  Button = 'button',
+  Reset = 'reset',
+  Submit = 'submit',
+}
+
 export enum IconPosition {
   Left = 'left',
   Right = 'right',


### PR DESCRIPTION
### Description

This PR addresses #420 and adds htmlType and form props button proxy.

##### Button

Added props. By default htmlType is set to `submit` if `form` is provided but no `htmlType`.

### Issue ticket number and link

#420 

### Checklist

- [ ] added the link to the Jira task
- [X] commit message and branch name follow conventions
- [ ] tests are included
- [ ] changes are accessible and documented from components stories
- [X] typings are updated or integrated accordingly with your changes
- [X] all added components are exported from index file (if necessary)
- [X] all added files include Apache 2.0 license
- [X] you are not committing extraneous files or sensible data
- [X] the browser console does not have any logged errors
- [X] necessary labels have been applied to this pull request (enhancement, bug, ecc.)
