### PR TITLE
feat(Dropdown): add optional `Tag` at the end of menu items

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -19,9 +19,10 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
+import { DropdownItem, DropdownProps } from './props'
 import { Button } from '../Button'
 import { Dropdown } from '.'
-import { DropdownProps } from './props'
+import { Tag } from '../Tag'
 
 const defaults: Partial<DropdownProps> = {
   items: [{
@@ -96,3 +97,24 @@ export const Disabled: Story = {
     isDisabled: true,
   },
 }
+
+export const HorizontalLayoutWithTag: Story = {
+  args: {
+    itemLayout: Dropdown.ItemLayout.Horizontal,
+    items: defaults?.items?.map<DropdownItem>(item => ({
+      ...item,
+      tag: <Tag isBordered={false}>{'Test'}</Tag>,
+    })),
+  },
+}
+
+export const VerticalLayoutWithTag: Story = {
+  args: {
+    itemLayout: Dropdown.ItemLayout.Vertical,
+    items: defaults?.items?.map<DropdownItem>(item => ({
+      ...item,
+      tag: <Tag isBordered={false}>{'Test'}</Tag>,
+    })),
+  },
+}
+

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -19,9 +19,9 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
-import { DropdownProps } from './props'
 import { Button } from '../Button'
 import { Dropdown } from '.'
+import { DropdownProps } from './props'
 import { Tag } from '../Tag'
 
 const defaults: Partial<DropdownProps> = {

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -19,7 +19,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
-import { DropdownItem, DropdownProps } from './props'
+import { DropdownProps } from './props'
 import { Button } from '../Button'
 import { Dropdown } from '.'
 import { Tag } from '../Tag'
@@ -52,6 +52,11 @@ const defaults: Partial<DropdownProps> = {
         label: 'value 4.2-1',
       }],
     }],
+  }, {
+    id: 'id5-with-tag',
+    label: 'with tag',
+    secondaryLabel: 'Some additional info 2',
+    tag: <Tag>{'Tag'}</Tag>,
   }],
   children: <Button >{'click me'}</Button>,
   onClick: action('on click'),
@@ -97,24 +102,3 @@ export const Disabled: Story = {
     isDisabled: true,
   },
 }
-
-export const HorizontalLayoutWithTag: Story = {
-  args: {
-    itemLayout: Dropdown.ItemLayout.Horizontal,
-    items: defaults?.items?.map<DropdownItem>(item => ({
-      ...item,
-      tag: <Tag isBordered={false}>{'Test'}</Tag>,
-    })),
-  },
-}
-
-export const VerticalLayoutWithTag: Story = {
-  args: {
-    itemLayout: Dropdown.ItemLayout.Vertical,
-    items: defaults?.items?.map<DropdownItem>(item => ({
-      ...item,
-      tag: <Tag isBordered={false}>{'Test'}</Tag>,
-    })),
-  },
-}
-

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -118,7 +118,7 @@ function itemsAdapter(items: DropdownItem[], layout: ItemLayout): AntdMenuItems 
     children: item.children ? itemsAdapter(item.children, layout) : undefined,
     danger: item.danger,
     key: item.id,
-    label: <Label item={item} layout={layout} />,
+    label: <Label item={item} layout={layout} tag={item.tag} />,
   }))
 }
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -132,7 +132,7 @@ function itemsAdapter(items: DropdownItem[], layout: ItemLayout): AntdMenuItems 
     children: item.children ? itemsAdapter(item.children, layout) : undefined,
     danger: item.danger,
     key: item.id,
