### PR TITLE
feat: enums as components properties

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -19,16 +19,9 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
-import { Hierarchy, IconPosition, Shape, Size, Type } from './Button.types'
 import { Button } from '.'
 import { Icon } from '../Icon'
 import { defaults } from './Button'
-
-const { Primary, Neutral, Danger } = Hierarchy
-const { Left, Right } = IconPosition
-const { Square, Circle } = Shape
-const { Small, Middle, Large } = Size
-const { Filled, Outlined, Ghost } = Type
 
 const icon = <Icon color="white" name="PiCircleHalfTiltLight" size={16} />
 
@@ -47,64 +40,64 @@ type Story = StoryObj<typeof meta>
 export const PrimaryFilled: Story = {
   args: {
     ...meta.args,
-    hierarchy: Primary,
-    type: Filled,
+    hierarchy: Button.Hierarchy.Primary,
+    type: Button.Type.Filled,
   },
 }
 
 export const PrimaryOutlined: Story = {
   args: {
     ...meta.args,
-    hierarchy: Primary,
-    type: Outlined,
+    hierarchy: Button.Hierarchy.Primary,
+    type: Button.Type.Outlined,
   },
 }
 
 export const PrimaryGhost: Story = {
   args: {
     ...meta.args,
-    hierarchy: Primary,
-    type: Ghost,
+    hierarchy: Button.Hierarchy.Primary,
+    type: Button.Type.Ghost,
   },
 }
 
 export const NeutralOutlined: Story = {
   args: {
     ...meta.args,
-    hierarchy: Neutral,
-    type: Outlined,
+    hierarchy: Button.Hierarchy.Neutral,
+    type: Button.Type.Outlined,
   },
 }
 
 export const NeutralGhost: Story = {
   args: {
     ...meta.args,
-    hierarchy: Neutral,
-    type: Ghost,
+    hierarchy: Button.Hierarchy.Neutral,
+    type: Button.Type.Ghost,
   },
 }
 
 export const DangerFilled: Story = {
   args: {
     ...meta.args,
-    hierarchy: Danger,
-    type: Filled,
+    hierarchy: Button.Hierarchy.Danger,
+    type: Button.Type.Filled,
   },
 }
 
 export const DangerOutlined: Story = {
   args: {
     ...meta.args,
-    hierarchy: Danger,
-    type: Outlined,
+    hierarchy: Button.Hierarchy.Danger,
+    type: Button.Type.Outlined,
   },
 }
 
 export const DangerGhost: Story = {
   args: {
     ...meta.args,
-    hierarchy: Danger,
-    type: Ghost,
+    hierarchy: Button.Hierarchy.Danger,
+    type: Button.Type.Ghost,
   },
 }
 
@@ -113,7 +106,7 @@ export const SquareShape: Story = {
     ...meta.args,
     children: undefined,
     icon,
-    shape: Square,
+    shape: Button.Shape.Square,
   },
 }
 
@@ -122,28 +115,28 @@ export const CircleShape: Story = {
     ...meta.args,
     children: undefined,
     icon,
-    shape: Circle,
+    shape: Button.Shape.Circle,
   },
 }
 
 export const SmallSize: Story = {
   args: {
     ...meta.args,
-    size: Small,
+    size: Button.Size.Small,
   },
 }
 
 export const MiddleSize: Story = {
   args: {
     ...meta.args,
-    size: Middle,
+    size: Button.Size.Middle,
   },
 }
 
 export const LargeSize: Story = {
   args: {
     ...meta.args,
-    size: Large,
+    size: Button.Size.Large,
   },
 }
 
@@ -165,7 +158,7 @@ export const WithIconLeft: Story = {
   args: {
     ...meta.args,
     icon,
-    iconPosition: Left,
+    iconPosition: Button.IconPosition.Left,
   },
 }
 
@@ -173,6 +166,6 @@ export const WithIconRight: Story = {
   args: {
     ...meta.args,
     icon,
-    iconPosition: Right,
+    iconPosition: Button.IconPosition.Right,
   },
 }

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -16,16 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { HTMLType, Hierarchy, IconPosition, Shape, Size, Type } from './Button.types'
 import { fireEvent, render, screen } from '../../test-utils'
 import { Button } from '.'
 import { Icon } from '../Icon'
-
-const { Neutral, Danger } = Hierarchy
-const { Right } = IconPosition
-const { Circle } = Shape
-const { Small, Large } = Size
-const { Outlined, Ghost } = Type
 
 const icon = <Icon color="white" name="PiCircleHalfTiltLight" size={16} />
 
