### PR TITLE
feat(button): Add block prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,13 @@
   "contributors": [
     "Daniele Cinà <daniele.cina@mia-platform.eu>",
     "Davide Bianchi <davide.bianchi@mia-platform.eu>",
+    "Edoardo Pessina <edoardo.pessina@mia-platform.eu>",
     "Federico Maggi <federico.maggi@mia-platform.eu>",
+    "Federico Pini <federico.pini@mia-platform.eu>",
+    "Giovanna Monti <giovanna.monti@mia-platform.eu>",
     "Giovanni Tommasi <giovanni.tommasi@mia-platform.eu>",
-    "Riccardo Corona <riccardo.corona@mia-platform.eu>",
-    "Giovanna Monti <giovanna.monti@mia-platform.eu>"
+    "Paola Nicosia <paola.nicosia@mia-platform.eu>",
+    "Riccardo Corona <riccardo.corona@mia-platform.eu>"
   ],
   "repository": {
     "type": "git",

--- a/src/components/Button/Button.props.ts
+++ b/src/components/Button/Button.props.ts
@@ -25,7 +25,7 @@ export type ButtonProps = {
   /**
    * Fits button width to its parent width
    */
-  block?: boolean,
+  isBlock?: boolean,
 
   /**
    * The children nodes to be rendered within the button context.

--- a/src/components/Button/Button.props.ts
+++ b/src/components/Button/Button.props.ts
@@ -23,6 +23,11 @@ import { HTMLType, Hierarchy, IconPosition, Shape, Size, Type } from './Button.t
 export type ButtonProps = {
 
   /**
+   * Fits button width to its parent width
+   */
+  block?: boolean,
+
+  /**
    * The children nodes to be rendered within the button context.
    */
   children?: ReactNode,

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -122,7 +122,7 @@ export const CircleShape: Story = {
 export const Block: Story = {
   args: {
     ...meta.args,
-    block: true,
+    isBlock: true,
   },
 }
 

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -119,6 +119,13 @@ export const CircleShape: Story = {
   },
 }
 
+export const Block: Story = {
+  args: {
+    ...meta.args,
+    block: true,
+  },
+}
+
 export const SmallSize: Story = {
   args: {
     ...meta.args,

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -154,7 +154,7 @@ describe('Button Component', () => {
   })
 
   test('renders block button correctly', () => {
-    const { asFragment } = render(<Button block>{'Button'}</Button>)
+    const { asFragment } = render(<Button isBlock={true}>{'Button'}</Button>)
     expect(asFragment()).toMatchSnapshot()
   })
 })

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -152,4 +152,9 @@ describe('Button Component', () => {
     const button = screen.getByTitle('title test')
     expect(button).toBeVisible()
   })
+
+  test('rendersblock button correctly', () => {
+    const { asFragment } = render(<Button block>{'Button'}</Button>)
+    expect(asFragment()).toMatchSnapshot()
+  })
 })

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -153,7 +153,7 @@ describe('Button Component', () => {
     expect(button).toBeVisible()
   })
 
-  test('rendersblock button correctly', () => {
+  test('renders block button correctly', () => {
     const { asFragment } = render(<Button block>{'Button'}</Button>)
     expect(asFragment()).toMatchSnapshot()
   })

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -49,6 +49,7 @@ export const defaults = {
  * @returns {Button} Button component
  */
 export const Button = ({
+  block,
   children,
   form,
   hierarchy = defaults.hierarchy,
@@ -79,6 +80,7 @@ export const Button = ({
 
   return (
     <AntButton
+      block={block}
       className={buttonClassNames}
       danger={hierarchy === Danger}
       disabled={isDisabled}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -49,7 +49,7 @@ export const defaults = {
  * @returns {Button} Button component
  */
 export const Button = ({
-  block,
+  isBlock,
   children,
   form,
   hierarchy = defaults.hierarchy,
@@ -80,7 +80,7 @@ export const Button = ({
 
   return (
     <AntButton
-      block={block}
+      block={isBlock}
       className={buttonClassNames}
       danger={hierarchy === Danger}
       disabled={isDisabled}

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Button Component renders block button correctly 1`] = `
+<DocumentFragment>
+  <button
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-block button buttonMd"
+    type="button"
+  >
+    <div
+      class="buttonText"
+    >
+      Button
+    </div>
+  </button>
+</DocumentFragment>
+`;
+
 exports[`Button Component renders button with href correctly 1`] = `
 <DocumentFragment>
   <a
@@ -398,21 +413,6 @@ exports[`Button Component renders square button correctly 1`] = `
         d="M200.12,55.88A102,102,0,1,0,55.88,200.13,102,102,0,1,0,200.12,55.88ZM90,209.62a89.61,89.61,0,0,1-21.23-13.89L90,174.49Zm32,8.16a90,90,0,0,1-20-3.58V162.49l20-20Zm32-3.58a89.8,89.8,0,0,1-20,3.58V130.49l20-20Zm32-17.4a89.45,89.45,0,0,1-20,12.83V98.49l20-20ZM60.27,187.24a90,90,0,0,1,127-127ZM198,184.57V71.43a90,90,0,0,1,0,113.14Z"
       />
     </svg>
-  </button>
-</DocumentFragment>
-`;
-
-exports[`Button Component rendersblock button correctly 1`] = `
-<DocumentFragment>
-  <button
-    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-block button buttonMd"
-    type="button"
-  >
-    <div
-      class="buttonText"
-    >
-      Button
-    </div>
   </button>
 </DocumentFragment>
 `;

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -401,3 +401,18 @@ exports[`Button Component renders square button correctly 1`] = `
   </button>
 </DocumentFragment>
 `;
+
+exports[`Button Component rendersblock button correctly 1`] = `
+<DocumentFragment>
+  <button
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-block button buttonMd"
+    type="button"
+  >
+    <div
+      class="buttonText"
+    >
+      Button
+    </div>
+  </button>
+</DocumentFragment>
+`;


### PR DESCRIPTION
### Description

This PR aims to add the `block` property to the button component. This property enables the button to fit the parent container witdh.

### Checklist

- [x] commit message and branch name follow conventions
- [x] tests are included
- [x] changes are accessible and documented from components stories
- [x] typings are updated or integrated accordingly with your changes
- [x] all added components are exported from index file (if necessary)
- [x] all added files include Apache 2.0 license
- [x] you are not committing extraneous files or sensitive data
- [x] the browser console does not have any logged errors
- [x] necessary labels have been applied to this pull request (enhancement, bug, ecc.)