-    label: <Label item={item} layout={layout} tag={item.tag} />,
+    label: <Label item={item} layout={layout} />,
   }))
 }
 

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -11,13 +11,17 @@ exports[`Dropdown Component highlights selectedItems multiple mode renders prope
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelContainer horizontalContainer"
+      class="labelOuterContainer"
     >
-      <span
-        class="primaryLabel"
+      <div
+        class="labelsContainer horizontalContainer"
       >
-        Label 1
-      </span>
+        <span
+          class="primaryLabel"
+        >
+          Label 1
+        </span>
+      </div>
     </div>
   </span>
 </li>
@@ -34,23 +38,27 @@ exports[`Dropdown Component highlights selectedItems multiple mode renders prope
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelContainer horizontalContainer"
+      class="labelOuterContainer"
     >
-      <span
-        class="primaryLabel"
+      <div
+        class="labelsContainer horizontalContainer"
       >
-        Label 2
-      </span>
-      <span
-        class="secondaryLabel"
-      >
-        ·
-      </span>
-      <span
-        class="secondaryLabel"
-      >
-        Additional Info 2
-      </span>
+        <span
+          class="primaryLabel"
+        >
+          Label 2
+        </span>
+        <span
+          class="secondaryLabel"
+        >
+          ·
+        </span>
+        <span
+          class="secondaryLabel"
+        >
+          Additional Info 2
+        </span>
+      </div>
     </div>
   </span>
 </li>
@@ -67,13 +75,17 @@ exports[`Dropdown Component highlights selectedItems multiple mode renders prope
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelContainer horizontalContainer"
+      class="labelOuterContainer"
     >
-      <span
-        class="primaryLabel"
+      <div
+        class="labelsContainer horizontalContainer"
       >
-        Label 1
-      </span>
+        <span
+          class="primaryLabel"
+        >
+          Label 1
+        </span>
+      </div>
     </div>
   </span>
 </li>
@@ -90,23 +102,27 @@ exports[`Dropdown Component highlights selectedItems multiple mode renders prope
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelContainer horizontalContainer"
+      class="labelOuterContainer"
     >
-      <span
-        class="primaryLabel"
+      <div
+        class="labelsContainer horizontalContainer"
       >
-        Label 2
-      </span>
-      <span
-        class="secondaryLabel"
-      >
-        ·
-      </span>
-      <span
-        class="secondaryLabel"
-      >
-        Additional Info 2
-      </span>
+        <span
+          class="primaryLabel"
+        >
+          Label 2
+        </span>
+        <span
+          class="secondaryLabel"
+        >
+          ·
+        </span>
+        <span
+          class="secondaryLabel"
+        >
+          Additional Info 2
+        </span>
+      </div>
     </div>
   </span>
 </li>
@@ -123,13 +139,17 @@ exports[`Dropdown Component highlights selectedItems multiple mode renders prope
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelContainer horizontalContainer"
+      class="labelOuterContainer"
     >
-      <span
-        class="primaryLabel"
+      <div
+        class="labelsContainer horizontalContainer"
       >
-        Label 1
-      </span>
+        <span
+          class="primaryLabel"
+        >
+          Label 1
+        </span>
+      </div>
     </div>
   </span>
 </li>
@@ -146,13 +166,17 @@ exports[`Dropdown Component highlights selectedItems single mode renders proper 
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelContainer horizontalContainer"
+      class="labelOuterContainer"
     >
-      <span
-        class="primaryLabel"
+      <div
+        class="labelsContainer horizontalContainer"
       >
-        Label 1
-      </span>
+        <span
+          class="primaryLabel"
+        >
+          Label 1
+        </span>
+      </div>
     </div>
   </span>
 </li>
@@ -169,13 +193,17 @@ exports[`Dropdown Component highlights selectedItems single mode updates highlig
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelContainer horizontalContainer"
+      class="labelOuterContainer"
     >
-      <span
-        class="primaryLabel"
+      <div
+        class="labelsContainer horizontalContainer"
       >
-        Label 1
-      </span>
+        <span
+          class="primaryLabel"
+        >
+          Label 1
+        </span>
+      </div>
     </div>
   </span>
 </li>
@@ -192,23 +220,27 @@ exports[`Dropdown Component highlights selectedItems single mode updates highlig
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelContainer horizontalContainer"
+      class="labelOuterContainer"
     >
-      <span
-        class="primaryLabel"
+      <div
+        class="labelsContainer horizontalContainer"
       >
-        Label 2
-      </span>
-      <span
-        class="secondaryLabel"
-      >
-        ·
-      </span>
-      <span
-        class="secondaryLabel"
-      >
-        Additional Info 2
-      </span>
+        <span
+          class="primaryLabel"
+        >
+          Label 2
+        </span>
+        <span
+          class="secondaryLabel"
+        >
+          ·
+        </span>
+        <span
+          class="secondaryLabel"
+        >
+          Additional Info 2
+        </span>
+      </div>
     </div>
   </span>
 </li>
@@ -225,13 +257,17 @@ exports[`Dropdown Component highlights selectedItems single mode updates highlig
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelContainer horizontalContainer"
+      class="labelOuterContainer"
     >
-      <span
-        class="primaryLabel"
+      <div
+        class="labelsContainer horizontalContainer"
       >
-        Label 1
-      </span>
+        <span
+          class="primaryLabel"
+        >
+          Label 1
+        </span>
+      </div>
     </div>
   </span>
 </li>

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Dropdown Component label layouts render labels 1`] = `
       class="labelOuterContainer"
     >
       <div
-        class="labelLabelsContainer horizontalContainer"
+        class="labelsContainer horizontalContainer"
       >
         <span
           class="primaryLabel"
@@ -41,7 +41,7 @@ exports[`Dropdown Component label layouts render labels 2`] = `
       class="labelOuterContainer"
     >
       <div
-        class="labelLabelsContainer horizontalContainer"
+        class="labelsContainer horizontalContainer"
       >
         <span
           class="primaryLabel"
@@ -78,7 +78,7 @@ exports[`Dropdown Component label layouts render labels 3`] = `
       class="labelOuterContainer"
     >
       <div
-        class="labelLabelsContainer horizontalContainer"
+        class="labelsContainer horizontalContainer"
       >
         <span
           class="primaryLabel danger"

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Dropdown Component highlights selectedItems multiple mode renders prope
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelOuterContainer"
+      class="itemRowContainer"
     >
       <div
         class="labelsContainer horizontalContainer"
@@ -38,7 +38,7 @@ exports[`Dropdown Component highlights selectedItems multiple mode renders prope
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelOuterContainer"
+      class="itemRowContainer"
     >
       <div
         class="labelsContainer horizontalContainer"
@@ -75,7 +75,7 @@ exports[`Dropdown Component highlights selectedItems multiple mode renders prope
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelOuterContainer"
+      class="itemRowContainer"
     >
       <div
         class="labelsContainer horizontalContainer"
@@ -102,7 +102,7 @@ exports[`Dropdown Component highlights selectedItems multiple mode renders prope
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelOuterContainer"
+      class="itemRowContainer"
     >
       <div
         class="labelsContainer horizontalContainer"
@@ -139,7 +139,7 @@ exports[`Dropdown Component highlights selectedItems multiple mode renders prope
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelOuterContainer"
+      class="itemRowContainer"
     >
       <div
         class="labelsContainer horizontalContainer"
@@ -166,7 +166,7 @@ exports[`Dropdown Component highlights selectedItems single mode renders proper 
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelOuterContainer"
+      class="itemRowContainer"
     >
       <div
         class="labelsContainer horizontalContainer"
@@ -193,7 +193,7 @@ exports[`Dropdown Component highlights selectedItems single mode updates highlig
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelOuterContainer"
+      class="itemRowContainer"
     >
       <div
         class="labelsContainer horizontalContainer"
@@ -220,7 +220,7 @@ exports[`Dropdown Component highlights selectedItems single mode updates highlig
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelOuterContainer"
+      class="itemRowContainer"
     >
       <div
         class="labelsContainer horizontalContainer"
@@ -257,7 +257,7 @@ exports[`Dropdown Component highlights selectedItems single mode updates highlig
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelOuterContainer"
+      class="itemRowContainer"
     >
       <div
         class="labelsContainer horizontalContainer"
@@ -284,7 +284,7 @@ exports[`Dropdown Component label layouts render labels 1`] = `
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelOuterContainer"
+      class="itemRowContainer"
     >
       <div
         class="labelsContainer horizontalContainer"
@@ -311,7 +311,7 @@ exports[`Dropdown Component label layouts render labels 2`] = `
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelOuterContainer"
+      class="itemRowContainer"
     >
       <div
         class="labelsContainer horizontalContainer"
@@ -348,7 +348,7 @@ exports[`Dropdown Component label layouts render labels 3`] = `
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelOuterContainer"
+      class="itemRowContainer"
     >
       <div
         class="labelsContainer horizontalContainer"

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -11,13 +11,17 @@ exports[`Dropdown Component label layouts render labels 1`] = `
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelContainer horizontalContainer"
+      class="labelOuterContainer"
     >
-      <span
-        class="primaryLabel"
+      <div
+        class="labelLabelsContainer horizontalContainer"
       >
-        Label 1
-      </span>
+        <span
+          class="primaryLabel"
+        >
+          Label 1
+        </span>
+      </div>
     </div>
   </span>
 </li>
@@ -34,23 +38,27 @@ exports[`Dropdown Component label layouts render labels 2`] = `
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelContainer horizontalContainer"
+      class="labelOuterContainer"
     >
-      <span
-        class="primaryLabel"
+      <div
+        class="labelLabelsContainer horizontalContainer"
       >
-        Label 2
-      </span>
-      <span
-        class="secondaryLabel"
-      >
-        ·
-      </span>
-      <span
-        class="secondaryLabel"
-      >
-        Additional Info 2
-      </span>
+        <span
+          class="primaryLabel"
+        >
+          Label 2
+        </span>
+        <span
+          class="secondaryLabel"
+        >
+          ·
+        </span>
+        <span
+          class="secondaryLabel"
+        >
+          Additional Info 2
+        </span>
+      </div>
     </div>
   </span>
 </li>
@@ -67,23 +75,27 @@ exports[`Dropdown Component label layouts render labels 3`] = `
     class="mia-platform-dropdown-menu-title-content"
   >
     <div
-      class="labelContainer horizontalContainer"
+      class="labelOuterContainer"
     >
-      <span
-        class="primaryLabel danger"
+      <div
+        class="labelLabelsContainer horizontalContainer"
       >
-        Danger Label
-      </span>
-      <span
-        class="secondaryLabel danger"
-      >
-        ·
-      </span>
-      <span
-        class="secondaryLabel danger"
-      >
-        Additional Info 2
-      </span>
+        <span
+          class="primaryLabel danger"
+        >
+          Danger Label
+        </span>
+        <span
+          class="secondaryLabel danger"
+        >
+          ·
+        </span>
+        <span
+          class="secondaryLabel danger"
+        >
+          Additional Info 2
+        </span>
+      </div>
     </div>
   </span>
 </li>

--- a/src/components/Dropdown/components/Label/__snapshots__/index.test.tsx.snap
+++ b/src/components/Dropdown/components/Label/__snapshots__/index.test.tsx.snap
@@ -240,6 +240,15 @@ exports[`Label vertical layout render with tag 1`] = `
           Secondary Label
         </span>
       </div>
+      <span
+        class="labelTag"
+      >
+        <span
+          class="mia-platform-tag"
+        >
+          Tag
+        </span>
+      </span>
     </div>
   </div>
 </body>

--- a/src/components/Dropdown/components/Label/__snapshots__/index.test.tsx.snap
+++ b/src/components/Dropdown/components/Label/__snapshots__/index.test.tsx.snap
@@ -4,13 +4,17 @@ exports[`Label horizontal layout render label only 1`] = `
 <body>
   <div>
     <div
-      class="labelContainer horizontalContainer"
+      class="labelOuterContainer"
     >
-      <span
-        class="primaryLabel"
+      <div
+        class="labelLabelsContainer horizontalContainer"
       >
-        Some Label
-      </span>
+        <span
+          class="primaryLabel"
+        >
+          Some Label
+        </span>
+      </div>
     </div>
   </div>
 </body>
@@ -20,13 +24,17 @@ exports[`Label horizontal layout render label only and danger 1`] = `
 <body>
   <div>
     <div
-      class="labelContainer horizontalContainer"
+      class="labelOuterContainer"
     >
-      <span
-        class="primaryLabel danger"
+      <div
+        class="labelLabelsContainer horizontalContainer"
       >
-        Some Label
-      </span>
+        <span
+          class="primaryLabel danger"
+        >
+          Some Label
+        </span>
+      </div>
     </div>
   </div>
 </body>
@@ -36,23 +44,27 @@ exports[`Label horizontal layout render with danger and secondaryLabel 1`] = `
 <body>
   <div>
     <div
-      class="labelContainer horizontalContainer"
+      class="labelOuterContainer"
     >
-      <span
-        class="primaryLabel danger"
+      <div
+        class="labelLabelsContainer horizontalContainer"
       >
-        Some Label
-      </span>
-      <span
-        class="secondaryLabel danger"
-      >
-        ·
-      </span>
-      <span
-        class="secondaryLabel danger"
-      >
-        Secondary Label
-      </span>
+        <span
+          class="primaryLabel danger"
+        >
+          Some Label
+        </span>
+        <span
+          class="secondaryLabel danger"
+        >
+          ·
+        </span>
+        <span
+          class="secondaryLabel danger"
+        >
+          Secondary Label
+        </span>
+      </div>
     </div>
   </div>
 </body>
@@ -62,23 +74,27 @@ exports[`Label horizontal layout render with secondaryLabel 1`] = `
 <body>
   <div>
     <div
-      class="labelContainer horizontalContainer"
+      class="labelOuterContainer"
     >
-      <span
-        class="primaryLabel"
+      <div
+        class="labelLabelsContainer horizontalContainer"
       >
-        Some Label
-      </span>
-      <span
-        class="secondaryLabel"
-      >
-        ·
-      </span>
-      <span
-        class="secondaryLabel"
-      >
-        Secondary Label
-      </span>
+        <span
+          class="primaryLabel"
+        >
+          Some Label
+        </span>
+        <span
+          class="secondaryLabel"
+        >
+          ·
+        </span>
+        <span
+          class="secondaryLabel"
+        >
+          Secondary Label
+        </span>
+      </div>
     </div>
   </div>
 </body>
@@ -88,13 +104,17 @@ exports[`Label vertical layout render label only 1`] = `
 <body>
   <div>
     <div
-      class="labelContainer verticalContainer"
+      class="labelOuterContainer"
     >
-      <span
-        class="primaryLabel strong"
+      <div
+        class="labelLabelsContainer verticalContainer"
       >
-        Some Label
-      </span>
+        <span
+          class="primaryLabel strong"
+        >
+          Some Label
+        </span>
+      </div>
     </div>
   </div>
 </body>
@@ -104,13 +124,17 @@ exports[`Label vertical layout render label only and danger 1`] = `
 <body>
   <div>
     <div
-      class="labelContainer verticalContainer"
+      class="labelOuterContainer"
     >
-      <span
-        class="primaryLabel danger strong"
+      <div
+        class="labelLabelsContainer verticalContainer"
       >
-        Some Label
-      </span>
+        <span
+          class="primaryLabel danger strong"
+        >
+          Some Label
+        </span>
+      </div>
     </div>
   </div>
 </body>
@@ -120,18 +144,22 @@ exports[`Label vertical layout render with danger and secondaryLabel 1`] = `
 <body>
   <div>
     <div
-      class="labelContainer verticalContainer"
+      class="labelOuterContainer"
     >
-      <span
-        class="primaryLabel danger strong"
+      <div
+        class="labelLabelsContainer verticalContainer"
       >
-        Some Label
-      </span>
-      <span
-        class="secondaryLabel danger"
-      >
-        Secondary Label
-      </span>
+        <span
+          class="primaryLabel danger strong"
+        >
+          Some Label
+        </span>
+        <span
+          class="secondaryLabel danger"
+        >
+          Secondary Label
+        </span>
+      </div>
     </div>
   </div>
 </body>
@@ -141,18 +169,22 @@ exports[`Label vertical layout render with secondaryLabel 1`] = `
 <body>
   <div>
     <div
-      class="labelContainer verticalContainer"
+      class="labelOuterContainer"
     >
-      <span
-        class="primaryLabel strong"
+      <div
+        class="labelLabelsContainer verticalContainer"
       >
-        Some Label
-      </span>
-      <span
-        class="secondaryLabel"
-      >
-        Secondary Label
-      </span>
+        <span
+          class="primaryLabel strong"
+        >
+          Some Label
+        </span>
+        <span
+          class="secondaryLabel"
+        >
+          Secondary Label
+        </span>
+      </div>
     </div>
   </div>
 </body>

--- a/src/components/Dropdown/components/Label/__snapshots__/index.test.tsx.snap
+++ b/src/components/Dropdown/components/Label/__snapshots__/index.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Label horizontal layout render label only 1`] = `
       class="labelOuterContainer"
     >
       <div
-        class="labelLabelsContainer horizontalContainer"
+        class="labelsContainer horizontalContainer"
       >
         <span
           class="primaryLabel"
@@ -27,7 +27,7 @@ exports[`Label horizontal layout render label only and danger 1`] = `
       class="labelOuterContainer"
     >
       <div
-        class="labelLabelsContainer horizontalContainer"
+        class="labelsContainer horizontalContainer"
       >
         <span
           class="primaryLabel danger"
@@ -47,7 +47,7 @@ exports[`Label horizontal layout render with danger and secondaryLabel 1`] = `
       class="labelOuterContainer"
     >
       <div
-        class="labelLabelsContainer horizontalContainer"
+        class="labelsContainer horizontalContainer"
       >
         <span
           class="primaryLabel danger"
@@ -77,7 +77,37 @@ exports[`Label horizontal layout render with secondaryLabel 1`] = `
       class="labelOuterContainer"
     >
       <div
-        class="labelLabelsContainer horizontalContainer"
+        class="labelsContainer horizontalContainer"
+      >
+        <span
+          class="primaryLabel"
+        >
+          Some Label
+        </span>
+        <span
+          class="secondaryLabel"
+        >
+          ·
+        </span>
+        <span
+          class="secondaryLabel"
+        >
+          Secondary Label
+        </span>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Label horizontal layout render with tag 1`] = `
+<body>
+  <div>
+    <div
+      class="labelOuterContainer"
+    >
+      <div
+        class="labelsContainer horizontalContainer"
       >
         <span
           class="primaryLabel"
@@ -107,7 +137,7 @@ exports[`Label vertical layout render label only 1`] = `
       class="labelOuterContainer"
     >
       <div
-        class="labelLabelsContainer verticalContainer"
+        class="labelsContainer verticalContainer"
       >
         <span
           class="primaryLabel strong"
@@ -127,7 +157,7 @@ exports[`Label vertical layout render label only and danger 1`] = `
       class="labelOuterContainer"
     >
       <div
-        class="labelLabelsContainer verticalContainer"
+        class="labelsContainer verticalContainer"
       >
         <span
           class="primaryLabel danger strong"
@@ -147,7 +177,7 @@ exports[`Label vertical layout render with danger and secondaryLabel 1`] = `
       class="labelOuterContainer"
     >
       <div
-        class="labelLabelsContainer verticalContainer"
+        class="labelsContainer verticalContainer"
       >
         <span
           class="primaryLabel danger strong"
@@ -172,7 +202,32 @@ exports[`Label vertical layout render with secondaryLabel 1`] = `
       class="labelOuterContainer"
     >
       <div
-        class="labelLabelsContainer verticalContainer"
+        class="labelsContainer verticalContainer"
+      >
+        <span
+          class="primaryLabel strong"
+        >
+          Some Label
+        </span>
+        <span
+          class="secondaryLabel"
+        >
+          Secondary Label
+        </span>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Label vertical layout render with tag 1`] = `
+<body>
+  <div>
+    <div
+      class="labelOuterContainer"
+    >
+      <div
+        class="labelsContainer verticalContainer"
       >
         <span
           class="primaryLabel strong"

--- a/src/components/Dropdown/components/Label/__snapshots__/index.test.tsx.snap
+++ b/src/components/Dropdown/components/Label/__snapshots__/index.test.tsx.snap
@@ -125,6 +125,11 @@ exports[`Label horizontal layout render with tag 1`] = `
           Secondary Label
         </span>
       </div>
+      <span
+        class="mia-platform-tag"
+      >
+        Tag
+      </span>
     </div>
   </div>
 </body>

--- a/src/components/Dropdown/components/Label/__snapshots__/index.test.tsx.snap
+++ b/src/components/Dropdown/components/Label/__snapshots__/index.test.tsx.snap
@@ -241,13 +241,9 @@ exports[`Label vertical layout render with tag 1`] = `
         </span>
       </div>
       <span
-        class="labelTag"
+        class="mia-platform-tag"
       >
-        <span
-          class="mia-platform-tag"
-        >
-          Tag
-        </span>
+        Tag
       </span>
     </div>
   </div>

--- a/src/components/Dropdown/components/Label/__snapshots__/index.test.tsx.snap
+++ b/src/components/Dropdown/components/Label/__snapshots__/index.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Label horizontal layout render label only 1`] = `
 <body>
   <div>
     <div
-      class="labelOuterContainer"
+      class="itemRowContainer"
     >
       <div
         class="labelsContainer horizontalContainer"
@@ -24,7 +24,7 @@ exports[`Label horizontal layout render label only and danger 1`] = `
 <body>
   <div>
     <div
-      class="labelOuterContainer"
+      class="itemRowContainer"
     >
       <div
         class="labelsContainer horizontalContainer"
@@ -44,7 +44,7 @@ exports[`Label horizontal layout render with danger and secondaryLabel 1`] = `
 <body>
   <div>
     <div
-      class="labelOuterContainer"
+      class="itemRowContainer"
     >
       <div
         class="labelsContainer horizontalContainer"
@@ -74,7 +74,7 @@ exports[`Label horizontal layout render with secondaryLabel 1`] = `
 <body>
   <div>
     <div
-      class="labelOuterContainer"
+      class="itemRowContainer"
     >
       <div
         class="labelsContainer horizontalContainer"
@@ -104,7 +104,7 @@ exports[`Label horizontal layout render with tag 1`] = `
 <body>
   <div>
     <div
-      class="labelOuterContainer"
+      class="itemRowContainer"
     >
       <div
         class="labelsContainer horizontalContainer"
@@ -139,7 +139,7 @@ exports[`Label vertical layout render label only 1`] = `
 <body>
   <div>
     <div
-      class="labelOuterContainer"
+      class="itemRowContainer"
     >
       <div
         class="labelsContainer verticalContainer"
@@ -159,7 +159,7 @@ exports[`Label vertical layout render label only and danger 1`] = `
 <body>
   <div>
     <div
-      class="labelOuterContainer"
+      class="itemRowContainer"
     >
       <div
         class="labelsContainer verticalContainer"
@@ -179,7 +179,7 @@ exports[`Label vertical layout render with danger and secondaryLabel 1`] = `
 <body>
   <div>
     <div
-      class="labelOuterContainer"
+      class="itemRowContainer"
     >
       <div
         class="labelsContainer verticalContainer"
@@ -204,7 +204,7 @@ exports[`Label vertical layout render with secondaryLabel 1`] = `
 <body>
   <div>
     <div
-      class="labelOuterContainer"
+      class="itemRowContainer"
     >
       <div
         class="labelsContainer verticalContainer"
@@ -229,7 +229,7 @@ exports[`Label vertical layout render with tag 1`] = `
 <body>
   <div>
     <div
-      class="labelOuterContainer"
+      class="itemRowContainer"
     >
       <div
         class="labelsContainer verticalContainer"

--- a/src/components/Dropdown/components/Label/index.test.tsx
+++ b/src/components/Dropdown/components/Label/index.test.tsx
@@ -77,6 +77,17 @@ describe('Label', () => {
       expect(baseElement).toMatchSnapshot()
     })
   })
+
+  describe('tag', () => {
+    it('throws an error if tag is not a Tag component', () => {
+      const renderFn = (): RenderResult => renderLabel({
+        item: { id: '1', label: 'Some Label' },
+        layout: ItemLayout.Horizontal,
+        tag: <div id="definitely-not-a-Tag" />,
+      })
+      expect(renderFn).toThrow('`tag` must be a Tag component')
+    })
+  })
 })
 
 function renderLabel(props: LabelProps): RenderResult {

--- a/src/components/Dropdown/components/Label/index.test.tsx
+++ b/src/components/Dropdown/components/Label/index.test.tsx
@@ -94,11 +94,11 @@ describe('Label', () => {
   describe('tag', () => {
     it('throws an error if tag is not a Tag component', () => {
       const renderFn = (): RenderResult => renderLabel({
-        item: { id: '1', label: 'Some Label', tag: <div id="definitely-not-a-Tag" /> },
+        item: { id: 'some-id', label: 'Some Label', tag: <div id="definitely-not-a-Tag" /> },
         layout: ItemLayout.Horizontal,
       })
 
-      expect(renderFn).toThrow('`item.tag` must be a Tag component')
+      expect(renderFn).toThrow('Error in Dropdown item with id `some-id`: `item.tag` must be a Tag component')
     })
   })
 })

--- a/src/components/Dropdown/components/Label/index.test.tsx
+++ b/src/components/Dropdown/components/Label/index.test.tsx
@@ -50,8 +50,7 @@ describe('Label', () => {
       },
       {
         name: 'with tag',
-        item: { id: '1', label: 'Some Label', secondaryLabel: 'Secondary Label' },
-        tag: <Tag>Tag</Tag>,
+        item: { id: '1', label: 'Some Label', secondaryLabel: 'Secondary Label', tag: <Tag>Tag</Tag> },
       },
     ]
 
@@ -81,13 +80,13 @@ describe('Label', () => {
       },
       {
         name: 'with tag',
-        item: { id: '1', label: 'Some Label', secondaryLabel: 'Secondary Label' },
-        tag: <Tag>Tag</Tag>,
+        item: { id: '1', label: 'Some Label', secondaryLabel: 'Secondary Label', tag: <Tag>Tag</Tag> },
+
       },
     ]
 
-    it.each(testCases)('render $name', ({ item, tag }) => {
-      const { baseElement } = renderLabel({ item, layout: ItemLayout.Vertical, tag })
+    it.each(testCases)('render $name', ({ item }) => {
+      const { baseElement } = renderLabel({ item, layout: ItemLayout.Vertical })
       expect(baseElement).toMatchSnapshot()
     })
   })
@@ -95,11 +94,11 @@ describe('Label', () => {
   describe('tag', () => {
     it('throws an error if tag is not a Tag component', () => {
       const renderFn = (): RenderResult => renderLabel({
-        item: { id: '1', label: 'Some Label' },
+        item: { id: '1', label: 'Some Label', tag: <div id="definitely-not-a-Tag" /> },
         layout: ItemLayout.Horizontal,
-        tag: <div id="definitely-not-a-Tag" />,
       })
-      expect(renderFn).toThrow('`tag` must be a Tag component')
+
+      expect(renderFn).toThrow('`item.tag` must be a Tag component')
     })
   })
 })

--- a/src/components/Dropdown/components/Label/index.test.tsx
+++ b/src/components/Dropdown/components/Label/index.test.tsx
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { ReactNode } from 'react'
+
 import { DropdownItem, ItemLayout } from '../../props'
 import Label, { LabelProps } from '.'
 import { RenderResult, render } from '../../../../test-utils'
@@ -25,6 +27,7 @@ describe('Label', () => {
   type TestCase = {
     name: string,
     item: DropdownItem,
+    tag?: ReactNode,
   }
 
   describe('horizontal layout', () => {
@@ -47,7 +50,8 @@ describe('Label', () => {
       },
       {
         name: 'with tag',
-        item: { id: '1', label: 'Some Label', secondaryLabel: 'Secondary Label', tag: <Tag>Tag</Tag> },
+        item: { id: '1', label: 'Some Label', secondaryLabel: 'Secondary Label' },
+        tag: <Tag>Tag</Tag>,
       },
     ]
 
@@ -77,12 +81,13 @@ describe('Label', () => {
       },
       {
         name: 'with tag',
-        item: { id: '1', label: 'Some Label', secondaryLabel: 'Secondary Label', tag: <Tag>Tag</Tag> },
+        item: { id: '1', label: 'Some Label', secondaryLabel: 'Secondary Label' },
+        tag: <Tag>Tag</Tag>,
       },
     ]
 
-    it.each(testCases)('render $name', ({ item }) => {
-      const { baseElement } = renderLabel({ item, layout: ItemLayout.Vertical })
+    it.each(testCases)('render $name', ({ item, tag }) => {
+      const { baseElement } = renderLabel({ item, layout: ItemLayout.Vertical, tag })
       expect(baseElement).toMatchSnapshot()
     })
   })

--- a/src/components/Dropdown/components/Label/index.test.tsx
+++ b/src/components/Dropdown/components/Label/index.test.tsx
@@ -19,6 +19,7 @@
 import { DropdownItem, ItemLayout } from '../../props'
 import Label, { LabelProps } from '.'
 import { RenderResult, render } from '../../../../test-utils'
+import { Tag } from '../../../Tag'
 
 describe('Label', () => {
   type TestCase = {
@@ -43,6 +44,10 @@ describe('Label', () => {
       {
         name: 'with danger and secondaryLabel',
         item: { id: '1', label: 'Some Label', secondaryLabel: 'Secondary Label', danger: true },
+      },
+      {
+        name: 'with tag',
+        item: { id: '1', label: 'Some Label', secondaryLabel: 'Secondary Label', tag: <Tag>Tag</Tag> },
       },
     ]
 
@@ -69,6 +74,10 @@ describe('Label', () => {
       {
         name: 'with danger and secondaryLabel',
         item: { id: '1', label: 'Some Label', secondaryLabel: 'Secondary Label', danger: true },
+      },
+      {
+        name: 'with tag',
+        item: { id: '1', label: 'Some Label', secondaryLabel: 'Secondary Label', tag: <Tag>Tag</Tag> },
       },
     ]
 

--- a/src/components/Dropdown/components/Label/index.test.tsx
+++ b/src/components/Dropdown/components/Label/index.test.tsx
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ReactNode } from 'react'
-
 import { DropdownItem, ItemLayout } from '../../props'
 import Label, { LabelProps } from '.'
 import { RenderResult, render } from '../../../../test-utils'
@@ -27,7 +25,6 @@ describe('Label', () => {
   type TestCase = {
     name: string,
     item: DropdownItem,
-    tag?: ReactNode,
   }
 
   describe('horizontal layout', () => {
@@ -81,7 +78,6 @@ describe('Label', () => {
       {
         name: 'with tag',
         item: { id: '1', label: 'Some Label', secondaryLabel: 'Secondary Label', tag: <Tag>Tag</Tag> },
-
       },
     ]
 

--- a/src/components/Dropdown/components/Label/index.tsx
+++ b/src/components/Dropdown/components/Label/index.tsx
@@ -32,7 +32,10 @@ export type LabelProps = {
 }
 
 const validateTagType = (tag?: ReactNode): void => {
-  if (tag && (!isValidElement(tag) || tag.type !== Tag)) {
+  if (!tag) {
+    return
+  }
+  if (!isValidElement(tag) || tag.type !== Tag) {
     throw new Error('`tag` must be a Tag component')
   }
 }
@@ -53,8 +56,8 @@ const Label = ({
     danger ? styles.danger : undefined
   ), [danger])
 
-  const containerClassName = useMemo(() => classNames(
-    styles.labelContainer,
+  const labelsContainerClassName = useMemo(() => classNames(
+    styles.labelLabelsContainer,
     layout === ItemLayout.Horizontal
       ? styles.horizontalContainer
       : styles.verticalContainer
@@ -63,15 +66,22 @@ const Label = ({
   validateTagType(tag)
 
   return (
-    <div className={containerClassName}>
-      <span className={primaryLabelClassName}>{label}</span>
+    <div className={styles.labelOuterContainer}>
+      <div className={labelsContainerClassName}>
+        <span className={primaryLabelClassName}>{label}</span>
+        {
+          !secondaryLabel
+            ? null
+            : <>
+              {layout === ItemLayout.Horizontal && <span className={secondaryLabelClassName}>{LABEL_DIVIDER}</span>}
+              <span className={secondaryLabelClassName}>{secondaryLabel}</span>
+            </>
+        }
+      </div>
       {
-        !secondaryLabel
-          ? null
-          : <>
-            {layout === ItemLayout.Horizontal && <span className={secondaryLabelClassName}>{LABEL_DIVIDER}</span>}
-            <span className={secondaryLabelClassName}>{secondaryLabel}</span>
-          </>
+        tag && (
+          <span className={styles.labelTag}>{tag}</span>
+        )
       }
     </div>
   )

--- a/src/components/Dropdown/components/Label/index.tsx
+++ b/src/components/Dropdown/components/Label/index.tsx
@@ -30,7 +30,7 @@ export type LabelProps = {
   item: DropdownItem
 }
 
-const validateTagType = (itemId: string, tag?: ReactNode,): void => {
+const validateTagType = (itemId: string, tag?: ReactNode): void => {
   if (!tag) {
     return
   }

--- a/src/components/Dropdown/components/Label/index.tsx
+++ b/src/components/Dropdown/components/Label/index.tsx
@@ -30,17 +30,17 @@ export type LabelProps = {
   item: DropdownItem
 }
 
-const validateTagType = (tag?: ReactNode): void => {
+const validateTagType = (itemId: string, tag?: ReactNode,): void => {
   if (!tag) {
     return
   }
   if (!isValidElement(tag) || tag.type !== Tag) {
-    throw new Error('`item.tag` must be a Tag component')
+    throw new Error(`Error in Dropdown item with id \`${itemId}\`: \`item.tag\` must be a Tag component`)
   }
 }
 
 const Label = ({
-  item: { danger, label, secondaryLabel, tag },
+  item: { id: itemId, danger, label, secondaryLabel, tag },
   layout,
 }: LabelProps): ReactElement => {
   const primaryLabelClassName = useMemo(() => classNames(
@@ -61,7 +61,7 @@ const Label = ({
       : styles.verticalContainer
   ), [layout])
 
-  validateTagType(tag)
+  validateTagType(itemId, tag)
 
   return (
     <div className={styles.itemRowContainer}>

--- a/src/components/Dropdown/components/Label/index.tsx
+++ b/src/components/Dropdown/components/Label/index.tsx
@@ -78,11 +78,7 @@ const Label = ({
             </>
         }
       </div>
-      {
-        tag && (
-          <span className={styles.labelTag}>{tag}</span>
-        )
-      }
+      {tag}
     </div>
   )
 }

--- a/src/components/Dropdown/components/Label/index.tsx
+++ b/src/components/Dropdown/components/Label/index.tsx
@@ -28,7 +28,6 @@ const LABEL_DIVIDER = '·'
 export type LabelProps = {
   layout: ItemLayout
   item: DropdownItem
-  tag?: ReactNode
 }
 
 const validateTagType = (tag?: ReactNode): void => {
@@ -36,14 +35,13 @@ const validateTagType = (tag?: ReactNode): void => {
     return
   }
   if (!isValidElement(tag) || tag.type !== Tag) {
-    throw new Error('`tag` must be a Tag component')
+    throw new Error('`item.tag` must be a Tag component')
   }
 }
 
 const Label = ({
-  item: { danger, label, secondaryLabel },
+  item: { danger, label, secondaryLabel, tag },
   layout,
-  tag,
 }: LabelProps): ReactElement => {
   const primaryLabelClassName = useMemo(() => classNames(
     styles.primaryLabel,

--- a/src/components/Dropdown/components/Label/index.tsx
+++ b/src/components/Dropdown/components/Label/index.tsx
@@ -16,10 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ReactElement, useMemo } from 'react'
+import { ReactElement, ReactNode, isValidElement, useMemo } from 'react'
 import classNames from 'classnames'
 
 import { DropdownItem, ItemLayout } from '../../props'
+import { Tag } from '../../../Tag'
 import styles from '../../dropdown.module.css'
 
 const LABEL_DIVIDER = '·'
@@ -27,12 +28,20 @@ const LABEL_DIVIDER = '·'
 export type LabelProps = {
   layout: ItemLayout
   item: DropdownItem
+  tag?: ReactNode
+}
+
+const validateTagType = (tag?: ReactNode): void => {
+  if (tag && (!isValidElement(tag) || tag.type !== Tag)) {
+    throw new Error('`tag` must be a Tag component')
+  }
 }
 
 const Label = ({
   item: { danger, label, secondaryLabel },
   layout,
-}: LabelProps): ReactElement => {
+  tag,
+}: LabelProps): ReactElement<LabelProps> => {
   const primaryLabelClassName = useMemo(() => classNames(
     styles.primaryLabel,
     danger ? styles.danger : undefined,
@@ -50,6 +59,8 @@ const Label = ({
       ? styles.horizontalContainer
       : styles.verticalContainer
   ), [layout])
+
+  validateTagType(tag)
 
   return (
     <div className={containerClassName}>

--- a/src/components/Dropdown/components/Label/index.tsx
+++ b/src/components/Dropdown/components/Label/index.tsx
@@ -44,7 +44,7 @@ const Label = ({
   item: { danger, label, secondaryLabel },
   layout,
   tag,
-}: LabelProps): ReactElement<LabelProps> => {
+}: LabelProps): ReactElement => {
   const primaryLabelClassName = useMemo(() => classNames(
     styles.primaryLabel,
     danger ? styles.danger : undefined,

--- a/src/components/Dropdown/components/Label/index.tsx
+++ b/src/components/Dropdown/components/Label/index.tsx
@@ -64,7 +64,7 @@ const Label = ({
   validateTagType(tag)
 
   return (
-    <div className={styles.labelOuterContainer}>
+    <div className={styles.itemRowContainer}>
       <div className={labelsContainerClassName}>
         <span className={primaryLabelClassName}>{label}</span>
         {

--- a/src/components/Dropdown/components/Label/index.tsx
+++ b/src/components/Dropdown/components/Label/index.tsx
@@ -57,7 +57,7 @@ const Label = ({
   ), [danger])
 
   const labelsContainerClassName = useMemo(() => classNames(
-    styles.labelLabelsContainer,
+    styles.labelsContainer,
     layout === ItemLayout.Horizontal
       ? styles.horizontalContainer
       : styles.verticalContainer

--- a/src/components/Dropdown/dropdown.module.css
+++ b/src/components/Dropdown/dropdown.module.css
@@ -66,6 +66,7 @@
 
 .labelContainer {
   display: flex;
+  text-align: left;
 }
 
 .horizontalContainer {

--- a/src/components/Dropdown/dropdown.module.css
+++ b/src/components/Dropdown/dropdown.module.css
@@ -72,7 +72,7 @@
   display: flex;
   flex-direction: row;
   gap: var(--spacing-gap-sm, 8px);
-  overflow: hidden;
+  align-items: center;
 }
 
 .labelsContainer {
@@ -90,8 +90,4 @@
 .verticalContainer {
   flex-direction: column;
   gap: var(--spacing-gap-xs, 4px);
-}
-
-.labelTag {
-  align-self: center;
 }

--- a/src/components/Dropdown/dropdown.module.css
+++ b/src/components/Dropdown/dropdown.module.css
@@ -62,6 +62,10 @@
     border-top-left-radius: var(--shape-border-radius-lg, 8px);
     border-top-right-radius: var(--shape-border-radius-lg, 8px);
   }
+
+  :global(.mia-platform-tag) {
+    margin-inline-end: unset;
+  }
 }
 
 .labelOuterContainer {
@@ -71,7 +75,7 @@
   overflow: hidden;
 }
 
-.labelLabelsContainer {
+.labelsContainer {
   display: flex;
   text-align: left;
   flex: 1 1 auto;

--- a/src/components/Dropdown/dropdown.module.css
+++ b/src/components/Dropdown/dropdown.module.css
@@ -64,9 +64,17 @@
   }
 }
 
-.labelContainer {
+.labelOuterContainer {
+  display: flex;
+  flex-direction: row;
+  gap: var(--spacing-gap-sm, 8px);
+  overflow: hidden;
+}
+
+.labelLabelsContainer {
   display: flex;
   text-align: left;
+  flex: 1 1 auto;
 }
 
 .horizontalContainer {
@@ -78,4 +86,8 @@
 .verticalContainer {
   flex-direction: column;
   gap: var(--spacing-gap-xs, 4px);
+}
+
+.labelTag {
+  align-self: center;
 }

--- a/src/components/Dropdown/dropdown.module.css
+++ b/src/components/Dropdown/dropdown.module.css
@@ -74,7 +74,7 @@
   }
 }
 
-.labelOuterContainer {
+.itemRowContainer {
   display: flex;
   flex-direction: row;
   gap: var(--spacing-gap-sm, 8px);

--- a/src/components/Dropdown/props.ts
+++ b/src/components/Dropdown/props.ts
@@ -46,6 +46,12 @@ export type DropdownItem = {
   secondaryLabel?: ReactNode,
 
   /**
+   * A Tag, displayed on the right side of the item.
+   * The argument must be a Tag component, otherwise an error will be thrown.
+   */
+  tag?: ReactNode
+
+  /**
    * List of sub-menu items.
    */
   children?: DropdownItem[],


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! -->

### Description

Implements the tag support for the Dropdown menu items labels.
The tag will be shown at the end of the label.

The user can specify the tag as a Tag component, otherwise an error is thrown.

#### Examples
With `Dropdown.ItemLayout.Vertical`:
![image](https://github.com/user-attachments/assets/a3ec64a9-0300-4b9a-8f51-8d89d4adf6b4)

With `Dropdown.ItemLayout.Horizontal`:
![image](https://github.com/user-attachments/assets/8a925c27-d732-45f3-8b5f-5d155cb8f062)


### Addressed issue

#530

### Checklist

<!-- For further details regarding standards and conventions adopted in this repository please take a look at the CONTRIBUTING.md file. -->

- [x] commit message and branch name follow conventions
- [x] tests are included
- [x] changes are accessible and documented from components stories
- [x] typings are updated or integrated accordingly with your changes
- [x] all added components are exported from index file (if necessary)
- [x] all added files include Apache 2.0 license
- [x] you are not committing extraneous files or sensitive data
- [x] the browser console does not have any logged errors
- [x] necessary labels have been applied to this pull request (enhancement, bug, ecc.)
