### PR TITLE
feat(core): add data-testid to components

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.props.ts
+++ b/src/components/Breadcrumb/Breadcrumb.props.ts
@@ -21,6 +21,11 @@ import { BreadcrumbItemType } from './Breadcrumb.types'
 export type BreadcrumbProps = {
 
   /**
+   * Identifies the component for testing purposes
+   */
+  dataTestId?: string;
+
+  /**
    * Indicates whether the component is loading.
    */
   isLoading?: boolean;

--- a/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -245,4 +245,9 @@ describe('Breadcrumb Component', () => {
     fireEvent.click(screen.getAllByText('Text 8')[1])
     expect(onDropdownVisibleChangeMock).toHaveBeenCalledTimes(1)
   })
+
+  test('should get breadcrumb by test id', () => {
+    render(<Breadcrumb dataTestId="breadcrumb-test" items={[]} />)
+    expect(screen.getByTestId('breadcrumb-test')).toBeTruthy()
+  })
 })

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -29,7 +29,12 @@ import styles from './Breadcrumb.module.css'
  *
  * @returns {Breadcrumb} Breadcrumb component
  */
-export const Breadcrumb = ({ isLoading, items, getPopupContainer }: BreadcrumbProps): ReactElement => {
+export const Breadcrumb = ({
+  dataTestId,
+  isLoading,
+  items,
+  getPopupContainer,
+}: BreadcrumbProps): ReactElement => {
   const [visibleItems, setVisibleItems] = useState<BreadcrumbButton[]>([])
 
   const breadcrumbRef = useRef<HTMLDivElement>(null)
@@ -70,7 +75,7 @@ export const Breadcrumb = ({ isLoading, items, getPopupContainer }: BreadcrumbPr
   }, [items])
 
   return (
-    <div className={styles.breadcrumb} ref={breadcrumbRef} >
+    <div className={styles.breadcrumb} data-testid={dataTestId} ref={breadcrumbRef}>
       <div className={styles.breadcrumbItems}>
         {
           visibleItems.map((breadcrumbItem, index, itemList) => renderItem(

--- a/src/components/Button/Button.props.ts
+++ b/src/components/Button/Button.props.ts
@@ -23,6 +23,11 @@ import { HTMLType, Hierarchy, IconPosition, Shape, Size, Type } from './Button.t
 export type ButtonProps = {
 
   /**
+   * Identifies the component for testing purposes
+   */
+  dataTestId?: string;
+
+  /**
    * The children nodes to be rendered within the button context.
    */
   children?: ReactNode,

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -152,4 +152,9 @@ describe('Button Component', () => {
     const button = screen.getByTitle('title test')
     expect(button).toBeVisible()
   })
+
+  test('should get button by test id', () => {
+    render(<Button dataTestId="button-test">{'Button'}</Button>)
+    expect(screen.getByTestId('button-test')).toBeTruthy()
+  })
 })

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -50,6 +50,7 @@ export const defaults = {
  */
 export const Button = ({
   children,
+  dataTestId,
   form,
   hierarchy = defaults.hierarchy,
   href,
@@ -81,6 +82,7 @@ export const Button = ({
     <AntButton
       className={buttonClassNames}
       danger={hierarchy === Danger}
+      data-testid={dataTestId}
       disabled={isDisabled}
       form={form}
       ghost={type !== Filled && hierarchy !== Neutral}

--- a/src/components/Card/Card.props.ts
+++ b/src/components/Card/Card.props.ts
@@ -21,6 +21,11 @@ import { ReactNode } from 'react'
 export type CardProps = {
 
   /**
+   * Identifies the component for testing purposes
+   */
+  dataTestId?: string;
+
+  /**
    * The children nodes to be rendered within the card context.
    */
   children?: ReactNode,

--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -71,4 +71,9 @@ describe('Card Component', () => {
     const { asFragment } = render(<Card isLoading={true} />)
     expect(asFragment()).toMatchSnapshot()
   })
+
+  test('should get card by test id', () => {
+    render(<Card dataTestId="card-test" />)
+    expect(screen.getByTestId('card-test')).toBeTruthy()
+  })
 })

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -40,6 +40,7 @@ export const defaults = {
  */
 export const Card = ({
   children,
+  dataTestId,
   docLink,
   extra,
   isLoading = defaults.isLoading,
@@ -55,7 +56,7 @@ export const Card = ({
   const onClickDocLink = useCallback(() => window.open(docLink, '_blank'), [docLink])
 
   return (
-    <div className={card}>
+    <div className={card} data-testid={dataTestId}>
       <Skeleton
         active
         loading={isLoading}

--- a/src/components/Drawer/Drawer.props.ts
+++ b/src/components/Drawer/Drawer.props.ts
@@ -22,49 +22,54 @@ import { CustomDrawerFooter, DrawerFooter, DrawerTitle } from './Drawer.types'
 
 export type DrawerProps = {
 
-    /**
-     * The children nodes to be rendered within the Drawer body.
-     */
-    children?: ReactNode,
+  /**
+   * Identifies the component for testing purposes
+   */
+  dataTestId?: string;
 
-    /**
-     * Controls whether to unmount child components on close.
-     */
-    destroyOnClose?: boolean,
+  /**
+   * The children nodes to be rendered within the Drawer body.
+   */
+  children?: ReactNode,
 
-    /**
-     * The reference url for documentation of the drawer contents.
-     * If present, a button is shown next to the title that, when clicked, opens the url in a new tab.
-     */
-    docLink?: string,
+  /**
+   * Controls whether to unmount child components on close.
+   */
+  destroyOnClose?: boolean,
 
-    /**
-     * Drawer footer.
-     */
-    footer?: DrawerFooter | CustomDrawerFooter,
+  /**
+   * The reference url for documentation of the drawer contents.
+   * If present, a button is shown next to the title that, when clicked, opens the url in a new tab.
+   */
+  docLink?: string,
 
-    /**
-     * drawer id for DOM node.
-     */
-    id?: string,
+  /**
+   * Drawer footer.
+   */
+  footer?: DrawerFooter | CustomDrawerFooter,
 
-    /**
-     * Controls whether the modal is visible.
-     */
-    isVisible?: boolean,
+  /**
+   * drawer id for DOM node.
+   */
+  id?: string,
 
-    /**
-     * React drawer key
-     */
-    key?: string,
+  /**
+   * Controls whether the modal is visible.
+   */
+  isVisible?: boolean,
 
-    /**
-     * Function invoked at the click of the Drawer close (X) button.
-     */
-    onClose?: () => void,
+  /**
+   * React drawer key
+   */
+  key?: string,
 
-    /**
-     * Title of the drawer, which briefly conveys information about its contents.
-     */
-    title: DrawerTitle,
+  /**
+   * Function invoked at the click of the Drawer close (X) button.
+   */
+  onClose?: () => void,
+
+  /**
+   * Title of the drawer, which briefly conveys information about its contents.
+   */
+  title: DrawerTitle,
 }

--- a/src/components/Drawer/Drawer.test.tsx
+++ b/src/components/Drawer/Drawer.test.tsx
@@ -73,4 +73,9 @@ describe('Drawer', () => {
     render(<Drawer {...props} isVisible={false} >{'the-content'}</Drawer>)
     expect(screen.queryByText(/drawer lipsum/i)).toBeNull()
   })
+
+  test('should get drawer by test id', () => {
+    render(<Drawer {...props} dataTestId="drawer-test" />)
+    expect(screen.getByTestId('drawer-test')).toBeTruthy()
+  })
 })

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -30,6 +30,7 @@ const closeIcon = <Icon color="currentColor" name="PiX" size={16} />
 
 export const Drawer = ({
   children,
+  dataTestId,
   destroyOnClose,
   docLink,
   footer,
@@ -43,6 +44,7 @@ export const Drawer = ({
     <AntdDrawer
       className={styles.drawer}
       closeIcon={closeIcon}
+      data-testid={dataTestId}
       destroyOnClose={destroyOnClose}
       footer={footer && <Drawer.Footer footer={footer} />}
       id={id}

--- a/src/components/FeedbackMessage/FeedbackMessage.props.ts
+++ b/src/components/FeedbackMessage/FeedbackMessage.props.ts
@@ -21,6 +21,11 @@ import { ReactNode } from 'react'
 export type FeedbackMessageProps = {
 
   /**
+   * Identifies the component for testing purposes
+   */
+  dataTestId?: string;
+
+  /**
    * The content to be shown as a message, after the icon. Could be either a string or a ReactNode.
    */
   message: string | ReactNode

--- a/src/components/FeedbackMessage/FeedbackMessage.test.tsx
+++ b/src/components/FeedbackMessage/FeedbackMessage.test.tsx
@@ -50,4 +50,9 @@ describe('FeedbackMessage Component', () => {
 
     expect(asFragment()).toMatchSnapshot()
   })
+
+  test('should get feedbackmessage by test id', () => {
+    render(<FeedbackMessage dataTestId="feedback-message-test" message="Feedback Message" />)
+    expect(screen.getByTestId('feedback-message-test')).toBeTruthy()
+  })
 })

--- a/src/components/FeedbackMessage/FeedbackMessage.tsx
+++ b/src/components/FeedbackMessage/FeedbackMessage.tsx
@@ -32,11 +32,12 @@ const { feedbackMessage } = styles
  * @returns {ReactElement} FeedbackMessage component
  */
 export const FeedbackMessage = ({
+  dataTestId,
   message,
   extra,
 }: FeedbackMessageProps): ReactElement => {
   return (
-    <span className={feedbackMessage}>
+    <span className={feedbackMessage} data-testid={dataTestId}>
       {message}
       {extra}
     </span>

--- a/src/components/Menu/Menu.props.ts
+++ b/src/components/Menu/Menu.props.ts
@@ -21,6 +21,11 @@ import { Hierarchy, Item, Mode } from './Menu.types'
 export type MenuProps = {
 
   /**
+   * Identifies the component for testing purposes
+   */
+  dataTestId?: string;
+
+  /**
    * Array with the keys of initially opened sub-menus.
    */
   defaultOpenKeys?: string[],

--- a/src/components/Menu/Menu.test.tsx
+++ b/src/components/Menu/Menu.test.tsx
@@ -97,4 +97,9 @@ describe('Menu Component', () => {
 
     await waitFor(() => expect(asFragment()).toMatchSnapshot())
   })
+
+  test('should get menu by test id', () => {
+    render(<Menu dataTestId="menu-test" items={[]} />)
+    expect(screen.getByTestId('menu-test')).toBeTruthy()
+  })
 })

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -47,6 +47,7 @@ export const defaults = {
  * @returns {Menu} Menu component
  */
 export const Menu = ({
+  dataTestId,
   defaultOpenKeys = defaults.defaultOpenKeys,
   defaultSelectedKey,
   hierarchy = defaults.hierarchy,
@@ -82,6 +83,7 @@ export const Menu = ({
       >
         <AntMenu
           className={menuClassNames}
+          data-testid={dataTestId}
           defaultOpenKeys={defaultOpenKeys}
           defaultSelectedKeys={defaultSelectedKey ? [defaultSelectedKey] : undefined}
           // getPopupContainer is needed for nested menus to inherit CSS properties in the vertical mode

--- a/src/components/Modal/Modal.props.ts
+++ b/src/components/Modal/Modal.props.ts
@@ -25,6 +25,11 @@ import { Aside, Footer, Size } from './Modal.types'
 export type ModalProps = {
 
   /**
+   * Identifies the component for testing purposes
+   */
+  dataTestId?: string;
+
+  /**
    * The children nodes to be rendered within the modal context.
    */
   children?: ReactNode,

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -149,4 +149,12 @@ describe('Modal Component', () => {
 
     expect(baseElement).toMatchSnapshot()
   })
+
+  test('should get modal by test id', async() => {
+    render(<Modal {...props} dataTestId="modal-test" />)
+
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeVisible())
+
+    expect(screen.getByTestId('modal-test')).toBeTruthy()
+  })
 })

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -51,6 +51,7 @@ export const defaults = {
  * @returns {Modal} Modal component
  */
 export const Modal = ({
+  dataTestId,
   aside,
   children,
   docLink,
@@ -77,6 +78,7 @@ export const Modal = ({
       centered
       className={modalClassNames}
       closable={isClosable}
+      data-testid={dataTestId}
       destroyOnClose={destroyOnClose}
       footer={<Modal.Footer footer={footer} />}
       getContainer={getContainer}

--- a/src/components/SegmentedControl/SegmentedControl.props.ts
+++ b/src/components/SegmentedControl/SegmentedControl.props.ts
@@ -23,6 +23,11 @@ import { Hierarchy, Option, OptionAlignment } from './SegmentedControl.types'
 export type SegmentedControlProps = {
 
   /**
+   * Identifies the component for testing purposes
+   */
+  dataTestId?: string;
+
+  /**
    * The option initially selected. Either one of the following:
    *
    * - `string`: the key of the initially selected option

--- a/src/components/SegmentedControl/SegmentedControl.test.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.test.tsx
@@ -135,8 +135,8 @@ describe('Segmented Control Component', () => {
 
       fireEvent.click(screen.getByRole('listitem', { name: clickedOption.key }))
 
-      expect(onChange).toBeCalledTimes(1)
-      expect(onChange).toBeCalledWith(clickedOption, expect.objectContaining({ ...MouseEvent }))
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith(clickedOption, expect.objectContaining({ ...MouseEvent }))
     })
   })
 
@@ -250,8 +250,13 @@ describe('Segmented Control Component', () => {
 
       fireEvent.click(screen.getByRole('listitem', { name: clickedOption }))
 
-      expect(onChange).toBeCalledTimes(1)
-      expect(onChange).toBeCalledWith(clickedOption, expect.objectContaining({ ...MouseEvent }))
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith(clickedOption, expect.objectContaining({ ...MouseEvent }))
+    })
+
+    test('should get segment control by test id', () => {
+      render(<SegmentedControl {...props} dataTestId="segment-control-test" />)
+      expect(screen.getByTestId('segment-control-test')).toBeTruthy()
     })
   })
 })

--- a/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.tsx
@@ -40,6 +40,7 @@ export const defaults = {
  * @returns {SegmentedControl} SegmentedControl component
  */
 export const SegmentedControl = ({
+  dataTestId,
   defaultValue,
   hierarchy = defaults.hierarchy,
   isDisabled = defaults.isDisabled,
@@ -67,6 +68,7 @@ export const SegmentedControl = ({
         optionsAlignment === Vertical && vertical,
         hierarchy === Primary && primary,
       ])}
+      data-testid={dataTestId}
     >
       {options.map((option) => {
         const currentKey = resolveKey(options, value) ?? selectedValue

--- a/src/components/Table/Table.props.ts
+++ b/src/components/Table/Table.props.ts
@@ -25,6 +25,11 @@ import { ColumnType, ExpandableConfig, GenericRecord, Layout, Locale, Pagination
 export type TableProps<RecordType extends GenericRecord> = {
 
   /**
+   * Identifies the component for testing purposes
+   */
+  dataTestId?: string;
+
+  /**
    * An array of column configurations for the table.
    *
    * column `object`:

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -427,4 +427,9 @@ describe('Table Component', () => {
     const { asFragment } = render(<Table {...props} columns={spannedColumns} />)
     await waitFor(() => expect(asFragment()).toMatchSnapshot())
   })
+
+  test('should get table by test id', () => {
+    render(<Table {...props} dataTestId="table-test" />)
+    expect(screen.getByTestId('table-test')).toBeTruthy()
+  })
 })

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -68,6 +68,7 @@ export const defaults = {
 export const Table = <RecordType extends GenericRecord>({
   columns,
   data,
+  dataTestId,
   actions = defaults.actions,
   expandable,
   footer,
@@ -127,6 +128,7 @@ export const Table = <RecordType extends GenericRecord>({
         bordered={isBordered}
         className={table}
         columns={tableColumns}
+        data-testId={dataTestId}
         dataSource={data}
         expandable={expandable}
         footer={footer}


### PR DESCRIPTION
### Description

This PR aims to add the `dataTestId` prop to almost every component.
I didn't add the prop to the components that I thought it was not necessary but it can be discussed and I'm not quite sure about the Icon component.

The components with the new prop are:
- Button
- Breadcrumb
- Drawer
- Menu
- SegmentedControl
- Modal
- Table
- FeedbackMessage

The components **without** the prop are:
- Divider
- Icon
- ThemeProvider
- Typography

### Addressed issue

Closes #372

### Checklist

- [x] commit message and branch name follow conventions
- [x] tests are included
- [x] changes are accessible and documented from components stories
- [x] typings are updated or integrated accordingly with your changes
- [x] all added components are exported from index file (if necessary)
- [x] all added files include Apache 2.0 license
- [x] you are not committing extraneous files or sensitive data
- [x] the browser console does not have any logged errors
- [x] necessary labels have been applied to this pull request (enhancement, bug, ecc.)