@@ -40,37 +33,37 @@ describe('Button Component', () => {
   })
 
   test('renders primary outline button correctly', () => {
-    const { asFragment } = render(<Button type={Outlined}>{'Button'}</Button>)
+    const { asFragment } = render(<Button type={Button.Type.Outlined}>{'Button'}</Button>)
     expect(asFragment()).toMatchSnapshot()
   })
 
   test('renders primary ghost button correctly', () => {
-    const { asFragment } = render(<Button type={Ghost}>{'Button'}</Button>)
+    const { asFragment } = render(<Button type={Button.Type.Ghost}>{'Button'}</Button>)
     expect(asFragment()).toMatchSnapshot()
   })
 
   test('renders neutral outline button correctly', () => {
-    const { asFragment } = render(<Button hierarchy={Neutral} type={Outlined}>{'Button'}</Button>)
+    const { asFragment } = render(<Button hierarchy={Button.Hierarchy.Neutral} type={Button.Type.Outlined}>{'Button'}</Button>)
     expect(asFragment()).toMatchSnapshot()
   })
 
   test('renders neutral ghost button correctly', () => {
-    const { asFragment } = render(<Button hierarchy={Neutral} type={Ghost}>{'Button'}</Button>)
+    const { asFragment } = render(<Button hierarchy={Button.Hierarchy.Neutral} type={Button.Type.Ghost}>{'Button'}</Button>)
     expect(asFragment()).toMatchSnapshot()
   })
 
   test('renders danger filled button correctly', () => {
-    const { asFragment } = render(<Button hierarchy={Danger}>{'Button'}</Button>)
+    const { asFragment } = render(<Button hierarchy={Button.Hierarchy.Danger}>{'Button'}</Button>)
     expect(asFragment()).toMatchSnapshot()
   })
 
   test('renders danger outline button correctly', () => {
-    const { asFragment } = render(<Button hierarchy={Danger} type={Outlined}>{'Button'}</Button>)
+    const { asFragment } = render(<Button hierarchy={Button.Hierarchy.Danger} type={Button.Type.Outlined}>{'Button'}</Button>)
     expect(asFragment()).toMatchSnapshot()
   })
 
   test('renders danger ghost button correctly', () => {
-    const { asFragment } = render(<Button hierarchy={Danger} type={Ghost}>{'Button'}</Button>)
+    const { asFragment } = render(<Button hierarchy={Button.Hierarchy.Danger} type={Button.Type.Ghost}>{'Button'}</Button>)
     expect(asFragment()).toMatchSnapshot()
   })
 
@@ -80,12 +73,12 @@ describe('Button Component', () => {
   })
 
   test('renders circle button correctly', () => {
-    const { asFragment } = render(<Button icon={icon} shape={Circle} />)
+    const { asFragment } = render(<Button icon={icon} shape={Button.Shape.Circle} />)
     expect(asFragment()).toMatchSnapshot()
   })
 
   test('renders small button correctly', () => {
-    const { asFragment } = render(<Button size={Small}>{'Button'}</Button>)
+    const { asFragment } = render(<Button size={Button.Size.Small}>{'Button'}</Button>)
     expect(asFragment()).toMatchSnapshot()
   })
 
@@ -95,7 +88,7 @@ describe('Button Component', () => {
   })
 
   test('renders large button correctly', () => {
-    const { asFragment } = render(<Button size={Large}>{'Button'}</Button>)
+    const { asFragment } = render(<Button size={Button.Size.Large}>{'Button'}</Button>)
     expect(asFragment()).toMatchSnapshot()
   })
 
@@ -118,7 +111,7 @@ describe('Button Component', () => {
   })
 
   test('renders button with icon right correctly', () => {
-    const { asFragment } = render(<Button icon={icon} iconPosition={Right}>{'Button'}</Button>)
+    const { asFragment } = render(<Button icon={icon} iconPosition={Button.IconPosition.Right}>{'Button'}</Button>)
     expect(asFragment()).toMatchSnapshot()
   })
 
@@ -128,17 +121,17 @@ describe('Button Component', () => {
   })
 
   test('renders primary filled button correctly with form ref and htmlType', () => {
-    const { asFragment } = render(<Button form="some-form" htmlType={HTMLType.Submit}>{'Button'}</Button>)
+    const { asFragment } = render(<Button form="some-form" htmlType={Button.HTMLType.Submit}>{'Button'}</Button>)
     expect(asFragment()).toMatchSnapshot()
   })
 
   test('renders primary outline button correctly with form ref and no htmlType', () => {
-    const { asFragment } = render(<Button form="some-form" type={Outlined}>{'Button'}</Button>)
+    const { asFragment } = render(<Button form="some-form" type={Button.Type.Outlined}>{'Button'}</Button>)
     expect(asFragment()).toMatchSnapshot()
   })
 
   test('renders primary outline button correctly with form ref and reset htmlType', () => {
-    const { asFragment } = render(<Button form="some-form" htmlType={HTMLType.Reset} type={Outlined}>{'Button'}</Button>)
+    const { asFragment } = render(<Button form="some-form" htmlType={Button.HTMLType.Reset} type={Button.Type.Outlined}>{'Button'}</Button>)
     expect(asFragment()).toMatchSnapshot()
   })
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -103,3 +103,4 @@ Button.IconPosition = IconPosition
 Button.Shape = Shape
 Button.Size = Size
 Button.Type = Type
+Button.HTMLType = HTMLType

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -97,3 +97,9 @@ export const Button = ({
     </AntButton>
   )
 }
+
+Button.Hierarchy = Hierarchy
+Button.IconPosition = IconPosition
+Button.Shape = Shape
+Button.Size = Size
+Button.Type = Type

--- a/src/components/Card/Card.mocks.tsx
+++ b/src/components/Card/Card.mocks.tsx
@@ -18,13 +18,8 @@
 
 import { action } from '@storybook/addon-actions'
 
-import { Hierarchy, Shape, Type } from '../Button/Button.types'
 import { Button } from '../Button'
 import { Icon } from '../Icon'
