### PR TITLE
fix(Icon): color prop defaults to "currentColor"

### DIFF
--- a/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -174,11 +174,13 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 1`] = `
       >
         <svg
           aria-label="PiDotsThree"
+          color="currentColor"
           fill="currentColor"
           height="16"
           role="img"
           stroke="currentColor"
           stroke-width="0"
+          style="color: currentColor;"
           viewBox="0 0 256 256"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
@@ -507,11 +509,13 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 2`] = `
       >
         <svg
           aria-label="PiDotsThree"
+          color="currentColor"
           fill="currentColor"
           height="16"
           role="img"
           stroke="currentColor"
           stroke-width="0"
+          style="color: currentColor;"
           viewBox="0 0 256 256"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
@@ -1340,11 +1344,13 @@ exports[`Breadcrumb Component renders controlled item menu correctly 1`] = `
             >
               <svg
                 aria-label="PiMagnifyingGlass"
+                color="currentColor"
                 fill="currentColor"
                 height="12"
                 role="img"
                 stroke="currentColor"
                 stroke-width="0"
+                style="color: currentColor;"
                 viewBox="0 0 256 256"
                 width="12"
                 xmlns="http://www.w3.org/2000/svg"
@@ -1868,11 +1874,13 @@ exports[`Breadcrumb Component renders item menu correctly 2`] = `
             >
               <svg
                 aria-label="PiMagnifyingGlass"
+                color="currentColor"
                 fill="currentColor"
                 height="12"
                 role="img"
                 stroke="currentColor"
                 stroke-width="0"
+                style="color: currentColor;"
                 viewBox="0 0 256 256"
                 width="12"
                 xmlns="http://www.w3.org/2000/svg"

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -23,7 +23,7 @@ import { Button } from '.'
 import { Icon } from '../Icon'
 import { defaults } from './Button'
 
