### PR TITLE
feat(Dropdown): add `onOpenChange` and `getPopupContainer` props

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "Giovanna Monti <giovanna.monti@mia-platform.eu>",
     "Giovanni Tommasi <giovanni.tommasi@mia-platform.eu>",
     "Paola Nicosia <paola.nicosia@mia-platform.eu>",
-    "Riccardo Corona <riccardo.corona@mia-platform.eu>"
+    "Riccardo Corona <riccardo.corona@mia-platform.eu>",
+    "Luca Maltagliati <luca.maltagliati@mia-platform.eu>"
   ],
   "repository": {
     "type": "git",

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -54,6 +54,7 @@ const defaults: Partial<DropdownProps> = {
   }],
   children: <Button >{'click me'}</Button>,
   onClick: action('on click'),
+  onOpenChange: action('on open change'),
 }
 
 const meta = {

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DropdownItem, DropdownProps, DropdownTrigger } from './props'
+import { DropdownItem, DropdownProps, DropdownTrigger, OpenChangeInfoSource } from './props'
 import { RenderResult, render, screen, userEvent, waitFor } from '../../test-utils'
 import { Button } from '../Button'
 import { Dropdown } from './Dropdown'
@@ -196,6 +196,40 @@ describe('Dropdown Component', () => {
         expect(invocation.selectedPath).toEqual(['2', '2-2', '2-2-1'])
         expect(invocation.item).toEqual(caseItems[1].children![1].children![0])
       }, 20000)
