### PR TITLE
feat(dropdown): highlight selected items with initialSelectedItems and multiple highlight support

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -91,6 +91,14 @@ export const MultipleHighlightSelection: Story = {
   },
 }
 
+export const MultipleHighlightSelectionWithVerticalLayout: Story = {
+  args: {
+    initialSelectedItems: [],
+    itemLayout: Dropdown.ItemLayout.Vertical,
+    multiple: true,
+  },
+}
+
 export const HoverTrigger: Story = {
   args: {
     triggers: [Dropdown.Trigger.Hover],

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -17,11 +17,12 @@
  */
 
 import type { Meta, StoryObj } from '@storybook/react'
+import { useCallback, useState } from 'react'
 import { action } from '@storybook/addon-actions'
 
+import { DropdownClickEvent, DropdownProps } from './props'
 import { Button } from '../Button'
 import { Dropdown } from '.'
-import { DropdownProps } from './props'
 
 const defaults: Partial<DropdownProps> = {
   items: [{
@@ -72,10 +73,60 @@ export default meta
 
 export const BasicExample: Story = {}
 
-export const VerticalLayoutExample: Story = {
+export const VerticalLayout: Story = {
   args: {
     itemLayout: Dropdown.ItemLayout.Vertical,
   },
+}
+
+export const HighlightSelection: Story = {
+  decorators: [
+    (Story, context) => {
+      const [selectedItems, setSelectedItems] = useState(['id1'])
+      const onClick = useCallback(({ id }: DropdownClickEvent) => {
+        setSelectedItems([id])
+      }, [])
+      return (
+        Story({
+          ...context,
+          args: {
+            ...context.allArgs,
+            selectedItems,
+            onClick,
+          },
+        })
+      )
+    },
+  ],
+}
+
+export const MultipleHighlightSelection: Story = {
+  decorators: [
+    (Story, context) => {
+      const [selectedItems, setSelectedItems] = useState<string[]>([])
+      const onClick = useCallback(({ id }: DropdownClickEvent) => {
+        setSelectedItems((prevItems) => {
+          if (!prevItems.includes(id)) {
+            return [...prevItems, id]
+          }
+          const newItems = [...prevItems]
+          newItems.splice(newItems.indexOf(id), 1)
+          return newItems
+        })
+      }, [])
+
+      return (
+        Story({
+          ...context,
+          args: {
+            ...context.allArgs,
+            selectedItems,
+            onClick,
+          },
+        })
+      )
+    },
+  ],
 }
 
 export const HoverTrigger: Story = {

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -17,12 +17,11 @@
  */
 
 import type { Meta, StoryObj } from '@storybook/react'
-import { useCallback, useState } from 'react'
 import { action } from '@storybook/addon-actions'
 
-import { DropdownClickEvent, DropdownProps } from './props'
 import { Button } from '../Button'
 import { Dropdown } from '.'
+import { DropdownProps } from './props'
 
 const defaults: Partial<DropdownProps> = {
   items: [{
@@ -80,53 +79,16 @@ export const VerticalLayout: Story = {
 }
 
 export const HighlightSelection: Story = {
-  decorators: [
-    (Story, context) => {
-      const [selectedItems, setSelectedItems] = useState(['id1'])
-      const onClick = useCallback(({ id }: DropdownClickEvent) => {
-        setSelectedItems([id])
-      }, [])
-      return (
-        Story({
-          ...context,
-          args: {
-            ...context.allArgs,
-            selectedItems,
-            onClick,
-          },
-        })
-      )
-    },
-  ],
+  args: {
+    initialSelectedItems: ['id1'],
+  },
 }
 
 export const MultipleHighlightSelection: Story = {
-  decorators: [
-    (Story, context) => {
-      const [selectedItems, setSelectedItems] = useState<string[]>([])
-      const onClick = useCallback(({ id }: DropdownClickEvent) => {
-        setSelectedItems((prevItems) => {
-          if (!prevItems.includes(id)) {
-            return [...prevItems, id]
-          }
-          const newItems = [...prevItems]
-          newItems.splice(newItems.indexOf(id), 1)
-          return newItems
-        })
-      }, [])
-
-      return (
-        Story({
-          ...context,
-          args: {
-            ...context.allArgs,
-            selectedItems,
-            onClick,
-          },
-        })
-      )
-    },
-  ],
+  args: {
+    initialSelectedItems: [],
+    multiple: true,
+  },
 }
 
 export const HoverTrigger: Story = {

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-nested-callbacks */
 /**
  * Copyright 2024 Mia srl
  *
@@ -267,12 +266,42 @@ describe('Dropdown Component', () => {
         const second = screen.getByRole('menuitem', { name: /Label 2/ })
         userEvent.click(second)
 
+        // eslint-disable-next-line max-nested-callbacks
         await waitFor(() => expect(onClick).toHaveBeenCalled())
 
         userEvent.click(button)
         const firstUpdated = await screen.findByRole('menuitem', { name: 'Label 1' })
         const secondUpdated = screen.getByRole('menuitem', { name: /Label 2/ })
         expect(firstUpdated).toMatchSnapshot('after click render Label 1 is not selected')
+        expect(secondUpdated).toMatchSnapshot('after click render Label 2 is selected')
+      })
+    })
+
+    describe('multiple mode', () => {
+      it('renders proper highlight', async() => {
+        const onClick = jest.fn()
+        const props: DropdownProps = {
+          ...defaultProps,
+          onClick,
+          initialSelectedItems: ['1'],
+          multiple: true,
+        }
+
+        renderDropdown({ props })
+        const button = screen.getByText('test-trigger-button')
+        userEvent.click(button)
+        const el = await screen.findByRole('menuitem', { name: 'Label 1' })
+        expect(el).toMatchSnapshot('first render with pre-selected label 1')
+
+        const second = screen.getByRole('menuitem', { name: /Label 2/ })
+        userEvent.click(second)
+        // eslint-disable-next-line max-nested-callbacks
+        await waitFor(() => expect(onClick).toHaveBeenCalled())
+
+        userEvent.click(button)
+        const firstUpdated = await screen.findByRole('menuitem', { name: 'Label 1' })
+        const secondUpdated = screen.getByRole('menuitem', { name: /Label 2/ })
+        expect(firstUpdated).toMatchSnapshot('after click render Label 1 is selected')
         expect(secondUpdated).toMatchSnapshot('after click render Label 2 is selected')
       })
     })

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -16,31 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  DropdownItem,
-  DropdownProps,
-  DropdownTrigger,
-  OpenChangeInfoSource,
-} from './props'
-import {
-  RenderResult,
-  render,
-  screen,
-  userEvent,
-  waitFor,
-} from '../../test-utils'
+import { DropdownItem, DropdownProps, DropdownTrigger, OpenChangeInfoSource } from './props'
+import { RenderResult, render, screen, userEvent, waitFor } from '../../test-utils'
 import { Button } from '../Button'
 import { Dropdown } from './Dropdown'
 
 const items: DropdownItem[] = [
   { id: '1', label: 'Label 1' },
   { id: '2', label: 'Label 2', secondaryLabel: 'Additional Info 2' },
-  {
-    id: '3',
-    label: 'Danger Label',
-    secondaryLabel: 'Additional Info 2',
-    danger: true,
-  },
+  { id: '3', label: 'Danger Label', secondaryLabel: 'Additional Info 2', danger: true },
 ]
 const defaultProps: DropdownProps = {
   items,
@@ -60,9 +44,7 @@ describe('Dropdown Component', () => {
     })
 
     it('opens dropdown on hover', async() => {
-      renderDropdown({
-        props: { ...defaultProps, triggers: [DropdownTrigger.Hover] },
-      })
+      renderDropdown({ props: { ...defaultProps, triggers: [DropdownTrigger.Hover] } })
       const button = screen.getByText('test-trigger-button')
       userEvent.hover(button)
       await screen.findByRole('menuitem', { name: 'Label 1' })
@@ -116,22 +98,17 @@ describe('Dropdown Component', () => {
           {
             id: '2',
             label: 'Label 2',
-            children: [
-              {
-                id: '2-1',
-                label: 'Label 2-1',
-              },
-              {
-                id: '2-2',
-                label: 'Label 2-2',
-                children: [
-                  {
-                    id: '2-2-1',
-                    label: 'Label 2-2-1',
-                  },
-                ],
-              },
-            ],
+            children: [{
+              id: '2-1',
+              label: 'Label 2-1',
+            }, {
+              id: '2-2',
+              label: 'Label 2-2',
+              children: [{
+                id: '2-2-1',
+                label: 'Label 2-2-1',
+              }],
+            }],
           },
         ]
         const props = {
@@ -157,16 +134,10 @@ describe('Dropdown Component', () => {
         onClick.mockClear()
 
         userEvent.click(button)
-        const item2 = await screen.findByRole('menuitem', {
-          name: /^Label 2/i,
-        })
+        const item2 = await screen.findByRole('menuitem', { name: /^Label 2/i })
         userEvent.hover(item2)
 
-        const sub1 = await screen.findByRole(
-          'menuitem',
-          { name: 'Label 2-1' },
-          { timeout: 10000 }
-        )
+        const sub1 = await screen.findByRole('menuitem', { name: 'Label 2-1' }, { timeout: 10000 })
         expect(sub1).toBeInTheDocument()
 
         userEvent.click(sub1)
@@ -186,22 +157,17 @@ describe('Dropdown Component', () => {
           {
             id: '2',
             label: 'Label 2',
-            children: [
-              {
-                id: '2-1',
-                label: 'Label 2-1',
-              },
-              {
-                id: '2-2',
-                label: 'Label 2-2',
-                children: [
-                  {
-                    id: '2-2-1',
-                    label: 'Label 2-2-1',
-                  },
-                ],
-              },
-            ],
+            children: [{
+              id: '2-1',
+              label: 'Label 2-1',
+            }, {
+              id: '2-2',
+              label: 'Label 2-2',
+              children: [{
+                id: '2-2-1',
+                label: 'Label 2-2-1',
+              }],
+            }],
           },
         ]
         const props = {
@@ -215,14 +181,8 @@ describe('Dropdown Component', () => {
 
         await screen.findByRole('menuitem', { name: 'Label 1' })
         userEvent.hover(screen.getByRole('menuitem', { name: /^Label 2/i }))
-        await screen.findByRole(
-          'menuitem',
-          { name: 'Label 2-1' },
-          { timeout: 10000 }
-        )
-        userEvent.hover(
-          screen.getByRole('menuitem', { name: 'Label 2-2 right' })
-        )
+        await screen.findByRole('menuitem', { name: 'Label 2-1' }, { timeout: 10000 })
+        userEvent.hover(screen.getByRole('menuitem', { name: 'Label 2-2 right' }))
 
         const sub1 = await screen.findByRole(
           'menuitem',
@@ -256,9 +216,7 @@ describe('Dropdown Component', () => {
       userEvent.click(button)
 
       await waitFor(() => expect(onOpenChange).toHaveBeenCalledTimes(1))
-      expect(onOpenChange).toHaveBeenCalledWith(true, {
-        source: OpenChangeInfoSource.Trigger,
-      })
+      expect(onOpenChange).toHaveBeenCalledWith(true, { source: OpenChangeInfoSource.Trigger })
     })
 
     it('invokes onOpenChange with menu source when closing clicking on a menu item', async() => {
@@ -276,9 +234,7 @@ describe('Dropdown Component', () => {
       userEvent.click(screen.getByRole('menuitem', { name: 'Label 1' }))
 
       await waitFor(() => expect(onOpenChange).toHaveBeenCalledTimes(2))
-      expect(onOpenChange).toHaveBeenNthCalledWith(2, false, {
-        source: OpenChangeInfoSource.Menu,
-      })
+      expect(onOpenChange).toHaveBeenNthCalledWith(2, false, { source: OpenChangeInfoSource.Menu })
     })
   })
 

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -184,11 +184,7 @@ describe('Dropdown Component', () => {
         await screen.findByRole('menuitem', { name: 'Label 2-1' }, { timeout: 10000 })
         userEvent.hover(screen.getByRole('menuitem', { name: 'Label 2-2 right' }))
 
-        const sub1 = await screen.findByRole(
-          'menuitem',
-          { name: 'Label 2-2-1' },
-          { timeout: 10000 }
-        )
+        const sub1 = await screen.findByRole('menuitem', { name: 'Label 2-2-1' }, { timeout: 10000 })
         expect(sub1).toBeInTheDocument()
 
         userEvent.click(sub1)

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -16,15 +16,31 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DropdownItem, DropdownProps, DropdownTrigger, OpenChangeInfoSource } from './props'
-import { RenderResult, render, screen, userEvent, waitFor } from '../../test-utils'
+import {
+  DropdownItem,
+  DropdownProps,
+  DropdownTrigger,
+  OpenChangeInfoSource,
+} from './props'
+import {
+  RenderResult,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from '../../test-utils'
 import { Button } from '../Button'
 import { Dropdown } from './Dropdown'
 
 const items: DropdownItem[] = [
   { id: '1', label: 'Label 1' },
   { id: '2', label: 'Label 2', secondaryLabel: 'Additional Info 2' },
-  { id: '3', label: 'Danger Label', secondaryLabel: 'Additional Info 2', danger: true },
+  {
+    id: '3',
+    label: 'Danger Label',
+    secondaryLabel: 'Additional Info 2',
+    danger: true,
+  },
 ]
 const defaultProps: DropdownProps = {
   items,
@@ -44,7 +60,9 @@ describe('Dropdown Component', () => {
     })
 
     it('opens dropdown on hover', async() => {
-      renderDropdown({ props: { ...defaultProps, triggers: [DropdownTrigger.Hover] } })
+      renderDropdown({
+        props: { ...defaultProps, triggers: [DropdownTrigger.Hover] },
+      })
       const button = screen.getByText('test-trigger-button')
       userEvent.hover(button)
       await screen.findByRole('menuitem', { name: 'Label 1' })
@@ -98,17 +116,22 @@ describe('Dropdown Component', () => {
           {
             id: '2',
             label: 'Label 2',
-            children: [{
-              id: '2-1',
-              label: 'Label 2-1',
-            }, {
-              id: '2-2',
-              label: 'Label 2-2',
-              children: [{
-                id: '2-2-1',
-                label: 'Label 2-2-1',
-              }],
-            }],
+            children: [
+              {
+                id: '2-1',
+                label: 'Label 2-1',
+              },
+              {
+                id: '2-2',
+                label: 'Label 2-2',
+                children: [
+                  {
+                    id: '2-2-1',
+                    label: 'Label 2-2-1',
+                  },
+                ],
+              },
+            ],
           },
         ]
         const props = {
@@ -134,10 +157,16 @@ describe('Dropdown Component', () => {
         onClick.mockClear()
 
         userEvent.click(button)
-        const item2 = await screen.findByRole('menuitem', { name: /^Label 2/i })
+        const item2 = await screen.findByRole('menuitem', {
+          name: /^Label 2/i,
+        })
         userEvent.hover(item2)
 
-        const sub1 = await screen.findByRole('menuitem', { name: 'Label 2-1' }, { timeout: 10000 })
+        const sub1 = await screen.findByRole(
+          'menuitem',
+          { name: 'Label 2-1' },
+          { timeout: 10000 }
+        )
         expect(sub1).toBeInTheDocument()
 
         userEvent.click(sub1)
@@ -157,17 +186,22 @@ describe('Dropdown Component', () => {
           {
             id: '2',
             label: 'Label 2',
-            children: [{
-              id: '2-1',
-              label: 'Label 2-1',
-            }, {
-              id: '2-2',
-              label: 'Label 2-2',
-              children: [{
-                id: '2-2-1',
-                label: 'Label 2-2-1',
-              }],
-            }],
+            children: [
+              {
+                id: '2-1',
+                label: 'Label 2-1',
+              },
+              {
+                id: '2-2',
+                label: 'Label 2-2',
+                children: [
+                  {
+                    id: '2-2-1',
+                    label: 'Label 2-2-1',
+                  },
+                ],
+              },
+            ],
           },
         ]
         const props = {
@@ -181,10 +215,20 @@ describe('Dropdown Component', () => {
 
         await screen.findByRole('menuitem', { name: 'Label 1' })
         userEvent.hover(screen.getByRole('menuitem', { name: /^Label 2/i }))
-        await screen.findByRole('menuitem', { name: 'Label 2-1' }, { timeout: 10000 })
-        userEvent.hover(screen.getByRole('menuitem', { name: 'Label 2-2 right' }))
+        await screen.findByRole(
+          'menuitem',
+          { name: 'Label 2-1' },
+          { timeout: 10000 }
+        )
+        userEvent.hover(
+          screen.getByRole('menuitem', { name: 'Label 2-2 right' })
+        )
 
-        const sub1 = await screen.findByRole('menuitem', { name: 'Label 2-2-1' }, { timeout: 10000 })
+        const sub1 = await screen.findByRole(
+          'menuitem',
+          { name: 'Label 2-2-1' },
+          { timeout: 10000 }
+        )
         expect(sub1).toBeInTheDocument()
 
         userEvent.click(sub1)
@@ -212,7 +256,9 @@ describe('Dropdown Component', () => {
       userEvent.click(button)
 
       await waitFor(() => expect(onOpenChange).toHaveBeenCalledTimes(1))
-      expect(onOpenChange).toHaveBeenCalledWith(true, { source: OpenChangeInfoSource.Trigger })
+      expect(onOpenChange).toHaveBeenCalledWith(true, {
+        source: OpenChangeInfoSource.Trigger,
+      })
     })
 
     it('invokes onOpenChange with menu source when closing clicking on a menu item', async() => {
@@ -230,13 +276,30 @@ describe('Dropdown Component', () => {
       userEvent.click(screen.getByRole('menuitem', { name: 'Label 1' }))
 
       await waitFor(() => expect(onOpenChange).toHaveBeenCalledTimes(2))
-      expect(onOpenChange).toHaveBeenNthCalledWith(2, false, { source: OpenChangeInfoSource.Menu })
+      expect(onOpenChange).toHaveBeenNthCalledWith(2, false, {
+        source: OpenChangeInfoSource.Menu,
+      })
+    })
+  })
+
+  describe('highlights selectedItems', () => {
+    it('renders proper highlight', async() => {
+      const props = {
+        ...defaultProps,
+        selectedItems: ['1'],
+      }
+
+      renderDropdown({ props })
+      const button = screen.getByText('test-trigger-button')
+      userEvent.click(button)
+      const el = await screen.findByRole('menuitem', { name: 'Label 1' })
+      expect(el).toMatchSnapshot()
     })
   })
 })
 
 function renderDropdown(
-  { props }: {props: DropdownProps} = { props: defaultProps }
+  { props }: { props: DropdownProps } = { props: defaultProps }
 ): RenderResult {
   return render(<Dropdown {...props} />)
 }

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -293,6 +293,7 @@ describe('Dropdown Component', () => {
         const el = await screen.findByRole('menuitem', { name: 'Label 1' })
         expect(el).toMatchSnapshot('first render with pre-selected label 1')
 
+        // click second label => selected items: label 1 + label 2
         const second = screen.getByRole('menuitem', { name: /Label 2/ })
         userEvent.click(second)
         // eslint-disable-next-line max-nested-callbacks
@@ -303,6 +304,18 @@ describe('Dropdown Component', () => {
         const secondUpdated = screen.getByRole('menuitem', { name: /Label 2/ })
         expect(firstUpdated).toMatchSnapshot('after click render Label 1 is selected')
         expect(secondUpdated).toMatchSnapshot('after click render Label 2 is selected')
+
+        // click first label => selected items: label 2
+        userEvent.click(firstUpdated)
+
+        // eslint-disable-next-line max-nested-callbacks
+        await waitFor(() => expect(onClick).toHaveBeenCalled())
+
+        userEvent.click(button)
+        const firstUpdatedDeSelected = await screen.findByRole('menuitem', { name: 'Label 1' })
+        const secondUpdatedStillSelected = await screen.findByRole('menuitem', { name: /Label 2/ })
+        expect(firstUpdatedDeSelected).toMatchSnapshot('after second click render Label 1 is deselected')
+        expect(secondUpdatedStillSelected).toMatchSnapshot('after second click render Label 2 is selected')
       })
     })
   })

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-nested-callbacks */
 /**
  * Copyright 2024 Mia srl
  *
@@ -235,17 +236,45 @@ describe('Dropdown Component', () => {
   })
 
   describe('highlights selectedItems', () => {
-    it('renders proper highlight', async() => {
-      const props = {
-        ...defaultProps,
-        selectedItems: ['1'],
-      }
+    describe('single mode', () => {
+      it('renders proper highlight', async() => {
+        const props: DropdownProps = {
+          ...defaultProps,
+          initialSelectedItems: ['1'],
+        }
 
-      renderDropdown({ props })
-      const button = screen.getByText('test-trigger-button')
-      userEvent.click(button)
-      const el = await screen.findByRole('menuitem', { name: 'Label 1' })
-      expect(el).toMatchSnapshot()
+        renderDropdown({ props })
+        const button = screen.getByText('test-trigger-button')
+        userEvent.click(button)
+        const el = await screen.findByRole('menuitem', { name: 'Label 1' })
+        expect(el).toMatchSnapshot()
+      })
+
+      it('updates highlight', async() => {
+        const onClick = jest.fn()
+        const props: DropdownProps = {
+          ...defaultProps,
+          onClick,
+          initialSelectedItems: ['1'],
+        }
+
+        renderDropdown({ props })
+        const button = screen.getByText('test-trigger-button')
+        userEvent.click(button)
+        const first = await screen.findByRole('menuitem', { name: 'Label 1' })
+        expect(first).toMatchSnapshot('at first render Label 1 is selected')
+
+        const second = screen.getByRole('menuitem', { name: /Label 2/ })
+        userEvent.click(second)
+
+        await waitFor(() => expect(onClick).toHaveBeenCalled())
+
+        userEvent.click(button)
+        const firstUpdated = await screen.findByRole('menuitem', { name: 'Label 1' })
+        const secondUpdated = screen.getByRole('menuitem', { name: /Label 2/ })
+        expect(firstUpdated).toMatchSnapshot('after click render Label 1 is not selected')
+        expect(secondUpdated).toMatchSnapshot('after click render Label 2 is selected')
+      })
     })
   })
 })

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -45,6 +45,7 @@ const antdSourceMap: Record<AntdTriggerSource, OpenChangeInfoSource> = {
 export const defaults = {
   itemLayout: ItemLayout.Horizontal,
   trigger: [DropdownTrigger.Click],
+  selectedItems: [],
 }
 
 export const Dropdown = ({
@@ -57,6 +58,7 @@ export const Dropdown = ({
   triggers = defaults.trigger,
   onOpenChange,
   getPopupContainer,
+  selectedItems = defaults.selectedItems,
 }: DropdownProps): ReactElement => {
   const uniqueClassName = useMemo(() => `dropdown-${crypto.randomUUID()}`, [])
 
@@ -77,10 +79,11 @@ export const Dropdown = ({
 
   const menu = useMemo(() => ({
     items: antdItems,
-    onClick: onAntdMenuClick,
     /* istanbul ignore next */
     getPopupContainer: (triggerNode: HTMLElement) => (document.querySelector(`.${uniqueClassName}`) || triggerNode) as HTMLElement,
-  }), [antdItems, onAntdMenuClick, uniqueClassName])
+    onClick: onAntdMenuClick,
+    selectedKeys: selectedItems,
+  }), [antdItems, onAntdMenuClick, selectedItems, uniqueClassName])
 
   const classes = useMemo(() => classNames(styles.dropdownWrapper, uniqueClassName), [uniqueClassName])
 

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -1,6 +1,85 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Dropdown Component highlights selectedItems renders proper highlight 1`] = `
+exports[`Dropdown Component highlights selectedItems single mode renders proper highlight 1`] = `
+<li
+  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-selected mia-platform-dropdown-menu-item-only-child"
+  data-menu-id="rc-menu-uuid-test-1"
+  role="menuitem"
+  tabindex="-1"
+>
+  <span
+    class="mia-platform-dropdown-menu-title-content"
+  >
+    <div
+      class="labelContainer horizontalContainer"
+    >
+      <span
+        class="primaryLabel"
+      >
+        Label 1
+      </span>
+    </div>
+  </span>
+</li>
+`;
+
+exports[`Dropdown Component highlights selectedItems single mode updates highlight: after click render Label 1 is not selected 1`] = `
+<li
+  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-only-child"
+  data-menu-id="rc-menu-uuid-test-1"
+  role="menuitem"
+  tabindex="-1"
+>
+  <span
+    class="mia-platform-dropdown-menu-title-content"
+  >
+    <div
+      class="labelContainer horizontalContainer"
+    >
+      <span
+        class="primaryLabel"
+      >
+        Label 1
+      </span>
+    </div>
+  </span>
+</li>
+`;
+
+exports[`Dropdown Component highlights selectedItems single mode updates highlight: after click render Label 2 is selected 1`] = `
+<li
+  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-active mia-platform-dropdown-menu-item-selected mia-platform-dropdown-menu-item-only-child"
+  data-menu-id="rc-menu-uuid-test-2"
+  role="menuitem"
+  tabindex="-1"
+>
+  <span
+    class="mia-platform-dropdown-menu-title-content"
+  >
+    <div
+      class="labelContainer horizontalContainer"
+    >
+      <span
+        class="primaryLabel"
+      >
+        Label 2
+      </span>
+      <span
+        class="secondaryLabel"
+      >
+        ·
+      </span>
+      <span
+        class="secondaryLabel"
+      >
+        Additional Info 2
+      </span>
+    </div>
+  </span>
+</li>
+`;
+
+exports[`Dropdown Component highlights selectedItems single mode updates highlight: at first render Label 1 is selected 1`] = `
 <li
   class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-selected mia-platform-dropdown-menu-item-only-child"
   data-menu-id="rc-menu-uuid-test-1"

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Dropdown Component highlights selectedItems renders proper highlight 1`] = `
+<li
+  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-selected mia-platform-dropdown-menu-item-only-child"
+  data-menu-id="rc-menu-uuid-test-1"
+  role="menuitem"
+  tabindex="-1"
+>
+  <span
+    class="mia-platform-dropdown-menu-title-content"
+  >
+    <div
+      class="labelContainer horizontalContainer"
+    >
+      <span
+        class="primaryLabel"
+      >
+        Label 1
+      </span>
+    </div>
+  </span>
+</li>
+`;
+
 exports[`Dropdown Component label layouts render labels 1`] = `
 <li
   class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-only-child"

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -1,5 +1,84 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Dropdown Component highlights selectedItems multiple mode renders proper highlight: after click render Label 1 is selected 1`] = `
+<li
+  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-selected mia-platform-dropdown-menu-item-only-child"
+  data-menu-id="rc-menu-uuid-test-1"
+  role="menuitem"
+  tabindex="-1"
+>
+  <span
+    class="mia-platform-dropdown-menu-title-content"
+  >
+    <div
+      class="labelContainer horizontalContainer"
+    >
+      <span
+        class="primaryLabel"
+      >
+        Label 1
+      </span>
+    </div>
+  </span>
+</li>
+`;
+
+exports[`Dropdown Component highlights selectedItems multiple mode renders proper highlight: after click render Label 2 is selected 1`] = `
+<li
+  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-active mia-platform-dropdown-menu-item-selected mia-platform-dropdown-menu-item-only-child"
+  data-menu-id="rc-menu-uuid-test-2"
+  role="menuitem"
+  tabindex="-1"
+>
+  <span
+    class="mia-platform-dropdown-menu-title-content"
+  >
+    <div
+      class="labelContainer horizontalContainer"
+    >
+      <span
+        class="primaryLabel"
+      >
+        Label 2
+      </span>
+      <span
+        class="secondaryLabel"
+      >
+        ·
+      </span>
+      <span
+        class="secondaryLabel"
+      >
+        Additional Info 2
+      </span>
+    </div>
+  </span>
+</li>
+`;
+
+exports[`Dropdown Component highlights selectedItems multiple mode renders proper highlight: first render with pre-selected label 1 1`] = `
+<li
+  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-selected mia-platform-dropdown-menu-item-only-child"
+  data-menu-id="rc-menu-uuid-test-1"
+  role="menuitem"
+  tabindex="-1"
+>
+  <span
+    class="mia-platform-dropdown-menu-title-content"
+  >
+    <div
+      class="labelContainer horizontalContainer"
+    >
+      <span
+        class="primaryLabel"
+      >
+        Label 1
+      </span>
+    </div>
+  </span>
+</li>
+`;
+
 exports[`Dropdown Component highlights selectedItems single mode renders proper highlight 1`] = `
 <li
   class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-selected mia-platform-dropdown-menu-item-only-child"

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -56,6 +56,62 @@ exports[`Dropdown Component highlights selectedItems multiple mode renders prope
 </li>
 `;
 
+exports[`Dropdown Component highlights selectedItems multiple mode renders proper highlight: after second click render Label 1 is deselected 1`] = `
+<li
+  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-active mia-platform-dropdown-menu-item-only-child"
+  data-menu-id="rc-menu-uuid-test-1"
+  role="menuitem"
+  tabindex="-1"
+>
+  <span
+    class="mia-platform-dropdown-menu-title-content"
+  >
+    <div
+      class="labelContainer horizontalContainer"
+    >
+      <span
+        class="primaryLabel"
+      >
+        Label 1
+      </span>
+    </div>
+  </span>
+</li>
+`;
+
+exports[`Dropdown Component highlights selectedItems multiple mode renders proper highlight: after second click render Label 2 is selected 1`] = `
+<li
+  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-selected mia-platform-dropdown-menu-item-only-child"
+  data-menu-id="rc-menu-uuid-test-2"
+  role="menuitem"
+  tabindex="-1"
+>
+  <span
+    class="mia-platform-dropdown-menu-title-content"
+  >
+    <div
+      class="labelContainer horizontalContainer"
+    >
+      <span
+        class="primaryLabel"
+      >
+        Label 2
+      </span>
+      <span
+        class="secondaryLabel"
+      >
+        ·
+      </span>
+      <span
+        class="secondaryLabel"
+      >
+        Additional Info 2
+      </span>
+    </div>
+  </span>
+</li>
+`;
+
 exports[`Dropdown Component highlights selectedItems multiple mode renders proper highlight: first render with pre-selected label 1 1`] = `
 <li
   class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-selected mia-platform-dropdown-menu-item-only-child"

--- a/src/components/Dropdown/dropdown.module.css
+++ b/src/components/Dropdown/dropdown.module.css
@@ -33,12 +33,14 @@
 }
 
 .dropdownWrapper {
-  & :global(.mia-platform-dropdown-menu-item-danger):hover {
+  & :global(.mia-platform-dropdown-menu-item-danger):hover,
+  & :global(.mia-platform-dropdown-menu-item-selected.mia-platform-dropdown-menu-item-danger) {
     /* overwrite antd default background */
     background-color: var(--palette-action-danger-hover, #FF5453) !important;
   }
 
-  & :global(.mia-platform-dropdown-menu-item-danger):hover .danger {
+  & :global(.mia-platform-dropdown-menu-item-danger):hover .danger,
+  & :global(.mia-platform-dropdown-menu-item-selected) .danger{
     color: var(--palette-common-white, #ffffff);
   }
 

--- a/src/components/Dropdown/dropdown.module.css
+++ b/src/components/Dropdown/dropdown.module.css
@@ -44,6 +44,10 @@
     color: var(--palette-common-white, #ffffff);
   }
 
+  & :global(.mia-platform-dropdown-menu-item-selected) .primaryLabel {
+    font-weight: var(--typography-bodyLBold-fontWeight, 600);
+  }
+
   :global(.mia-platform-dropdown-menu-submenu-title) {
     display: flex !important;
   }

--- a/src/components/Dropdown/props.ts
+++ b/src/components/Dropdown/props.ts
@@ -123,6 +123,8 @@ export type DropdownProps = {
    */
   onClick: (event: DropdownClickEvent) => void
 
+  selectedItems?: string[],
+
   /**
    * list of triggers that can open the Dropdown (accepts: click, hover, contextMenu).
    */

--- a/src/components/Dropdown/props.ts
+++ b/src/components/Dropdown/props.ts
@@ -102,9 +102,9 @@ export type DropdownProps = {
   children?: ReactElement,
 
   /**
-   * list of items to be rendered within the Dropdown.
+   * List of items to be shown as selected at first render
    */
-  items: DropdownItem[],
+  initialSelectedItems?: string[],
 
   /**
    * Whether the dropdown menu is disabled.
@@ -112,9 +112,19 @@ export type DropdownProps = {
   isDisabled?: boolean,
 
   /**
-   * Allows to control the Dropdown label layout (accepts: horizontal, vertical)
+   * list of items to be rendered within the Dropdown.
+   */
+  items: DropdownItem[],
+
+  /**
+   * Allows to control the Dropdown label layout (accepts: horizontal, vertical).
    */
   itemLayout?: ItemLayout,
+
+  /**
+   * control whether to allow multiple highlight selection.
+   */
+  multiple?: boolean
 
   /**
    * @param DropdownClickEvent event contains the reference to the clicked item, specifically it holds
@@ -122,8 +132,6 @@ export type DropdownProps = {
    * - selectedPath: array of strings representing the selected item json path
    */
   onClick: (event: DropdownClickEvent) => void
-
-  selectedItems?: string[],
 
   /**
    * list of triggers that can open the Dropdown (accepts: click, hover, contextMenu).


### PR DESCRIPTION
### Description

This PR introduces:

 - `Dropdown#initialSelectedItems` **optional** prop that helps selecting one or more items at first render.
 - `Dropdown#multiple` **optional** prop that can be used to control whether dropdown highlights should consider multiple items or a single one.

**Screenshot below shows highlight in multiple mode**

<img width="527" alt="Screenshot 2024-08-14 alle 16 06 58" src="https://github.com/user-attachments/assets/43d40fc8-c272-4138-b232-b8c2d3ef88bd">


### Checklist

<!-- For further details regarding standards and conventions adopted in this repository please take a look at the CONTRIBUTING.md file. -->

- [x] commit message and branch name follow conventions
- [x] tests are included
- [x] changes are accessible and documented from components stories
- [x] typings are updated or integrated accordingly with your changes
- [x] all added components are exported from index file (if necessary)
- [x] all added files include Apache 2.0 license
- [x] you are not committing extraneous files or sensitive data
- [x] the browser console does not have any logged errors
- [x] necessary labels have been applied to this pull request (enhancement, bug, ecc.)
