### PR TITLE
fix(card): fixed card padding for skeleton 

### DIFF
--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -22,11 +22,11 @@
   background-color: var(--palette-common-white, #ffffff);
   border-radius: var(--shape-border-radius-lg, 8px);
   border-width: var(--shape-border-width-xs, 1px);
-  padding: var(--spacing-padding-sm, 8px) 0;
+  padding: var(--spacing-padding-sm, 8px) var(--spacing-padding-xl, 24px);
 }
 
 .content {
-  padding: var(--spacing-padding-lg, 16px) var(--spacing-padding-xl, 24px);
+  padding: var(--spacing-padding-lg, 16px) 0;
   gap: var(--spacing-gap-xl, 24px);
 }
 
@@ -38,7 +38,7 @@
 .header {
   display: flex;
   justify-content: space-between;
-  padding: var(--spacing-padding-sm, 8px) var(--spacing-padding-xl, 24px);
+  padding: var(--spacing-padding-sm, 8px) 0;
   gap: var(--spacing-gap-xl, 24px);
 }
 


### PR DESCRIPTION
### Description

Card padding style was only considering content and header, not skeleton.  
This caused skeleton to be 100% wide.  
This MR moves the left/right padding from just content and header to the card container itself

skeleton before:  
![image](https://github.com/user-attachments/assets/a975ba83-fba3-4262-baeb-3aa126a98cd7) 

skeleton now:  
![image](https://github.com/user-attachments/assets/40bd0e47-3931-4ad0-957f-7a90ae0c4fe9)  


content before:
![image](https://github.com/user-attachments/assets/eb2bb425-de3f-4055-b39b-f304e61a063d)

content now (unchanged):
![image](https://github.com/user-attachments/assets/cc9d87c1-1c31-420b-a61a-088618a76874)



##### Card
  - fixed skeleton padding

### Checklist

<!-- For further details regarding standards and conventions adopted in this repository please take a look at the CONTRIBUTING.md file. -->

- [X] commit message and branch name follow conventions
- [ ] tests are included
- [ ] changes are accessible and documented from components stories
- [ ] typings are updated or integrated accordingly with your changes
- [ ] all added components are exported from index file (if necessary)
- [ ] all added files include Apache 2.0 license
- [ ] you are not committing extraneous files or sensitive data
- [ ] the browser console does not have any logged errors
- [ ] necessary labels have been applied to this pull request (enhancement, bug, ecc.)