+    })
+  })
+
+  describe('onOpenChange', () => {
+    it('invokes onOpenChange with trigger source when opening', async() => {
+      const onOpenChange = jest.fn()
+      const props = {
+        ...defaultProps,
+        onOpenChange,
+      }
+
+      renderDropdown({ props })
+      const button = screen.getByText('test-trigger-button')
+      userEvent.click(button)
+
+      await waitFor(() => expect(onOpenChange).toHaveBeenCalledTimes(1))
+      expect(onOpenChange).toHaveBeenCalledWith(true, { source: OpenChangeInfoSource.Trigger })
+    })
+
+    it('invokes onOpenChange with menu source when closing clicking on a menu item', async() => {
+      const onOpenChange = jest.fn()
+      const props = {
+        ...defaultProps,
+        onOpenChange,
+      }
+
+      renderDropdown({ props })
+      const button = screen.getByText('test-trigger-button')
+      userEvent.click(button)
+
+      await screen.findByRole('menuitem', { name: 'Label 1' })
+      userEvent.click(screen.getByRole('menuitem', { name: 'Label 1' }))
+      await waitFor(() => expect(onOpenChange).toHaveBeenCalledTimes(2))
+      expect(onOpenChange).toHaveBeenNthCalledWith(2, false, { source: OpenChangeInfoSource.Menu })
     })
   })
 })

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -228,6 +228,7 @@ describe('Dropdown Component', () => {
 
       await screen.findByRole('menuitem', { name: 'Label 1' })
       userEvent.click(screen.getByRole('menuitem', { name: 'Label 1' }))
+
       await waitFor(() => expect(onOpenChange).toHaveBeenCalledTimes(2))
       expect(onOpenChange).toHaveBeenNthCalledWith(2, false, { source: OpenChangeInfoSource.Menu })
     })

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -103,7 +103,7 @@ export const Dropdown = ({
       menu={menu}
       overlayClassName={classes}
       trigger={triggers}
-      onOpenChange={onOpenChange ? onOpenChangeInternal : undefined}
+      onOpenChange={onOpenChangeInternal}
     >
       {innerNode}
     </AntdDropdown>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -20,7 +20,7 @@ import { Dropdown as AntdDropdown, type MenuProps as AntdMenuProps } from 'antd'
 import React, { ReactElement, ReactNode, useCallback, useMemo } from 'react'
 import classNames from 'classnames'
 
-import { DropdownClickEvent, DropdownItem, DropdownProps, DropdownTrigger, ItemLayout } from './props'
+import { DropdownClickEvent, DropdownItem, DropdownProps, DropdownTrigger, ItemLayout, OpenChangeInfoSource } from './props'
 import Label from './components/Label'
 import styles from './dropdown.module.css'
 
@@ -49,9 +49,8 @@ export const Dropdown = ({
   items,
   onClick,
   triggers = defaults.trigger,
-  open,
   onOpenChange,
-  placement,
+  getPopupContainer,
 }: DropdownProps): ReactElement => {
   const uniqueClassName = useMemo(() => `dropdown-${crypto.randomUUID()}`, [])
 
@@ -79,17 +78,35 @@ export const Dropdown = ({
 
   const classes = useMemo(() => classNames(styles.dropdownWrapper, uniqueClassName), [uniqueClassName])
 
+  const onOpenChangeInternal = useCallback(
+    (open: boolean, info?: {source: 'trigger'| 'menu'}) => {
+      if (!onOpenChange) {
+        return
+      }
+      switch (info?.source) {
+      case 'trigger':
+        onOpenChange(open, { source: OpenChangeInfoSource.Trigger })
+        break
+      case 'menu':
+        onOpenChange(open, { source: OpenChangeInfoSource.Menu })
+        break
+      default:
+        onOpenChange(open)
+      }
+    },
+    [onOpenChange]
+  )
+
   return (
     <AntdDropdown
       autoFocus={autoFocus}
       disabled={isDisabled}
       dropdownRender={dropdownRender}
+      getPopupContainer={getPopupContainer}
       menu={menu}
-      open={open}
       overlayClassName={classes}
-      placement={placement}
       trigger={triggers}
-      onOpenChange={onOpenChange}
+      onOpenChange={onOpenChangeInternal}
     >
       {innerNode}
     </AntdDropdown>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -49,6 +49,8 @@ export const Dropdown = ({
   items,
   onClick,
   triggers = defaults.trigger,
+  open,
+  onOpenChange,
 }: DropdownProps): ReactElement => {
   const uniqueClassName = useMemo(() => `dropdown-${crypto.randomUUID()}`, [])
 
@@ -82,8 +84,10 @@ export const Dropdown = ({
       disabled={isDisabled}
       dropdownRender={dropdownRender}
       menu={menu}
+      open={open}
       overlayClassName={classes}
       trigger={triggers}
+      onOpenChange={onOpenChange}
     >
       {innerNode}
     </AntdDropdown>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -20,7 +20,7 @@ import { Dropdown as AntdDropdown, type MenuProps as AntdMenuProps } from 'antd'
 import React, { ReactElement, ReactNode, useCallback, useMemo } from 'react'
 import classNames from 'classnames'
 
-import { DropdownClickEvent, DropdownItem, DropdownProps, DropdownTrigger, ItemLayout, OpenChangeInfoSource } from './props'
+import { DropdownClickEvent, DropdownItem, DropdownProps, DropdownTrigger, ItemLayout } from './props'
 import Label from './components/Label'
 import styles from './dropdown.module.css'
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -85,11 +85,11 @@ export const Dropdown = ({
   const classes = useMemo(() => classNames(styles.dropdownWrapper, uniqueClassName), [uniqueClassName])
 
   const onOpenChangeInternal = useCallback(
-    (open: boolean, info?: {source: 'trigger'| 'menu'}) => {
+    (open: boolean, info: {source: 'trigger'| 'menu'}) => {
       if (!onOpenChange) {
         return
       }
-      onOpenChange(open, info ? { source: antdSourceMap[info.source] } : undefined)
+      onOpenChange(open, { source: antdSourceMap[info.source] })
     },
     [onOpenChange]
   )

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -36,6 +36,12 @@ type AntdMenuClickEvent = {
   domEvent: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>
 }
 
+type AntdTriggerSource = 'trigger'|'menu'
+const antdSourceMap: Record<AntdTriggerSource, OpenChangeInfoSource> = {
+  'trigger': OpenChangeInfoSource.Trigger,
+  'menu': OpenChangeInfoSource.Menu,
+}
+
 export const defaults = {
   itemLayout: ItemLayout.Horizontal,
   trigger: [DropdownTrigger.Click],
@@ -83,16 +89,11 @@ export const Dropdown = ({
       if (!onOpenChange) {
         return
       }
-      switch (info?.source) {
-      case 'trigger':
-        onOpenChange(open, { source: OpenChangeInfoSource.Trigger })
-        break
-      case 'menu':
-        onOpenChange(open, { source: OpenChangeInfoSource.Menu })
-        break
-      default:
+      if (!info?.source) {
         onOpenChange(open)
+        return
       }
+      onOpenChange(open, info ? { source: antdSourceMap[info.source] } : undefined)
     },
     [onOpenChange]
   )
@@ -106,7 +107,7 @@ export const Dropdown = ({
       menu={menu}
       overlayClassName={classes}
       trigger={triggers}
-      onOpenChange={onOpenChangeInternal}
+      onOpenChange={onOpenChange ? onOpenChangeInternal : undefined}
     >
       {innerNode}
     </AntdDropdown>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -20,7 +20,7 @@ import { Dropdown as AntdDropdown, type MenuProps as AntdMenuProps } from 'antd'
 import React, { ReactElement, ReactNode, useCallback, useMemo } from 'react'
 import classNames from 'classnames'
 
-import { DropdownClickEvent, DropdownItem, DropdownProps, DropdownTrigger, ItemLayout } from './props'
+import { DropdownClickEvent, DropdownItem, DropdownProps, DropdownTrigger, ItemLayout, OpenChangeInfoSource } from './props'
 import Label from './components/Label'
 import styles from './dropdown.module.css'
 
@@ -51,6 +51,7 @@ export const Dropdown = ({
   triggers = defaults.trigger,
   open,
   onOpenChange,
+  placement,
 }: DropdownProps): ReactElement => {
   const uniqueClassName = useMemo(() => `dropdown-${crypto.randomUUID()}`, [])
 
@@ -86,6 +87,7 @@ export const Dropdown = ({
       menu={menu}
       open={open}
       overlayClassName={classes}
+      placement={placement}
       trigger={triggers}
       onOpenChange={onOpenChange}
     >

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -89,10 +89,6 @@ export const Dropdown = ({
       if (!onOpenChange) {
         return
       }
-      if (!info?.source) {
-        onOpenChange(open)
-        return
-      }
       onOpenChange(open, info ? { source: antdSourceMap[info.source] } : undefined)
     },
     [onOpenChange]

--- a/src/components/Dropdown/props.ts
+++ b/src/components/Dropdown/props.ts
@@ -80,6 +80,11 @@ export type DropdownClickEvent = {
   selectedPath: string[],
 }
 
+export enum OpenChangeInfoSource {
+  Trigger = 'trigger',
+  Menu = 'menu'
+}
+
 export type DropdownProps = {
 
   /**
@@ -132,5 +137,5 @@ export type DropdownProps = {
    * - source: the source of the open change, can be 'trigger' or 'menu'
    * @returns
    */
-    onOpenChange?: (open: boolean, info: {source: 'trigger' | 'menu'}) => void
+   onOpenChange?: (open: boolean, info: {source: OpenChangeInfoSource}) => void
 }

--- a/src/components/Dropdown/props.ts
+++ b/src/components/Dropdown/props.ts
@@ -80,9 +80,14 @@ export type DropdownClickEvent = {
   selectedPath: string[],
 }
 
-export type OpenChangeInfoSource = 'trigger' | 'menu'
+export enum OpenChangeInfoSource {
+  Trigger='trigger',
+  Menu='menu'
+}
 
-export type Placement = 'topLeft'| 'topCenter'| 'topRight'| 'bottomLeft'| 'bottomCenter'| 'bottomRight'| 'top'| 'bottom'
+export type OpenChangeInfo = {
+  source: OpenChangeInfoSource
+}
 
 export type DropdownProps = {
 
@@ -124,24 +129,22 @@ export type DropdownProps = {
   triggers?: DropdownTrigger[],
 
   /**
-   * Whether the dropdown menu is currently open.
-   */
-  open?: boolean,
-
-  /**
    * Called when the open state changes. Not triggered when hidden by click item.
    *
    * @param open the current open state of the Dropdown
-   * @param info an object with the following props:
-   * - source: the source of the open change, can be 'trigger' or 'menu'
+   * @param info an object containing the `source` of the open change, that can be:
+   * - trigger: the open state was changed by an external trigger
+   *    (e.g. the dropdown is opening because the children was clicked, or closing because the focus was lost)
+   * - menu: the open state was changed by clicking on a menu item
+   *    (e.g. the dropdown is closing because a menu item was clicked)
    * @returns
    */
-   onOpenChange?: (open: boolean, info: {source: OpenChangeInfoSource}) => void
+   onOpenChange?: (open: boolean, info?: OpenChangeInfo) => void
 
    /**
-    * The placement of the dropdown menu, it can be one of the following:
-    * `bottom`, `bottomLeft`, `bottomRight`, `top`, `topLeft`, `topRight`
-    * (default: `bottomLeft`)
+    * To set the container of the dropdown menu.
+    * The default is to create a div element in body,
+    *  but you can reset it to the scrolling area and make a relative reposition.
     */
-   placement?: Placement
+   getPopupContainer?: (triggerNode: HTMLElement) => HTMLElement
 }

--- a/src/components/Dropdown/props.ts
+++ b/src/components/Dropdown/props.ts
@@ -139,7 +139,7 @@ export type DropdownProps = {
    *    (e.g. the dropdown is closing because a menu item was clicked)
    * @returns
    */
-   onOpenChange?: (open: boolean, info?: OpenChangeInfo) => void
+   onOpenChange?: (open: boolean, info: OpenChangeInfo) => void
 
    /**
     * To set the container of the dropdown menu.

--- a/src/components/Dropdown/props.ts
+++ b/src/components/Dropdown/props.ts
@@ -118,4 +118,19 @@ export type DropdownProps = {
    * list of triggers that can open the Dropdown (accepts: click, hover, contextMenu).
    */
   triggers?: DropdownTrigger[],
+
+  /**
+   * Whether the dropdown menu is currently open.
+   */
+  open?: boolean,
+
+  /**
+   * Called when the open state changes. Not triggered when hidden by click item.
+   *
+   * @param open the current open state of the Dropdown
+   * @param info an object with the following props:
+   * - source: the source of the open change, can be 'trigger' or 'menu'
+   * @returns
+   */
+    onOpenChange?: (open: boolean, info: {source: 'trigger' | 'menu'}) => void
 }

--- a/src/components/Dropdown/props.ts
+++ b/src/components/Dropdown/props.ts
@@ -141,6 +141,7 @@ export type DropdownProps = {
    /**
     * The placement of the dropdown menu, it can be one of the following:
     * `bottom`, `bottomLeft`, `bottomRight`, `top`, `topLeft`, `topRight`
+    * (default: `bottomLeft`)
     */
    placement?: Placement
 }

--- a/src/components/Dropdown/props.ts
+++ b/src/components/Dropdown/props.ts
@@ -143,7 +143,7 @@ export type DropdownProps = {
 
    /**
     * To set the container of the dropdown menu.
-    * The default is to create a div element in body,
+    * The default behavior is to create a div element and append it at the end of the body,
     *  but you can reset it to the scrolling area and make a relative reposition.
     */
    getPopupContainer?: (triggerNode: HTMLElement) => HTMLElement

--- a/src/components/Dropdown/props.ts
+++ b/src/components/Dropdown/props.ts
@@ -80,10 +80,9 @@ export type DropdownClickEvent = {
   selectedPath: string[],
 }
 
-export enum OpenChangeInfoSource {
-  Trigger = 'trigger',
-  Menu = 'menu'
-}
+export type OpenChangeInfoSource = 'trigger' | 'menu'
+
+export type Placement = 'topLeft'| 'topCenter'| 'topRight'| 'bottomLeft'| 'bottomCenter'| 'bottomRight'| 'top'| 'bottom'
 
 export type DropdownProps = {
 
@@ -138,4 +137,10 @@ export type DropdownProps = {
    * @returns
    */
    onOpenChange?: (open: boolean, info: {source: OpenChangeInfoSource}) => void
+
+   /**
+    * The placement of the dropdown menu, it can be one of the following:
+    * `bottom`, `bottomLeft`, `bottomRight`, `top`, `topLeft`, `topRight`
+    */
+   placement?: Placement
 }

--- a/src/components/Dropdown/props.ts
+++ b/src/components/Dropdown/props.ts
@@ -81,8 +81,8 @@ export type DropdownClickEvent = {
 }
 
 export enum OpenChangeInfoSource {
-  Trigger='trigger',
-  Menu='menu'
+  Trigger = 'trigger',
+  Menu = 'menu'
 }
 
 export type OpenChangeInfo = {


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! -->

### Description

I'm working on a component that needs to be aware of the changes of the nested `Dropdown` open status. Therefore, I added the according props in order to expose the needed state to the outer components.

I also need to modify the menu container to fix some positioning issues

##### Dropdown

    - add `onOpenChange` prop, forwarded to the inner Antd component
    - add `getPopupContainer` prop, forwarded to the inner Antd component

### Checklist

<!-- For further details regarding standards and conventions adopted in this repository please take a look at the CONTRIBUTING.md file. -->

- [x] commit message and branch name follow conventions
- [X] tests are included
- [x] changes are accessible and documented from components stories
- [x] typings are updated or integrated accordingly with your changes
- [x] all added components are exported from index file (if necessary)
- [x] all added files include Apache 2.0 license
- [x] you are not committing extraneous files or sensitive data
- [x] the browser console does not have any logged errors
- [x] necessary labels have been applied to this pull request (enhancement, bug, ecc.)
