### PR TITLE
fix(modal): Fix useModal rerender issue on children change

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "Davide Bianchi <davide.bianchi@mia-platform.eu>",
     "Federico Maggi <federico.maggi@mia-platform.eu>",
     "Giovanni Tommasi <giovanni.tommasi@mia-platform.eu>",
-    "Riccardo Corona <riccardo.corona@mia-platform.eu>"
+    "Riccardo Corona <riccardo.corona@mia-platform.eu>",
+    "Giovanna Monti <giovanna.monti@mia-platform.eu>"
   ],
   "repository": {
     "type": "git",

--- a/src/hooks/useModal/useModal.test.tsx
+++ b/src/hooks/useModal/useModal.test.tsx
@@ -16,10 +16,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { ReactNode, useCallback, useState } from 'react'
 import { act, render, renderHook, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import { Button } from '../..'
 import { useModal } from '.'
+
+const ModalWrapper = ({ modalTitle, modalChildren } : {modalTitle: string, modalChildren: ReactNode}): JSX.Element => {
+  const { Modal, openModal, toggleModal } = useModal()
+  const [status, setStatus] = useState('idle')
+
+  const changeContent = useCallback(() : void => {
+    setStatus('changed')
+  }, [])
+
+  return (
+    <>
+      <Button onClick={openModal}>Open Modal</Button>
+      <Button onClick={toggleModal}>Toggle Modal Visibility</Button>
+      <Button onClick={changeContent}>Change Modal Content</Button>
+      <Modal title={modalTitle}>
+        {status === 'idle' ? modalChildren : 'Something changed!'}
+      </Modal>
+    </>
+  )
+}
 
 describe('useModal', () => {
   test('should return isModalVisible, openModal, closeModal and toggleModal properties', async() => {
@@ -41,34 +63,37 @@ describe('useModal', () => {
     const title = 'Modal Title'
     const children = 'Modal Content'
 
-    const Example = (): JSX.Element => {
-      const { Modal, openModal, toggleModal } = useModal()
-      return (
-        <>
-          <Button onClick={openModal}>Open Modal</Button>
-          <Button onClick={toggleModal}>Change Modal Status</Button>
-          <Modal title={title}>
-            {children}
-          </Modal>
-        </>
-      )
-    }
+    render(<ModalWrapper modalChildren={children} modalTitle={title} />)
 
-    render(<Example />)
-
-    screen.getByRole('button', { name: /Open Modal/i }).click()
+    userEvent.click(screen.getByRole('button', { name: /open modal/i }))
 
     expect(await screen.findByRole('h4', { name: title })).toBeInTheDocument()
     expect(screen.getByText(children)).toBeInTheDocument()
 
-    screen.getByRole('button', { name: /Close/i }).click()
+    screen.getByRole('button', { name: /close/i }).click()
 
     await waitFor(() => expect(screen.queryByRole('h4', { name: title })).not.toBeInTheDocument())
     expect(screen.queryByText(children)).toBeNull()
 
-    screen.getByRole('button', { name: /Change Modal Status/i }).click()
+    userEvent.click(screen.getByRole('button', { name: /toggle modal visibility/i }))
 
     expect(await screen.findByRole('h4', { name: /modal title/i })).toBeInTheDocument()
     expect(screen.getByText(children)).toBeInTheDocument()
+  })
+
+  test('should not rerender Modal when children change', async() => {
+    const title = 'Modal Title'
+    const children = 'Modal Content'
+
+    render(<ModalWrapper modalChildren={children} modalTitle={title} />)
+
+    userEvent.click(screen.getByRole('button', { name: /toggle modal visibility/i }))
+
+    expect(await screen.findByRole('h4', { name: /modal title/i })).toBeInTheDocument()
+    expect(screen.getByText(children)).toBeInTheDocument()
+
+    const modal = screen.getByRole('dialog')
+    userEvent.click(screen.getByRole('button', { name: /change modal content/i }))
+    expect(modal).toBeInTheDocument()
   })
 })

--- a/src/hooks/useModal/useModal.tsx
+++ b/src/hooks/useModal/useModal.tsx
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ReactElement, useCallback, useState } from 'react'
+import { ReactElement, useCallback, useMemo, useState } from 'react'
 
 import { Modal } from '../../components/Modal/Modal'
 import { ModalAPI } from './useModal.types'
@@ -35,15 +35,17 @@ export const useModal = (): ModalAPI => {
   const closeModal = useCallback(() => setIsModalVisible(false), [])
   const toggleModal = useCallback(() => setIsModalVisible(prevState => !prevState), [])
 
-  const ModalComponent = useCallback((props: ModalProps): ReactElement => {
-    return (
-      <Modal
-        {...props}
-        isVisible={props.isVisible ?? isModalVisible}
-        onCloseClick={props.onCloseClick ?? closeModal}
-      />
-    )
+  const ModalComponentMemoized = useMemo(() => {
+    return function ModalComponent(props: ModalProps): ReactElement {
+      return (
+        <Modal
+          {...props}
+          isVisible={props.isVisible ?? isModalVisible}
+          onCloseClick={props.onCloseClick ?? closeModal}
+        />
+      )
+    }
   }, [closeModal, isModalVisible])
 
-  return { Modal: ModalComponent, isModalVisible, openModal, closeModal, toggleModal }
+  return { Modal: ModalComponentMemoized, isModalVisible, openModal, closeModal, toggleModal }
 }

--- a/src/hooks/useModal/useModal.tsx
+++ b/src/hooks/useModal/useModal.tsx
@@ -35,7 +35,7 @@ export const useModal = (): ModalAPI => {
   const closeModal = useCallback(() => setIsModalVisible(false), [])
   const toggleModal = useCallback(() => setIsModalVisible(prevState => !prevState), [])
 
-  const ModalComponent = (props: ModalProps): ReactElement => {
+  const ModalComponent = useCallback((props: ModalProps): ReactElement => {
     return (
       <Modal
         {...props}
@@ -43,7 +43,7 @@ export const useModal = (): ModalAPI => {
         onCloseClick={props.onCloseClick ?? closeModal}
       />
     )
-  }
+  }, [closeModal, isModalVisible])
 
   return { Modal: ModalComponent, isModalVisible, openModal, closeModal, toggleModal }
 }


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! -->

### Description

Fixed a memorization problem on the useModal hook which caused modals to rerender whenever their content changed.

##### [hooks - useModal]

### Checklist

<!-- For further details regarding standards and conventions adopted in this repository please take a look at the CONTRIBUTING.md file. -->

- [ ] added the link to the Jira task
- [x] commit message and branch name follow conventions
- [x] tests are included
- [ ] changes are accessible and documented from components stories
- [ ] typings are updated or integrated accordingly with your changes
- [ ] all added components are exported from index file (if necessary)
- [ ] all added files include Apache 2.0 license
- [x] you are not committing extraneous files or sensitive data
- [x] the browser console does not have any logged errors
- [ ] necessary labels have been applied to this pull request (enhancement, bug, ecc.)