-
-const { Danger } = Hierarchy
-const { Circle } = Shape
-const { Outlined } = Type
 
 const actionIcon = (
   <Icon
@@ -35,10 +30,10 @@ const actionIcon = (
 )
 export const actionButton = (
   <Button
-    hierarchy={Danger}
+    hierarchy={Button.Hierarchy.Danger}
     icon={actionIcon}
-    shape={Circle}
-    type={Outlined}
+    shape={Button.Shape.Circle}
+    type={Button.Type.Outlined}
     onClick={action('click')}
   />
 )

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -19,7 +19,6 @@
 import { ReactElement, useCallback, useMemo } from 'react'
 import { Skeleton } from 'antd'
 
-import { Shape, Type } from '../Button/Button.types'
 import { BodyS } from '../Typography/BodyX/BodyS'
 import { Button } from '../Button'
 import { CardProps } from './Card.props'
@@ -28,8 +27,6 @@ import { Icon } from '../Icon'
 import styles from './Card.module.css'
 import { useTheme } from '../../hooks/useTheme'
 
-const { Circle } = Shape
-const { Ghost } = Type
 const { card, content, header, heading } = styles
 
 export const defaults = {
@@ -71,8 +68,8 @@ export const Card = ({
               {docLink && <div className={styles.docLink}>
                 <Button
                   icon={docLinkIcon}
-                  shape={Circle}
-                  type={Ghost}
+                  shape={Button.Shape.Circle}
+                  type={Button.Type.Ghost}
                   onClick={onClickDocLink}
                 />
               </div>}

--- a/src/components/Divider/Divider.stories.tsx
+++ b/src/components/Divider/Divider.stories.tsx
@@ -19,7 +19,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
 import { Divider } from '.'
-import { Orientation } from './Divider.types'
 import { defaults } from './Divider'
 
 const meta = {
@@ -44,7 +43,7 @@ export const Horizontal: Story = {
 export const Vertical: Story = {
   args: {
     ...meta.args,
-    orientation: Orientation.Vertical,
+    orientation: Divider.Orientation.Vertical,
   },
 }
 

--- a/src/components/Divider/Divider.test.tsx
+++ b/src/components/Divider/Divider.test.tsx
@@ -18,7 +18,6 @@
 
 import { render, screen } from '../../test-utils'
 import { Divider } from '.'
-import { Orientation } from './Divider.types'
 
 describe('Divider Component', () => {
   beforeEach(() => {
@@ -41,7 +40,7 @@ describe('Divider Component', () => {
   })
 
   test('renders vertical divider correctly', () => {
-    const { asFragment } = render(<Divider orientation={Orientation.Vertical} />)
+    const { asFragment } = render(<Divider orientation={Divider.Orientation.Vertical} />)
 
     expect(screen.getByRole('separator')).toBeVisible()
     expect(asFragment()).toMatchSnapshot()

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -54,3 +54,6 @@ export const Divider = ({
     </AntDivider>
   )
 }
+
+Divider.Orientation = Orientation
+Divider.TextOrientation = TextOrientation

--- a/src/components/FeedbackMessage/FeedbackMessage.stories.tsx
+++ b/src/components/FeedbackMessage/FeedbackMessage.stories.tsx
@@ -19,11 +19,9 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { useState } from 'react'
 
-import { Hierarchy, Size } from '../Button/Button.types'
 import { Button } from '../Button'
 import { FeedbackMessage } from '.'
 import { Icon } from '../Icon'
-import { Position } from '../../hooks/useFeedbackMessage/useFeedbackMessage.types'
 import { useFeedbackMessage } from '../../hooks/useFeedbackMessage'
 
 const meta = {
@@ -45,35 +43,35 @@ export const FeedbackMessages: Story = {
     return (
       <div style={{ display: 'flex', gap: '4px' }}>
         <Button
-          hierarchy={Hierarchy.Neutral}
+          hierarchy={Button.Hierarchy.Neutral}
           icon={<Icon color="blue" name="PiInfo" size={16} />}
           onClick={() => info({ message })}
         >
           Info
         </Button>
         <Button
-          hierarchy={Hierarchy.Neutral}
+          hierarchy={Button.Hierarchy.Neutral}
           icon={<Icon color="green" name="PiCheck" size={16} />}
           onClick={() => success({ message })}
         >
           Success
         </Button>
         <Button
-          hierarchy={Hierarchy.Neutral}
+          hierarchy={Button.Hierarchy.Neutral}
           icon={<Icon name="PiSpinner" size={16} />}
           onClick={() => loading({ message })}
         >
           Loading
         </Button>
         <Button
-          hierarchy={Hierarchy.Neutral}
+          hierarchy={Button.Hierarchy.Neutral}
           icon={<Icon color="orange" name="PiWarning" size={16} />}
           onClick={() => warning({ message })}
         >
           Warning
         </Button>
         <Button
-          hierarchy={Hierarchy.Neutral}
+          hierarchy={Button.Hierarchy.Neutral}
           icon={<Icon color="red" name="PiXCircle" size={16} />}
           onClick={() => error({ message })}
         >
@@ -94,7 +92,7 @@ export const FeedbackMessageWithExtraContent: Story = {
 
     const onClick = (): void => {
       success({
-        extra: <Button size={Size.Small} onClick={onDismiss}>Dismiss</Button>,
+        extra: <Button size={Button.Size.Small} onClick={onDismiss}>Dismiss</Button>,
         key: 'messageKey',
         message,
         sticky: true,
@@ -114,13 +112,13 @@ export const FeedbackMessageAtTheBottomOfThePage: Story = {
     return (
       <div style={{ display: 'flex', gap: 4 }}>
         <Button
-          hierarchy={Hierarchy.Neutral}
-          onClick={() => info({ message, position: Position.Bottom, duration: 10 })}
+          hierarchy={Button.Hierarchy.Neutral}
+          onClick={() => info({ message, position: useFeedbackMessage.Position.Bottom, duration: 10 })}
         >
           Open
         </Button>
         <Button
-          hierarchy={Hierarchy.Neutral}
+          hierarchy={Button.Hierarchy.Neutral}
           onClick={() => dismiss()}
         >
           Dismiss

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -19,7 +19,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
-import { Hierarchy, Mode } from './Menu.types'
 import { category, divider, group, item, nestedGroup } from './Menu.mocks'
 import { Menu } from './'
 import { defaults } from './Menu'
@@ -52,7 +51,7 @@ export const Inline: Story = {
 export const Vertical: Story = {
   args: {
     ...meta.args,
-    mode: Mode.Vertical,
+    mode: Menu.Mode.Vertical,
   },
   decorators: [Story => (
     <div style={{ width: '75%' }}>
@@ -71,7 +70,7 @@ export const Collapsed: Story = {
 export const Primary: Story = {
   args: {
     ...meta.args,
-    hierarchy: Hierarchy.Primary,
+    hierarchy: Menu.Hierarchy.Primary,
   },
 }
 

--- a/src/components/Menu/Menu.test.tsx
+++ b/src/components/Menu/Menu.test.tsx
@@ -16,13 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Hierarchy, Mode } from './Menu.types'
 import { category, divider, group, item } from './Menu.mocks'
 import { render, screen, waitFor } from '../../test-utils'
 import { Menu } from '.'
-
-const { Primary } = Hierarchy
-const { Vertical } = Mode
 
 const items = [item, group, divider, category]
 
@@ -47,7 +43,7 @@ describe('Menu Component', () => {
   test('renders vertical menu correctly', async() => {
     global.console.error = (msg) => !msg.toString().includes(warningToSuppress) && originalErr(msg)
 
-    const { asFragment } = render(<Menu items={items} mode={Vertical} />)
+    const { asFragment } = render(<Menu items={items} mode={Menu.Mode.Vertical} />)
     await waitFor(() => expect(asFragment()).toMatchSnapshot())
 
     global.console.error = originalErr
@@ -59,7 +55,7 @@ describe('Menu Component', () => {
   })
 
   test('renders primary menu correctly', async() => {
-    const { asFragment } = render(<Menu hierarchy={Primary} items={items} />)
+    const { asFragment } = render(<Menu hierarchy={Menu.Hierarchy.Primary} items={items} />)
     await waitFor(() => expect(asFragment()).toMatchSnapshot())
   })
 

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -20,7 +20,7 @@ import { Menu as AntMenu, ConfigProvider, Skeleton } from 'antd'
 import { ReactElement, useMemo, useState } from 'react'
 import classNames from 'classnames'
 
-import { Hierarchy, Mode } from './Menu.types'
+import { Hierarchy, ItemType, Mode } from './Menu.types'
 import defaultTheme, { primaryTheme } from './Menu.theme'
 import { MenuProps } from './Menu.props'
 import formatLabels from './Menu.utils'
@@ -109,3 +109,7 @@ Menu.skeletonParagraph = {
   rows: 6,
   width: ['30%', '80%', '65%', '30%', '70%', '60%'],
 }
+
+Menu.ItemType = ItemType
+Menu.Hierarchy = Hierarchy
+Menu.Mode = Mode

--- a/src/components/Modal/Modal.Title.tsx
+++ b/src/components/Modal/Modal.Title.tsx
@@ -18,16 +18,12 @@
 
 import { ReactElement, useCallback, useMemo } from 'react'
 
-import { Shape, Type } from '../Button/Button.types'
 import { Button } from '../Button'
 import { H4 } from '../Typography/HX/H4'
 import { Icon } from '../Icon'
 import { TitleProps } from './Modal.props'
 import styles from './Modal.module.css'
 import { useTheme } from '../../hooks/useTheme'
-
-const { Circle } = Shape
-const { Ghost } = Type
 
 /**
  * Title component of Modal, which has within it and manages the modal title and the eventual docLink.
@@ -53,8 +49,8 @@ export const Title = ({
         {docLink && <div className={styles.docLink}>
           <Button
             icon={docLinkIcon}
-            shape={Circle}
-            type={Ghost}
+            shape={Button.Shape.Circle}
+            type={Button.Type.Ghost}
             onClick={onClickDocLink}
           />
         </div>}

--- a/src/components/Modal/Modal.mocks.tsx
+++ b/src/components/Modal/Modal.mocks.tsx
@@ -19,16 +19,12 @@
 import { ReactElement } from 'react'
 import { action } from '@storybook/addon-actions'
 
-import { Hierarchy, Type } from '../Button/Button.types'
 import { columns, data, rowKey } from '../Table/Table.mocks'
 import { Button } from '../Button'
 import { Modal } from '.'
 import { ModalProps } from './Modal.props'
 import { Table } from '../Table'
 import { useModal } from '../../hooks/useModal'
-
-const { Neutral } = Hierarchy
-const { Outlined } = Type
 
 export const children = (
   <>
@@ -91,9 +87,9 @@ export const footer = {
   buttons: [
     <Button key={'ok'} onClick={action('ok')}>{'OK'}</Button>,
     <Button
-      hierarchy={Neutral}
+      hierarchy={Button.Hierarchy.Neutral}
       key={'cancel'}
-      type={Outlined}
+      type={Button.Type.Outlined}
       onClick={action('cancel')}
     >
       {'Cancel'}
@@ -107,25 +103,25 @@ export const footerCustom = {
       Button 1
     </Button>,
     <Button
-      hierarchy={Neutral}
+      hierarchy={Button.Hierarchy.Neutral}
       key={'2'}
-      type={Outlined}
+      type={Button.Type.Outlined}
       onClick={action('button 2')}
     >
       Button 2
     </Button>,
     <Button
-      hierarchy={Neutral}
+      hierarchy={Button.Hierarchy.Neutral}
       key={'3'}
-      type={Outlined}
+      type={Button.Type.Outlined}
       onClick={action('button 3')}
     >
       Button 3
     </Button>,
     <Button
-      hierarchy={Neutral}
+      hierarchy={Button.Hierarchy.Neutral}
       key={'4'}
-      type={Outlined}
+      type={Button.Type.Outlined}
       onClick={action('button 4')}
     >
       Button 4
@@ -138,10 +134,10 @@ export const footerLoading = {
   buttons: [
     <Button isLoading key={'ok'}>{'OK'}</Button>,
     <Button
-      hierarchy={Neutral}
+      hierarchy={Button.Hierarchy.Neutral}
       isDisabled
       key={'cancel'}
-      type={Outlined}
+      type={Button.Type.Outlined}
     >
       {'Cancel'}
     </Button>,

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -23,11 +23,9 @@ import { useEffect } from 'react'
 import { WithOpenButton, asideFixed, asideOpenable, children, childrenFullWidth, childrenLong, docLink, footer, footerCustom, footerLoading, title } from './Modal.mocks'
 import { Button } from '../Button'
 import { Modal } from '.'
-import { Size } from './Modal.types'
 import { defaults } from './Modal'
 import { useModal } from '../../hooks/useModal'
 
-const { Large, FullScreen } = Size
 const meta = {
   component: Modal,
   args: {
@@ -55,7 +53,7 @@ export const LargeSize: Story = {
   args: {
     ...meta.args,
     children: childrenLong,
-    size: Large,
+    size: Modal.Size.Large,
   },
   decorators: [(_, { args }) => <WithOpenButton {...args} />],
 }
@@ -64,7 +62,7 @@ export const FullScreenSize: Story = {
   args: {
     ...meta.args,
     children: childrenLong,
-    size: FullScreen,
+    size: Modal.Size.FullScreen,
   },
   decorators: [(_, { args }) => <WithOpenButton {...args} />],
 }
@@ -138,7 +136,7 @@ export const WithAsideFixed: Story = {
     ...meta.args,
     aside: asideFixed,
     children: childrenLong,
-    size: Large,
+    size: Modal.Size.Large,
   },
   decorators: [(_, { args }) => <WithOpenButton {...args} />],
 }
@@ -148,7 +146,7 @@ export const WithAsideOpenable: Story = {
     ...meta.args,
     aside: asideOpenable,
     children: childrenLong,
-    size: Large,
+    size: Modal.Size.Large,
   },
   decorators: [(_, { args }) => <WithOpenButton {...args} />],
 }

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -19,9 +19,6 @@
 import { asideFixed, asideOpenable, docLink, footer, footerCustom, title } from './Modal.mocks'
 import { fireEvent, render, screen, waitFor } from '../../test-utils'
 import { Modal } from '.'
-import { Size } from './Modal.types'
-
-const { Large, FullScreen } = Size
 
 const props = {
   children: 'Modal Content',
@@ -50,7 +47,7 @@ describe('Modal Component', () => {
   })
 
   test('renders large modal correctly (with empty footer)', async() => {
-    const { baseElement } = render(<Modal {...props} footer={undefined} size={Large} />)
+    const { baseElement } = render(<Modal {...props} footer={undefined} size={Modal.Size.Large} />)
 
     await waitFor(() => expect(screen.getByRole('dialog')).toBeVisible())
     expect(screen.getByRole('h4', { name: title })).toBeVisible()
@@ -61,7 +58,7 @@ describe('Modal Component', () => {
   })
 
   test('renders fullscreen modal correctly (with empty header)', async() => {
-    const { baseElement } = render(<Modal {...props} size={FullScreen} title={undefined} />)
+    const { baseElement } = render(<Modal {...props} size={Modal.Size.FullScreen} title={undefined} />)
 
     await waitFor(() => expect(screen.getByRole('dialog')).toBeVisible())
     expect(screen.getByText(/Modal Content/i)).toBeVisible()
@@ -110,7 +107,7 @@ describe('Modal Component', () => {
   })
 
   test('renders modal with aside fixed', async() => {
-    const { baseElement } = render(<Modal {...props} aside={asideFixed} size={Large} />)
+    const { baseElement } = render(<Modal {...props} aside={asideFixed} size={Modal.Size.Large} />)
 
     await waitFor(() => expect(screen.getByRole('dialog')).toBeVisible())
     const asideTitle = screen.getByRole('paragraph')
@@ -122,7 +119,7 @@ describe('Modal Component', () => {
   })
 
   test('renders modal with aside openable', async() => {
-    const { baseElement } = render(<Modal {...props} aside={asideOpenable} size={Large} />)
+    const { baseElement } = render(<Modal {...props} aside={asideOpenable} size={Modal.Size.Large} />)
 
     await waitFor(() => expect(screen.getByRole('dialog')).toBeVisible())
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -100,3 +100,4 @@ export const Modal = ({
 Modal.Title = Title
 Modal.Body = Body
 Modal.Footer = Footer
+Modal.Size = Size

--- a/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -19,7 +19,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
-import { Hierarchy, OptionAlignment } from './SegmentedControl.types'
 import { labeledOptions, stringOptions } from './SegmentedControl.mocks'
 import { SegmentedControl } from '.'
 import { defaults } from './SegmentedControl'
@@ -53,11 +52,11 @@ export const StringOptions: Story = {
 }
 
 export const Primary: Story = {
-  args: { ...meta.args, hierarchy: Hierarchy.Primary },
+  args: { ...meta.args, hierarchy: SegmentedControl.Hierarchy.Primary },
 }
 
 export const Vertical: Story = {
-  args: { ...meta.args, optionsAlignment: OptionAlignment.Vertical },
+  args: { ...meta.args, optionsAlignment: SegmentedControl.OptionAlignment.Vertical },
 }
 
 export const Disabled: Story = {
@@ -78,7 +77,7 @@ export const MultiLine: Story = {
 }
 
 export const MultiLineVertical: Story = {
-  args: { ...meta.args, optionsAlignment: OptionAlignment.Vertical },
+  args: { ...meta.args, optionsAlignment: SegmentedControl.OptionAlignment.Vertical },
   decorators: [Story => (
     <div style={{ width: '40%' }}>
       <Story />

--- a/src/components/SegmentedControl/SegmentedControl.test.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.test.tsx
@@ -16,13 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Hierarchy, OptionAlignment } from './SegmentedControl.types'
 import { fireEvent, render, screen } from '../../test-utils'
 import { labeledOptions, stringOptions } from './SegmentedControl.mocks'
 import { SegmentedControl } from '.'
-
-const { Primary } = Hierarchy
-const { Vertical } = OptionAlignment
 
 describe('Segmented Control Component', () => {
   beforeEach(() => {
@@ -58,7 +54,7 @@ describe('Segmented Control Component', () => {
     })
 
     test('renders primary options correctly', () => {
-      const { asFragment } = render(<SegmentedControl {...props} hierarchy={Primary} />)
+      const { asFragment } = render(<SegmentedControl {...props} hierarchy={SegmentedControl.Hierarchy.Primary} />)
 
       expect(screen.getByRole('list')).toBeVisible()
 
@@ -75,7 +71,12 @@ describe('Segmented Control Component', () => {
     })
 
     test('renders vertical options correctly', () => {
-      const { asFragment } = render(<SegmentedControl {...props} optionsAlignment={Vertical} />)
+      const { asFragment } = render(
+        <SegmentedControl
+          {...props}
+          optionsAlignment={SegmentedControl.OptionAlignment.Vertical}
+        />
+      )
 
       expect(screen.getByRole('list')).toBeVisible()
 
@@ -168,7 +169,7 @@ describe('Segmented Control Component', () => {
     })
 
     test('renders primary options correctly', () => {
-      const { asFragment } = render(<SegmentedControl {...props} hierarchy={Primary} />)
+      const { asFragment } = render(<SegmentedControl {...props} hierarchy={SegmentedControl.Hierarchy.Primary} />)
 
       expect(screen.getByRole('list')).toBeVisible()
 
@@ -185,7 +186,12 @@ describe('Segmented Control Component', () => {
     })
 
     test('renders vertical options correctly', () => {
-      const { asFragment } = render(<SegmentedControl {...props} optionsAlignment={Vertical} />)
+      const { asFragment } = render(
+        <SegmentedControl
+          {...props}
+          optionsAlignment={SegmentedControl.OptionAlignment.Vertical}
+        />
+      )
 
       expect(screen.getByRole('list')).toBeVisible()
 

--- a/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.tsx
@@ -108,3 +108,6 @@ export const SegmentedControl = ({
     </ul>
   )
 }
+
+SegmentedControl.Hierarchy = Hierarchy
+SegmentedControl.OptionAlignment = OptionAlignment

--- a/src/components/Table/Table.Action.tsx
+++ b/src/components/Table/Table.Action.tsx
@@ -17,13 +17,10 @@
  */
 
 import { ColumnAlignment, GenericRecord, TableAction } from './Table.types'
-import { Hierarchy, Type } from '../Button/Button.types'
 import { Button } from '../Button'
 import styles from './Table.module.css'
 
 const { action } = styles
-const { Danger, Neutral } = Hierarchy
-const { Ghost } = Type
 
 export const getAction = <RecordType extends GenericRecord>({
   dataIndex,
@@ -41,10 +38,10 @@ export const getAction = <RecordType extends GenericRecord>({
     render: (_: unknown, record: RecordType, index: number | undefined) => (
       <div className={action}>
         <Button
-          hierarchy={isDanger ? Danger : Neutral}
+          hierarchy={isDanger ? Button.Hierarchy.Danger : Button.Hierarchy.Neutral}
           icon={icon}
           isDisabled={typeof isDisabled === 'function' ? isDisabled(record, index) : isDisabled}
-          type={Ghost}
+          type={Button.Type.Ghost}
           onClick={(event) => onClick?.(record, index, event)}
         />
       </div>

--- a/src/components/Table/Table.mocks.tsx
+++ b/src/components/Table/Table.mocks.tsx
@@ -22,7 +22,6 @@ import { get } from 'lodash-es'
 
 import { Action, ColumnAlignment, ColumnFilterMode, ColumnType, ExpandableConfig, Pagination, RowSelection, SortOrder, TableAction } from './Table.types'
 import { Button } from '../Button'
-import { Hierarchy as ButtonHierarchy } from '../Button/Button.types'
 import { Icon } from '../Icon'
 import { Table } from '.'
 import { TableProps } from './Table.props'
@@ -244,10 +243,10 @@ export const WithExternalFiltersAndSorters = (props: TableProps<TableRecord>): R
   return (
     <Space direction="vertical" style={{ width: '100%' }} >
       <Space>
-        <Button hierarchy={ButtonHierarchy.Neutral} onClick={filterValue2}>{'Filter Value 2'}</Button>
-        <Button hierarchy={ButtonHierarchy.Neutral} onClick={sortField2Descending}>{'Sort Field 2 Descending'}</Button>
-        <Button hierarchy={ButtonHierarchy.Neutral} onClick={clearFilters}>{'Clear filters'}</Button>
-        <Button hierarchy={ButtonHierarchy.Neutral} onClick={clearSort}>{'Clear sort'}</Button>
+        <Button hierarchy={Button.Hierarchy.Neutral} onClick={filterValue2}>{'Filter Value 2'}</Button>
+        <Button hierarchy={Button.Hierarchy.Neutral} onClick={sortField2Descending}>{'Sort Field 2 Descending'}</Button>
+        <Button hierarchy={Button.Hierarchy.Neutral} onClick={clearFilters}>{'Clear filters'}</Button>
+        <Button hierarchy={Button.Hierarchy.Neutral} onClick={clearSort}>{'Clear sort'}</Button>
       </Space>
       <Table
         {...props}

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -38,7 +38,6 @@ import {
   sizedColumns,
   spannedColumns,
 } from './Table.mocks'
-import { Size } from './Table.types'
 import { Table } from '.'
 import { defaults } from './Table'
 
@@ -61,11 +60,11 @@ export const Default: Story = {
 }
 
 export const Small: Story = {
-  args: { ...meta.args, size: Size.Small },
+  args: { ...meta.args, size: Table.Size.Small },
 }
 
 export const Large: Story = {
-  args: { ...meta.args, size: Size.Large },
+  args: { ...meta.args, size: Table.Size.Large },
 }
 
 export const Loading: Story = {

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -18,10 +18,7 @@
 
 import { WithExternalFiltersAndSorters, alignedColumns, columns, customActions, data, expandable, filteredAndSortedColumns, footer, hugeData, pagination, rowKey, rowSelection, sizedColumns, spannedColumns } from './Table.mocks'
 import { fireEvent, render, screen, waitFor, within } from '../../test-utils'
-import { Size } from './Table.types'
 import { Table } from '.'
-
-const { Small, Large } = Size
 
 describe('Table Component', () => {
   beforeEach(() => {
@@ -59,12 +56,12 @@ describe('Table Component', () => {
   })
 
   test('renders small table correctly', async() => {
-    const { asFragment } = render(<Table {...props} size={Small} />)
+    const { asFragment } = render(<Table {...props} size={Table.Size.Small} />)
     await waitFor(() => expect(asFragment()).toMatchSnapshot())
   })
 
   test('renders large table correctly', async() => {
-    const { asFragment } = render(<Table {...props} size={Large} />)
+    const { asFragment } = render(<Table {...props} size={Table.Size.Large} />)
     await waitFor(() => expect(asFragment()).toMatchSnapshot())
   })
 

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -19,7 +19,7 @@
 import { Table as AntTable, Skeleton } from 'antd'
 import { ReactElement, useMemo } from 'react'
 
-import { Action, GenericRecord, Layout, Size } from './Table.types'
+import { Action, ColumnAlignment, ColumnFilterMode, GenericRecord, Layout, Size, SortOrder } from './Table.types'
 import { Icon } from '../Icon'
 import { IconProps } from '../Icon/Icon.props'
 import { TableProps } from './Table.props'
@@ -152,3 +152,10 @@ export const Table = <RecordType extends GenericRecord>({
 
 Table.scroll = defaults.scroll
 Table.pagination = defaults.pagination
+
+Table.ColumnAlignment = ColumnAlignment
+Table.ColumnFilterMode = ColumnFilterMode
+Table.Layout = Layout
+Table.Size = Size
+Table.SortOrder = SortOrder
+Table.Action = Action

--- a/src/components/Typography/BodyX/BodyL/index.tsx
+++ b/src/components/Typography/BodyX/BodyL/index.tsx
@@ -20,10 +20,7 @@ import { ReactElement } from 'react'
 
 import { BodyX } from '../BodyX'
 import { BodyXProps } from '../BodyX.props'
-import { Size } from '../BodyX.types'
-
-const { L } = Size
 
 export const BodyL = (props: BodyXProps): ReactElement => {
-  return <BodyX {...props} size={L} />
+  return <BodyX {...props} size={BodyX.Size.L} />
 }

--- a/src/components/Typography/BodyX/BodyM/index.tsx
+++ b/src/components/Typography/BodyX/BodyM/index.tsx
@@ -20,10 +20,7 @@ import { ReactElement } from 'react'
 
 import { BodyX } from '../BodyX'
 import { BodyXProps } from '../BodyX.props'
-import { Size } from '../BodyX.types'
-
-const { M } = Size
 
 export const BodyM = (props: BodyXProps): ReactElement => {
-  return <BodyX {...props} size={M} />
+  return <BodyX {...props} size={BodyX.Size.M} />
 }

--- a/src/components/Typography/BodyX/BodyS/index.tsx
+++ b/src/components/Typography/BodyX/BodyS/index.tsx
@@ -20,10 +20,7 @@ import { ReactElement } from 'react'
 
 import { BodyX } from '../BodyX'
 import { BodyXProps } from '../BodyX.props'
-import { Size } from '../BodyX.types'
-
-const { S } = Size
 
 export const BodyS = (props: BodyXProps): ReactElement => {
-  return <BodyX {...props} size={S} />
+  return <BodyX {...props} size={BodyX.Size.S} />
 }

--- a/src/components/Typography/BodyX/BodyX.stories.tsx
+++ b/src/components/Typography/BodyX/BodyX.stories.tsx
@@ -20,10 +20,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 
 import { BodyX, defaults } from './BodyX'
 import { customCopyable, customEllipsis, displayAll, fontUrl, loremIpsum } from '../Typography.mocks'
-import { Size } from './BodyX.types'
 import { Typography } from '..'
-
-const { S } = Size
 
 const bodySLongText = ['BodyS', loremIpsum].join(' | ')
 const bodyMLongText = ['BodyM', loremIpsum].join(' | ')
@@ -61,7 +58,7 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const BodyXComponent: Story = {
-  args: { ...meta.args, size: S },
+  args: { ...meta.args, size: BodyX.Size.S },
   argTypes: {
     isBold: { table: { disable: false } },
     size: { table: { disable: false } },

--- a/src/components/Typography/BodyX/BodyX.tsx
+++ b/src/components/Typography/BodyX/BodyX.tsx
@@ -67,3 +67,5 @@ export const BodyX = ({
     </AntParagraph>
   )
 }
+
+BodyX.Size = Size

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -20,6 +20,8 @@ import { useFeedbackMessage } from './useFeedbackMessage'
 import { useModal } from './useModal'
 import { useTheme } from './useTheme'
 
+export * from './useFeedbackMessage'
+
 export default {
   useFeedbackMessage,
   useModal,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -20,8 +20,6 @@ import { useFeedbackMessage } from './useFeedbackMessage'
 import { useModal } from './useModal'
 import { useTheme } from './useTheme'
 
-export * from './useFeedbackMessage'
-
 export default {
   useFeedbackMessage,
   useModal,

--- a/src/hooks/useFeedbackMessage/index.ts
+++ b/src/hooks/useFeedbackMessage/index.ts
@@ -17,3 +17,7 @@
  */
 
 export { useFeedbackMessage } from './useFeedbackMessage'
+export {
+  Position as UseFeedbackMessagePosition,
+  Type as UseFeedbackMessageType,
+} from './useFeedbackMessage.types'

--- a/src/hooks/useFeedbackMessage/index.ts
+++ b/src/hooks/useFeedbackMessage/index.ts
@@ -17,7 +17,3 @@
  */
 
 export { useFeedbackMessage } from './useFeedbackMessage'
-export {
-  Position as UseFeedbackMessagePosition,
-  Type as UseFeedbackMessageType,
-} from './useFeedbackMessage.types'

--- a/src/hooks/useFeedbackMessage/useFeedbackMessage.test.tsx
+++ b/src/hooks/useFeedbackMessage/useFeedbackMessage.test.tsx
@@ -19,7 +19,6 @@
 /* eslint-disable react/no-multi-comp */
 
 import { act, fireEvent, render, screen, waitFor } from '../../test-utils'
-import { Position } from './useFeedbackMessage.types'
 import { useFeedbackMessage } from '.'
 
 jest.useFakeTimers()
@@ -185,10 +184,10 @@ describe('useFeedbackMessage', () => {
 
       return (
         <>
-          <button type="button" onClick={() => info({ message, position: Position.Bottom })}>
+          <button type="button" onClick={() => info({ message, position: useFeedbackMessage.Position.Bottom })}>
             Open message
           </button>
-          <button type="button" onClick={() => info({ message: updatedMessage, position: Position.Bottom })}>
+          <button type="button" onClick={() => info({ message: updatedMessage, position: useFeedbackMessage.Position.Bottom })}>
             Open updated message
           </button>
         </>

--- a/src/hooks/useFeedbackMessage/useFeedbackMessage.tsx
+++ b/src/hooks/useFeedbackMessage/useFeedbackMessage.tsx
@@ -97,3 +97,6 @@ export function useFeedbackMessage(): MessageAPI {
     warning,
   }), [dismiss, error, info, loading, success, warning])
 }
+
+useFeedbackMessage.Position = Position
+useFeedbackMessage.Type = Type

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,9 +27,8 @@ import { SegmentedControl } from './components/SegmentedControl'
 import { Table } from './components/Table'
 import { ThemeProvider } from './components/ThemeProvider'
 import { Typography } from './components/Typography'
+import hooks from './hooks'
 import themes from './themes'
-
-export * from './hooks'
 
 export {
   Button,
@@ -42,6 +41,7 @@ export {
   Table,
   ThemeProvider,
   Typography,
+  hooks,
   themes,
   testUtils,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,8 +27,9 @@ import { SegmentedControl } from './components/SegmentedControl'
 import { Table } from './components/Table'
 import { ThemeProvider } from './components/ThemeProvider'
 import { Typography } from './components/Typography'
-import hooks from './hooks'
 import themes from './themes'
+
+export * from './hooks'
 
 export {
   Button,
@@ -41,7 +42,6 @@ export {
   Table,
   ThemeProvider,
   Typography,
-  hooks,
   themes,
   testUtils,
 }


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! -->

### Description

This PR aims at facilitating access to component enumerations setting them as properties of the component itself.

E.g.:

```js
import { Button } from '@mia-platform-internal/console-design-system-react' 

<Button hierarchy={Button.Hierarchy.Primary} />
```

### Checklist

<!-- For further details regarding standards and conventions adopted in this repository please take a look at the CONTRIBUTING.md file. -->

- [x] commit message and branch name follow conventions
- [x] tests are included
- [x] typings are updated or integrated accordingly with your changes
- [x] all added files include Apache 2.0 license
- [x] you are not committing extraneous files or sensible data
- [x] the browser console does not have any logged errors
- [x] necessary labels have been applied to this pull request (enhancement, bug, ecc.)