-const icon = <Icon color="white" name="PiCircleHalfTiltLight" size={16} />
+const icon = <Icon name="PiArrowArcRight" size={16} />
 
 const meta = {
   component: Button,
@@ -174,5 +174,13 @@ export const WithIconRight: Story = {
     ...meta.args,
     icon,
     iconPosition: Button.IconPosition.Right,
+  },
+}
+
+export const NeutralWithIcon: Story = {
+  args: {
+    ...meta.args,
+    hierarchy: Button.Hierarchy.Neutral,
+    icon,
   },
 }

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -37,7 +37,7 @@ export const Icon = ({
   size = defaults.size,
   color,
 }: IconProps): ReactElement | null => {
-  const { color: defaultColor, size: defaultSize, className } = useContext(IconContext)
+  const { size: defaultSize, className } = useContext(IconContext)
 
   const IconComponent = name in customIcons
     ? customIcons?.[name as keyof typeof customIcons]
@@ -52,7 +52,7 @@ export const Icon = ({
     <IconComponent
       aria-label={name}
       className={className}
-      color={color ?? defaultColor}
+      color={color ?? 'currentColor'}
       height={size ?? defaultSize}
       role={'img'}
       size={size ?? defaultSize}

--- a/src/components/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/src/components/Icon/__snapshots__/Icon.test.tsx.snap
@@ -4,11 +4,13 @@ exports[`Icon Component renders Ant icon correctly 1`] = `
 <DocumentFragment>
   <svg
     aria-label="AiOutlineHome"
+    color="currentColor"
     fill="currentColor"
     height="24"
     role="img"
     stroke="currentColor"
     stroke-width="0"
+    style="color: currentColor;"
     viewBox="0 0 1024 1024"
     width="24"
     xmlns="http://www.w3.org/2000/svg"
@@ -24,6 +26,7 @@ exports[`Icon Component renders Feather icon correctly 1`] = `
 <DocumentFragment>
   <svg
     aria-label="FiHome"
+    color="currentColor"
     fill="none"
     height="24"
     role="img"
@@ -31,6 +34,7 @@ exports[`Icon Component renders Feather icon correctly 1`] = `
     stroke-linecap="round"
     stroke-linejoin="round"
     stroke-width="2"
+    style="color: currentColor;"
     viewBox="0 0 24 24"
     width="24"
     xmlns="http://www.w3.org/2000/svg"
@@ -49,11 +53,13 @@ exports[`Icon Component renders Phosphor icon correctly 1`] = `
 <DocumentFragment>
   <svg
     aria-label="PiHouse"
+    color="currentColor"
     fill="currentColor"
     height="24"
     role="img"
     stroke="currentColor"
     stroke-width="0"
+    style="color: currentColor;"
     viewBox="0 0 256 256"
     width="24"
     xmlns="http://www.w3.org/2000/svg"
@@ -69,6 +75,7 @@ exports[`Icon Component renders custom icon correctly 1`] = `
 <DocumentFragment>
   <svg
     aria-label="MiaPlatform"
+    color="currentColor"
     data-file-name="SvgMiaPlatform"
     height="24"
     role="img"

--- a/src/components/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/src/components/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`Segmented Control Component labeled options renders disabled segmented 
     >
       <svg
         aria-label="MiaPlatform"
+        color="currentColor"
         data-file-name="SvgMiaPlatform"
         height="16"
         role="img"
@@ -29,11 +30,13 @@ exports[`Segmented Control Component labeled options renders disabled segmented 
     >
       <svg
         aria-label="PiChartPieSlice"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         viewBox="0 0 256 256"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -52,11 +55,13 @@ exports[`Segmented Control Component labeled options renders disabled segmented 
     >
       <svg
         aria-label="AiOutlineDesktop"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         viewBox="0 0 1024 1024"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -75,11 +80,13 @@ exports[`Segmented Control Component labeled options renders disabled segmented 
     >
       <svg
         aria-label="AiOutlineFieldTime"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         t="1569683618210"
         version="1.1"
         viewBox="0 0 1024 1024"
@@ -104,11 +111,13 @@ exports[`Segmented Control Component labeled options renders disabled segmented 
     >
       <svg
         aria-label="AiOutlineLock"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         viewBox="0 0 1024 1024"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -127,11 +136,13 @@ exports[`Segmented Control Component labeled options renders disabled segmented 
     >
       <svg
         aria-label="AiOutlineFork"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         viewBox="0 0 1024 1024"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -150,11 +161,13 @@ exports[`Segmented Control Component labeled options renders disabled segmented 
     >
       <svg
         aria-label="AiOutlineFilter"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         viewBox="0 0 1024 1024"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -182,6 +195,7 @@ exports[`Segmented Control Component labeled options renders options correctly 1
     >
       <svg
         aria-label="MiaPlatform"
+        color="currentColor"
         data-file-name="SvgMiaPlatform"
         height="16"
         role="img"
@@ -198,11 +212,13 @@ exports[`Segmented Control Component labeled options renders options correctly 1
     >
       <svg
         aria-label="PiChartPieSlice"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         viewBox="0 0 256 256"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -221,11 +237,13 @@ exports[`Segmented Control Component labeled options renders options correctly 1
     >
       <svg
         aria-label="AiOutlineDesktop"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         viewBox="0 0 1024 1024"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -244,11 +262,13 @@ exports[`Segmented Control Component labeled options renders options correctly 1
     >
       <svg
         aria-label="AiOutlineFieldTime"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         t="1569683618210"
         version="1.1"
         viewBox="0 0 1024 1024"
@@ -273,11 +293,13 @@ exports[`Segmented Control Component labeled options renders options correctly 1
     >
       <svg
         aria-label="AiOutlineLock"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         viewBox="0 0 1024 1024"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -296,11 +318,13 @@ exports[`Segmented Control Component labeled options renders options correctly 1
     >
       <svg
         aria-label="AiOutlineFork"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         viewBox="0 0 1024 1024"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -319,11 +343,13 @@ exports[`Segmented Control Component labeled options renders options correctly 1
     >
       <svg
         aria-label="AiOutlineFilter"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         viewBox="0 0 1024 1024"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -351,6 +377,7 @@ exports[`Segmented Control Component labeled options renders primary options cor
     >
       <svg
         aria-label="MiaPlatform"
+        color="currentColor"
         data-file-name="SvgMiaPlatform"
         height="16"
         role="img"
@@ -367,11 +394,13 @@ exports[`Segmented Control Component labeled options renders primary options cor
     >
       <svg
         aria-label="PiChartPieSlice"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         viewBox="0 0 256 256"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -390,11 +419,13 @@ exports[`Segmented Control Component labeled options renders primary options cor
     >
       <svg
         aria-label="AiOutlineDesktop"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         viewBox="0 0 1024 1024"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -413,11 +444,13 @@ exports[`Segmented Control Component labeled options renders primary options cor
     >
       <svg
         aria-label="AiOutlineFieldTime"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         t="1569683618210"
         version="1.1"
         viewBox="0 0 1024 1024"
@@ -442,11 +475,13 @@ exports[`Segmented Control Component labeled options renders primary options cor
     >
       <svg
         aria-label="AiOutlineLock"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         viewBox="0 0 1024 1024"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -465,11 +500,13 @@ exports[`Segmented Control Component labeled options renders primary options cor
     >
       <svg
         aria-label="AiOutlineFork"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         viewBox="0 0 1024 1024"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -488,11 +525,13 @@ exports[`Segmented Control Component labeled options renders primary options cor
     >
       <svg
         aria-label="AiOutlineFilter"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         viewBox="0 0 1024 1024"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -520,6 +559,7 @@ exports[`Segmented Control Component labeled options renders vertical options co
     >
       <svg
         aria-label="MiaPlatform"
+        color="currentColor"
         data-file-name="SvgMiaPlatform"
         height="16"
         role="img"
@@ -536,11 +576,13 @@ exports[`Segmented Control Component labeled options renders vertical options co
     >
       <svg
         aria-label="PiChartPieSlice"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         viewBox="0 0 256 256"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -559,11 +601,13 @@ exports[`Segmented Control Component labeled options renders vertical options co
     >
       <svg
         aria-label="AiOutlineDesktop"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         viewBox="0 0 1024 1024"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -582,11 +626,13 @@ exports[`Segmented Control Component labeled options renders vertical options co
     >
       <svg
         aria-label="AiOutlineFieldTime"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         t="1569683618210"
         version="1.1"
         viewBox="0 0 1024 1024"
@@ -611,11 +657,13 @@ exports[`Segmented Control Component labeled options renders vertical options co
     >
       <svg
         aria-label="AiOutlineLock"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         viewBox="0 0 1024 1024"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -634,11 +682,13 @@ exports[`Segmented Control Component labeled options renders vertical options co
     >
       <svg
         aria-label="AiOutlineFork"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         viewBox="0 0 1024 1024"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -657,11 +707,13 @@ exports[`Segmented Control Component labeled options renders vertical options co
     >
       <svg
         aria-label="AiOutlineFilter"
+        color="currentColor"
         fill="currentColor"
         height="16"
         role="img"
         stroke="currentColor"
         stroke-width="0"
+        style="color: currentColor;"
         viewBox="0 0 1024 1024"
         width="16"
         xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! -->

### Description

#357 suggests to have a different default for the [`Icon`](https://github.com/mia-platform/design-system/blob/main/src/components/Icon/Icon.tsx) prop, from the default value included in the theme to the [`currentColor` keyword](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#currentcolor_keyword).

I wasn't unsure if change the default on the Icon component (which will reflect to any usage of the `Icon` component) or to the `Icon` included in `Button` components (since it's more noticeable in buttons with _neutral_ hierarchy, see #521). I'm going with this implementation but I'm open for suggestions.

#### Icon
- `color` prop defaults to `currentColor`

#### Button
- added in the Storybook the example _Neutral with icon_ to verify that the icon have its color changed during hover.

### Addressed issue

Closes #357

### Checklist

<!-- For further details regarding standards and conventions adopted in this repository please take a look at the CONTRIBUTING.md file. -->

- [X] commit message and branch name follow conventions
- [X] tests are included
- [X] changes are accessible and documented from components stories
- [X] typings are updated or integrated accordingly with your changes
- [X] all added components are exported from index file (if necessary)
- [X] all added files include Apache 2.0 license
- [X] you are not committing extraneous files or sensitive data
- [X] the browser console does not have any logged errors
- [X] necessary labels have been applied to this pull request (enhancement, bug, ecc.)
