### PR TITLE
feat(button): added title prop

### DIFF
--- a/src/components/Button/Button.props.ts
+++ b/src/components/Button/Button.props.ts
@@ -110,6 +110,11 @@ export type ButtonProps = {
   target?: string,
 
   /**
+   * Adds a tooltip that contains the value of the property.
+   */
+  title?: string,
+
+  /**
    * Defines the button type. Either:
    *
    * - "filled": button with a solid fill, typically used for primary actions;

--- a/src/components/Button/Button.props.ts
+++ b/src/components/Button/Button.props.ts
@@ -110,7 +110,7 @@ export type ButtonProps = {
   target?: string,
 
   /**
-   * Adds a tooltip that contains the value of the property.
+   * HTML `title` global attribute.
    */
   title?: string,
 

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -145,4 +145,11 @@ describe('Button Component', () => {
     expect(onClick).toHaveBeenCalledTimes(1)
     expect(onClick).toBeCalledWith(expect.objectContaining({ ...MouseEvent }))
   })
+
+  test('renders title correctly', async() => {
+    render(<Button title={'title test'}>{'Button'}</Button>)
+
+    const button = screen.getByTitle('title test')
+    expect(button).toBeVisible()
+  })
 })

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -62,6 +62,7 @@ export const Button = ({
   shape = defaults.shape,
   size = defaults.size,
   target,
+  title,
   type = defaults.type,
 }: ButtonProps): ReactElement => {
   const buttonClassNames = useMemo(() => classnames(
@@ -87,6 +88,7 @@ export const Button = ({
       loading={isLoading}
       shape={shape === Square ? 'default' : 'circle'}
       size={size}
+      title={title}
       type={hierarchy === Neutral ? 'default' : 'primary'}
       onClick={onClick}
       {...href && { href, rel: 'noopener noreferrer', target }}


### PR DESCRIPTION
### Description

This PR aims at adding the `title` property to the Button component.
It's very useful for buttons that consist of only an icon and doesn't impact the style or the behaviour of the component.

### Checklist

- [x] commit message and branch name follow conventions
- [x] tests are included
- [x] changes are accessible and documented from components stories
- [x] typings are updated or integrated accordingly with your changes
- [ ] all added components are exported from index file (if necessary)
- [ ] all added files include Apache 2.0 license
- [x] you are not committing extraneous files or sensitive data
- [x] the browser console does not have any logged errors
- [x] necessary labels have been applied to this pull request (enhancement, bug, ecc.)
