### PR TITLE
feat(Table): added rowState prop

### DIFF
--- a/src/components/Table/Table.mocks.tsx
+++ b/src/components/Table/Table.mocks.tsx
@@ -200,6 +200,20 @@ export const expandable = (callbacks: Callbacks = {}): ExpandableConfig<TableRec
   ...callbacks,
 })
 
+/** Row State */
+
+export type TableRecordState = TableRecord & { state?: string }
+
+export const dataState: TableRecordState[] = [
+  { state: 'Default', field1: 'Value 1', field2: 'Value 1', field3: 'Value 1', nested: { field4: 'Value 1' } },
+  { state: 'Info', field1: 'Value 2', field2: 'Value 2', field3: 'Value 2', nested: { field4: 'Value 2' } },
+  { state: 'Warning', field1: 'Value 3', field2: 'Value 3', field3: 'Value 3', nested: { field4: 'Value 3' } },
+  { state: 'Error', field1: 'Value 4', field2: 'Value 4', field3: 'Value 4', nested: { field4: 'Value 4' } },
+  { state: 'Success', field1: 'Value 5', field2: 'Value 5', field3: 'Value 5', nested: { field4: 'Value 5' } },
+]
+
+export const columnsState: ColumnType<TableRecordState>[] = [{ dataIndex: 'state', title: 'State' }, ...columns]
+
 /** Pagination */
 
 export const pagination = (callbacks: Callbacks = {}): Pagination => ({

--- a/src/components/Table/Table.module.css
+++ b/src/components/Table/Table.module.css
@@ -37,6 +37,48 @@
     padding-top: var(--column-padding) !important;
     padding-bottom: var(--column-padding) !important;
   }
+
+  :global(.mia-platform-table-row) {
+    &.infoState {
+      & > td {
+        background: var(--palette-info-100, #E5F0FC);
+      }
+
+      &:hover > td {
+        background: var(--palette-info-200, #D2E5FC);
+      }
+    }
+
+    &.warningState {
+      & > td {
+        background: var(--palette-warning-100, #FFF0B3);
+      }
+
+      &:hover > td {
+        background: var(--palette-warning-200, #FFE1A0);
+      }
+    }
+
+    &.errorState {
+      & > td {
+        background: var(--palette-error-100, #FFEBEB);
+      }
+
+      &:hover > td {
+        background: var(--palette-error-200, #FFDBDB);
+      }
+    }
+
+    &.successState {
+      & > td {
+        background: var(--palette-success-100, #DEF8D8);
+      }
+
+      &:hover > td {
+        background: var(--palette-success-200, #C8F2BF);
+      }
+    }
+  }
 }
 
 .action {

--- a/src/components/Table/Table.props.ts
+++ b/src/components/Table/Table.props.ts
@@ -20,7 +20,7 @@
 
 import { HTMLAttributes, ReactElement } from 'react'
 
-import { ColumnType, ExpandableConfig, GenericRecord, Layout, Locale, Pagination, RowSelection, Scroll, Size, TableAction, UserAction } from './Table.types'
+import { ColumnType, ExpandableConfig, GenericRecord, Layout, Locale, Pagination, RowSelection, RowState, Scroll, Size, TableAction, UserAction } from './Table.types'
 
 export type TableProps<RecordType extends GenericRecord> = {
 
@@ -288,4 +288,13 @@ export type TableProps<RecordType extends GenericRecord> = {
    *   - scrollToFirstRowOnChange: Whether to automatically scroll to the first row of the page after onChange is invoked. <br> `boolean`
    */
   scroll?: Scroll,
+
+  /**
+   * Configuration for row state in table.
+   *
+   * @param record - The data record for the row.
+   * @param index - The index of the row.
+   * @returns The state of the row.
+   */
+  rowState?: (record: RecordType, index: number) => RowState | undefined
 }

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -19,13 +19,17 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
+import { Action, RowState as RowStateEnum } from './Table.types'
 import {
   TableRecord,
+  TableRecordState,
   WithExternalFiltersAndSorters,
   alignedColumns,
   columns,
+  columnsState,
   customActions,
   data,
+  dataState,
   expandable,
   filteredAndSortedColumns,
   footer,
@@ -38,7 +42,6 @@ import {
   sizedColumns,
   spannedColumns,
 } from './Table.mocks'
-import { Action } from './Table.types'
 import { Table } from '.'
 import { defaults } from './Table'
 
@@ -154,4 +157,13 @@ export const ColumnWidth: Story = {
 
 export const ColumnSpan: Story = {
   args: { ...meta.args, columns: spannedColumns, isBordered: true },
+}
+
+export const RowState: Story = {
+  args: {
+    ...meta.args,
+    columns: columnsState,
+    data: dataState,
+    rowState: (record: TableRecordState) => (record.state?.toLowerCase() as RowStateEnum),
+  },
 }

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { WithExternalFiltersAndSorters, alignedColumns, columns, customActions, data, expandable, filteredAndSortedColumns, footer, hugeData, pagination, rowKey, rowSelection, sizedColumns, spannedColumns } from './Table.mocks'
+import { Action, RowState } from './Table.types'
+import { TableRecordState, WithExternalFiltersAndSorters, alignedColumns, columns, columnsState, customActions, data, dataState, expandable, filteredAndSortedColumns, footer, hugeData, pagination, rowKey, rowSelection, sizedColumns, spannedColumns } from './Table.mocks'
 import { fireEvent, render, screen, waitFor, within } from '../../test-utils'
-import { Action } from './Table.types'
 import { Table } from '.'
 
 describe('Table Component', () => {
@@ -425,6 +425,19 @@ describe('Table Component', () => {
 
   test('renders spanned columns correctly', async() => {
     const { asFragment } = render(<Table {...props} columns={spannedColumns} />)
+    await waitFor(() => expect(asFragment()).toMatchSnapshot())
+  })
+
+  test('renders rows with state correctly', async() => {
+    const { asFragment } = render(
+      <Table
+        {...props}
+        columns={columnsState}
+        data={dataState}
+        rowState={(record: TableRecordState) => (record.state?.toLowerCase() as RowState)}
+      />
+    )
+
     await waitFor(() => expect(asFragment()).toMatchSnapshot())
   })
 })

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -17,9 +17,9 @@
  */
 
 import { Table as AntTable, Skeleton } from 'antd'
-import { ReactElement, useMemo } from 'react'
+import { ReactElement, useCallback, useMemo } from 'react'
 
-import { Action, ColumnAlignment, ColumnFilterMode, GenericRecord, Layout, Size, SortOrder } from './Table.types'
+import { Action, ColumnAlignment, ColumnFilterMode, GenericRecord, Layout, RowState, Size, SortOrder } from './Table.types'
 import { Icon } from '../Icon'
 import { IconProps } from '../Icon/Icon.props'
 import { TableProps } from './Table.props'
@@ -85,6 +85,7 @@ export const Table = <RecordType extends GenericRecord>({
   pagination = defaults.pagination,
   size = defaults.size,
   scroll = defaults.scroll,
+  rowState,
 }: TableProps<RecordType>): ReactElement => {
   const theme = useTheme()
   const iconSize = theme?.shape?.size?.md as IconProps['size'] || 16
@@ -118,6 +119,12 @@ export const Table = <RecordType extends GenericRecord>({
     ...pagination,
   }), [pagination])
 
+  const rowClassName = useCallback((record: RecordType, index: number) => {
+    const state = rowState?.(record, index)
+    const isValidState = state && Object.values(Table.RowState).includes(state)
+    return isValidState ? styles[`${state}State`] : ''
+  }, [rowState])
+
   return (
     <Skeleton
       active
@@ -133,6 +140,7 @@ export const Table = <RecordType extends GenericRecord>({
         loading={false}
         locale={intlLocale}
         pagination={tablePagination}
+        rowClassName={rowState ? rowClassName : undefined}
         rowKey={rowKey}
         rowSelection={rowSelection}
         scroll={scroll}
@@ -159,3 +167,4 @@ Table.Layout = Layout
 Table.Size = Size
 Table.SortOrder = SortOrder
 Table.Action = Action
+Table.RowState = RowState

--- a/src/components/Table/Table.types.ts
+++ b/src/components/Table/Table.types.ts
@@ -50,6 +50,13 @@ export enum SortOrder {
   Descend = 'descend',
 }
 
+export enum RowState {
+  Info = 'info',
+  Warning = 'warning',
+  Error = 'error',
+  Success = 'success'
+}
+
 export type Scroll = {
   x?: number | string | true,
   y?: number | string,

--- a/src/components/Table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/Table/__snapshots__/Table.test.tsx.snap
@@ -3613,6 +3613,292 @@ exports[`Table Component renders pagination correctly 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Table Component renders rows with state correctly 1`] = `
+<DocumentFragment>
+  <div
+    class="mia-platform-table-wrapper table"
+  >
+    <div
+      class="mia-platform-spin-nested-loading"
+    >
+      <div
+        class="mia-platform-spin-container"
+      >
+        <div
+          class="mia-platform-table mia-platform-table-middle mia-platform-table-scroll-horizontal"
+        >
+          <div
+            class="mia-platform-table-container"
+          >
+            <div
+              class="mia-platform-table-header mia-platform-table-sticky-holder"
+              style="overflow: hidden; top: 0px;"
+            >
+              <table
+                style="table-layout: fixed; visibility: hidden;"
+              >
+                <colgroup />
+                <thead
+                  class="mia-platform-table-thead"
+                >
+                  <tr>
+                    <th
+                      class="mia-platform-table-cell"
+                      scope="col"
+                    >
+                      State
+                    </th>
+                    <th
+                      class="mia-platform-table-cell"
+                      scope="col"
+                    >
+                      Field 1
+                    </th>
+                    <th
+                      class="mia-platform-table-cell"
+                      scope="col"
+                    >
+                      Field 2
+                    </th>
+                    <th
+                      class="mia-platform-table-cell"
+                      scope="col"
+                    >
+                      Field 3
+                    </th>
+                    <th
+                      class="mia-platform-table-cell"
+                      scope="col"
+                    >
+                      Field 4
+                    </th>
+                  </tr>
+                </thead>
+              </table>
+            </div>
+            <div
+              class="mia-platform-table-body"
+              style="overflow-x: auto; overflow-y: hidden;"
+            >
+              <table
+                style="width: auto; min-width: 100%; table-layout: auto;"
+              >
+                <colgroup />
+                <tbody
+                  class="mia-platform-table-tbody"
+                >
+                  <tr
+                    aria-hidden="true"
+                    class="mia-platform-table-measure-row"
+                    style="height: 0px; font-size: 0px;"
+                  >
+                    <td
+                      style="padding: 0px; border: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden;"
+                      >
+                         
+                      </div>
+                    </td>
+                    <td
+                      style="padding: 0px; border: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden;"
+                      >
+                         
+                      </div>
+                    </td>
+                    <td
+                      style="padding: 0px; border: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden;"
+                      >
+                         
+                      </div>
+                    </td>
+                    <td
+                      style="padding: 0px; border: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden;"
+                      >
+                         
+                      </div>
+                    </td>
+                    <td
+                      style="padding: 0px; border: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden;"
+                      >
+                         
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="mia-platform-table-row mia-platform-table-row-level-0"
+                    data-row-key="Value 1"
+                  >
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Default
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 1
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 1
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 1
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 1
+                    </td>
+                  </tr>
+                  <tr
+                    class="mia-platform-table-row mia-platform-table-row-level-0 infoState"
+                    data-row-key="Value 2"
+                  >
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Info
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 2
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 2
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 2
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 2
+                    </td>
+                  </tr>
+                  <tr
+                    class="mia-platform-table-row mia-platform-table-row-level-0 warningState"
+                    data-row-key="Value 3"
+                  >
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Warning
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 3
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 3
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 3
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 3
+                    </td>
+                  </tr>
+                  <tr
+                    class="mia-platform-table-row mia-platform-table-row-level-0 errorState"
+                    data-row-key="Value 4"
+                  >
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Error
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 4
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 4
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 4
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 4
+                    </td>
+                  </tr>
+                  <tr
+                    class="mia-platform-table-row mia-platform-table-row-level-0 successState"
+                    data-row-key="Value 5"
+                  >
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Success
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 5
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 5
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 5
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 5
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Table Component renders selectable rows correctly 1`] = `
 <DocumentFragment>
   <div


### PR DESCRIPTION
### Description

This PR adds the property `rowState` to the Table component. This property lets you specify the row's state (info, warning, error, success) based on the record. The state controls the background colour of the row.

##### Table

- Added property `rowState`

### Addressed issue

Although in a limited manner, the PR addresses the issue https://github.com/mia-platform/design-system/issues/448

### Checklist

<!-- For further details regarding standards and conventions adopted in this repository please take a look at the CONTRIBUTING.md file. -->

- [x] commit message and branch name follow conventions
- [x] tests are included
- [x] changes are accessible and documented from components stories
- [x] typings are updated or integrated accordingly with your changes
- [x] all added components are exported from index file (if necessary)
- [x] all added files include Apache 2.0 license
- [x] you are not committing extraneous files or sensitive data
- [x] the browser console does not have any logged errors
- [x] necessary labels have been applied to this pull request (enhancement, bug, ecc.)
