### PR TITLE
fix: remove extra padding from button with icon only

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@fontsource/inter": "^5.0.20",
-    "antd": "5.13.0",
+    "antd": "5.17.0",
     "lodash-es": "^4.17.21",
     "react-icons": "^4.11.0"
   },

--- a/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -2010,7 +2010,7 @@ exports[`Breadcrumb Component renders item menu correctly 3`] = `
             </div>
           </div>
           <div
-            class="mia-platform-dropdown-trigger breadcrumbMenuIcon withLabel"
+            class="mia-platform-dropdown-trigger breadcrumbMenuIcon withLabel mia-platform-dropdown-open"
           >
             <svg
               aria-label="caret-full-down"
@@ -2166,6 +2166,82 @@ exports[`Breadcrumb Component renders item menu correctly 3`] = `
           <svg
             aria-label="caret-full-down"
             data-file-name="SvgCaretFullDown"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      class="mia-platform-dropdown mia-platform-dropdown-placement-bottomLeft"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+    >
+      <div
+        class="dropdownMenuContainer"
+      >
+        <div
+          class="dropdownMenuSearch"
+        >
+          <span
+            class="mia-platform-input-affix-wrapper mia-platform-input-affix-wrapper-focused mia-platform-input-outlined"
+          >
+            <input
+              class="mia-platform-input"
+              placeholder="Search..."
+              type="text"
+              value="1"
+            />
+            <span
+              class="mia-platform-input-suffix"
+            >
+              <svg
+                aria-label="PiMagnifyingGlass"
+                color="currentColor"
+                fill="currentColor"
+                height="12"
+                role="img"
+                stroke="currentColor"
+                stroke-width="0"
+                style="color: currentColor;"
+                viewBox="0 0 256 256"
+                width="12"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M229.66,218.34l-50.07-50.06a88.11,88.11,0,1,0-11.31,11.31l50.06,50.07a8,8,0,0,0,11.32-11.32ZM40,112a72,72,0,1,1,72,72A72.08,72.08,0,0,1,40,112Z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+        <div
+          class="dropdownMenu"
+        >
+          <ul
+            class="mia-platform-dropdown-menu mia-platform-dropdown-menu-root mia-platform-dropdown-menu-vertical mia-platform-dropdown-menu-light"
+            data-menu-list="true"
+            role="menu"
+            tabindex="0"
+          >
+            <li
+              class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-only-child"
+              data-menu-id="rc-menu-uuid-test-item-1"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <span
+                class="mia-platform-dropdown-menu-title-content"
+              >
+                <div
+                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyS"
+                  role="paragraph"
+                >
+                  Item 1
+                </div>
+              </span>
+            </li>
+          </ul>
+          <div
+            aria-hidden="true"
+            style="display: none;"
           />
         </div>
       </div>

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -22,6 +22,11 @@
   justify-content: center;
   gap: var(--spacing-gap-xs, 4px);
   box-shadow: none;
+
+  & :global(.mia-platform-btn-icon) {
+    margin-inline-end: unset;
+    margin-inline-start: unset;
+  }
 }
 
 /* TODO: add 12px padding to theme */

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -212,6 +212,14 @@ export const Loading: Story = {
   },
 }
 
+export const IconOnly: Story = {
+  args: {
+    ...meta.args,
+    children: undefined,
+    icon,
+  },
+}
+
 export const WithIconLeft: Story = {
   args: {
     ...meta.args,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -37,10 +37,18 @@ const {
 } = styles
 
 const { Primary, Neutral, Danger } = Hierarchy
-const { Left, Right } = IconPosition
+const { Left } = IconPosition
 const { Square } = Shape
 const { Small, Middle, Large } = Size
 const { Filled, Ghost, Link } = Type
+
+enum AntdIconPosition {
+  Start = 'start',
+  End = 'end'
+}
+const getAntdPosition = (position: IconPosition):AntdIconPosition => {
+  return position === Left ? AntdIconPosition.Start : AntdIconPosition.End
+}
 
 export const defaults = {
   hierarchy: Primary,
@@ -89,6 +97,7 @@ export const Button = ({
     ]
   ), [children, size, type])
 
+  const antdIconPosition = useMemo(() => getAntdPosition(iconPosition), [iconPosition])
   return (
     <AntButton
       block={isBlock}
@@ -98,6 +107,8 @@ export const Button = ({
       form={form}
       ghost={type !== Filled && hierarchy !== Neutral}
       htmlType={form && !htmlType ? HTMLType.Submit : htmlType}
+      icon={icon}
+      iconPosition={antdIconPosition}
       loading={isLoading}
       shape={shape === Square ? 'default' : 'circle'}
       size={size}
@@ -106,9 +117,7 @@ export const Button = ({
       onClick={onClick}
       {...href && { href, rel: 'noopener noreferrer', target }}
     >
-      {iconPosition === Left && icon}
       {children && <div className={type !== Link ? buttonText : undefined}>{children}</div>}
-      {iconPosition === Right && icon}
     </AntButton>
   )
 }

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -38,23 +38,27 @@ exports[`Button Component renders button with icon left correctly 1`] = `
     class="mia-platform-btn mia-platform-btn-primary button buttonMd"
     type="button"
   >
-    <svg
-      aria-label="PiCircleHalfTiltLight"
-      color="white"
-      fill="currentColor"
-      height="16"
-      role="img"
-      stroke="currentColor"
-      stroke-width="0"
-      style="color: white;"
-      viewBox="0 0 256 256"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
+    <span
+      class="mia-platform-btn-icon"
     >
-      <path
-        d="M200.12,55.88A102,102,0,1,0,55.88,200.13,102,102,0,1,0,200.12,55.88ZM90,209.62a89.61,89.61,0,0,1-21.23-13.89L90,174.49Zm32,8.16a90,90,0,0,1-20-3.58V162.49l20-20Zm32-3.58a89.8,89.8,0,0,1-20,3.58V130.49l20-20Zm32-17.4a89.45,89.45,0,0,1-20,12.83V98.49l20-20ZM60.27,187.24a90,90,0,0,1,127-127ZM198,184.57V71.43a90,90,0,0,1,0,113.14Z"
-      />
-    </svg>
+      <svg
+        aria-label="PiCircleHalfTiltLight"
+        color="white"
+        fill="currentColor"
+        height="16"
+        role="img"
+        stroke="currentColor"
+        stroke-width="0"
+        style="color: white;"
+        viewBox="0 0 256 256"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M200.12,55.88A102,102,0,1,0,55.88,200.13,102,102,0,1,0,200.12,55.88ZM90,209.62a89.61,89.61,0,0,1-21.23-13.89L90,174.49Zm32,8.16a90,90,0,0,1-20-3.58V162.49l20-20Zm32-3.58a89.8,89.8,0,0,1-20,3.58V130.49l20-20Zm32-17.4a89.45,89.45,0,0,1-20,12.83V98.49l20-20ZM60.27,187.24a90,90,0,0,1,127-127ZM198,184.57V71.43a90,90,0,0,1,0,113.14Z"
+        />
+      </svg>
+    </span>
     <div
       class="buttonText"
     >
@@ -75,23 +79,27 @@ exports[`Button Component renders button with icon right correctly 1`] = `
     >
       Button
     </div>
-    <svg
-      aria-label="PiCircleHalfTiltLight"
-      color="white"
-      fill="currentColor"
-      height="16"
-      role="img"
-      stroke="currentColor"
-      stroke-width="0"
-      style="color: white;"
-      viewBox="0 0 256 256"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
+    <span
+      class="mia-platform-btn-icon mia-platform-btn-icon-end"
     >
-      <path
-        d="M200.12,55.88A102,102,0,1,0,55.88,200.13,102,102,0,1,0,200.12,55.88ZM90,209.62a89.61,89.61,0,0,1-21.23-13.89L90,174.49Zm32,8.16a90,90,0,0,1-20-3.58V162.49l20-20Zm32-3.58a89.8,89.8,0,0,1-20,3.58V130.49l20-20Zm32-17.4a89.45,89.45,0,0,1-20,12.83V98.49l20-20ZM60.27,187.24a90,90,0,0,1,127-127ZM198,184.57V71.43a90,90,0,0,1,0,113.14Z"
-      />
-    </svg>
+      <svg
+        aria-label="PiCircleHalfTiltLight"
+        color="white"
+        fill="currentColor"
+        height="16"
+        role="img"
+        stroke="currentColor"
+        stroke-width="0"
+        style="color: white;"
+        viewBox="0 0 256 256"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M200.12,55.88A102,102,0,1,0,55.88,200.13,102,102,0,1,0,200.12,55.88ZM90,209.62a89.61,89.61,0,0,1-21.23-13.89L90,174.49Zm32,8.16a90,90,0,0,1-20-3.58V162.49l20-20Zm32-3.58a89.8,89.8,0,0,1-20,3.58V130.49l20-20Zm32-17.4a89.45,89.45,0,0,1-20,12.83V98.49l20-20ZM60.27,187.24a90,90,0,0,1,127-127ZM198,184.57V71.43a90,90,0,0,1,0,113.14Z"
+        />
+      </svg>
+    </span>
   </button>
 </DocumentFragment>
 `;
@@ -99,26 +107,30 @@ exports[`Button Component renders button with icon right correctly 1`] = `
 exports[`Button Component renders circle button correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary button buttonMdIconOnly"
+    class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only button buttonMdIconOnly"
     type="button"
   >
-    <svg
-      aria-label="PiCircleHalfTiltLight"
-      color="white"
-      fill="currentColor"
-      height="16"
-      role="img"
-      stroke="currentColor"
-      stroke-width="0"
-      style="color: white;"
-      viewBox="0 0 256 256"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
+    <span
+      class="mia-platform-btn-icon"
     >
-      <path
-        d="M200.12,55.88A102,102,0,1,0,55.88,200.13,102,102,0,1,0,200.12,55.88ZM90,209.62a89.61,89.61,0,0,1-21.23-13.89L90,174.49Zm32,8.16a90,90,0,0,1-20-3.58V162.49l20-20Zm32-3.58a89.8,89.8,0,0,1-20,3.58V130.49l20-20Zm32-17.4a89.45,89.45,0,0,1-20,12.83V98.49l20-20ZM60.27,187.24a90,90,0,0,1,127-127ZM198,184.57V71.43a90,90,0,0,1,0,113.14Z"
-      />
-    </svg>
+      <svg
+        aria-label="PiCircleHalfTiltLight"
+        color="white"
+        fill="currentColor"
+        height="16"
+        role="img"
+        stroke="currentColor"
+        stroke-width="0"
+        style="color: white;"
+        viewBox="0 0 256 256"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M200.12,55.88A102,102,0,1,0,55.88,200.13,102,102,0,1,0,200.12,55.88ZM90,209.62a89.61,89.61,0,0,1-21.23-13.89L90,174.49Zm32,8.16a90,90,0,0,1-20-3.58V162.49l20-20Zm32-3.58a89.8,89.8,0,0,1-20,3.58V130.49l20-20Zm32-17.4a89.45,89.45,0,0,1-20,12.83V98.49l20-20ZM60.27,187.24a90,90,0,0,1,127-127ZM198,184.57V71.43a90,90,0,0,1,0,113.14Z"
+        />
+      </svg>
+    </span>
   </button>
 </DocumentFragment>
 `;
@@ -432,26 +444,30 @@ exports[`Button Component renders small button correctly 1`] = `
 exports[`Button Component renders small button icon only correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-sm button buttonSmIconOnly"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-sm mia-platform-btn-icon-only button buttonSmIconOnly"
     type="button"
   >
-    <svg
-      aria-label="PiCircleHalfTiltLight"
-      color="white"
-      fill="currentColor"
-      height="16"
-      role="img"
-      stroke="currentColor"
-      stroke-width="0"
-      style="color: white;"
-      viewBox="0 0 256 256"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
+    <span
+      class="mia-platform-btn-icon"
     >
-      <path
-        d="M200.12,55.88A102,102,0,1,0,55.88,200.13,102,102,0,1,0,200.12,55.88ZM90,209.62a89.61,89.61,0,0,1-21.23-13.89L90,174.49Zm32,8.16a90,90,0,0,1-20-3.58V162.49l20-20Zm32-3.58a89.8,89.8,0,0,1-20,3.58V130.49l20-20Zm32-17.4a89.45,89.45,0,0,1-20,12.83V98.49l20-20ZM60.27,187.24a90,90,0,0,1,127-127ZM198,184.57V71.43a90,90,0,0,1,0,113.14Z"
-      />
-    </svg>
+      <svg
+        aria-label="PiCircleHalfTiltLight"
+        color="white"
+        fill="currentColor"
+        height="16"
+        role="img"
+        stroke="currentColor"
+        stroke-width="0"
+        style="color: white;"
+        viewBox="0 0 256 256"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M200.12,55.88A102,102,0,1,0,55.88,200.13,102,102,0,1,0,200.12,55.88ZM90,209.62a89.61,89.61,0,0,1-21.23-13.89L90,174.49Zm32,8.16a90,90,0,0,1-20-3.58V162.49l20-20Zm32-3.58a89.8,89.8,0,0,1-20,3.58V130.49l20-20Zm32-17.4a89.45,89.45,0,0,1-20,12.83V98.49l20-20ZM60.27,187.24a90,90,0,0,1,127-127ZM198,184.57V71.43a90,90,0,0,1,0,113.14Z"
+        />
+      </svg>
+    </span>
   </button>
 </DocumentFragment>
 `;
@@ -459,26 +475,30 @@ exports[`Button Component renders small button icon only correctly 1`] = `
 exports[`Button Component renders square button correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary button buttonMdIconOnly"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-icon-only button buttonMdIconOnly"
     type="button"
   >
-    <svg
-      aria-label="PiCircleHalfTiltLight"
-      color="white"
-      fill="currentColor"
-      height="16"
-      role="img"
-      stroke="currentColor"
-      stroke-width="0"
-      style="color: white;"
-      viewBox="0 0 256 256"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
+    <span
+      class="mia-platform-btn-icon"
     >
-      <path
-        d="M200.12,55.88A102,102,0,1,0,55.88,200.13,102,102,0,1,0,200.12,55.88ZM90,209.62a89.61,89.61,0,0,1-21.23-13.89L90,174.49Zm32,8.16a90,90,0,0,1-20-3.58V162.49l20-20Zm32-3.58a89.8,89.8,0,0,1-20,3.58V130.49l20-20Zm32-17.4a89.45,89.45,0,0,1-20,12.83V98.49l20-20ZM60.27,187.24a90,90,0,0,1,127-127ZM198,184.57V71.43a90,90,0,0,1,0,113.14Z"
-      />
-    </svg>
+      <svg
+        aria-label="PiCircleHalfTiltLight"
+        color="white"
+        fill="currentColor"
+        height="16"
+        role="img"
+        stroke="currentColor"
+        stroke-width="0"
+        style="color: white;"
+        viewBox="0 0 256 256"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M200.12,55.88A102,102,0,1,0,55.88,200.13,102,102,0,1,0,200.12,55.88ZM90,209.62a89.61,89.61,0,0,1-21.23-13.89L90,174.49Zm32,8.16a90,90,0,0,1-20-3.58V162.49l20-20Zm32-3.58a89.8,89.8,0,0,1-20,3.58V130.49l20-20Zm32-17.4a89.45,89.45,0,0,1-20,12.83V98.49l20-20ZM60.27,187.24a90,90,0,0,1,127-127ZM198,184.57V71.43a90,90,0,0,1,0,113.14Z"
+        />
+      </svg>
+    </span>
   </button>
 </DocumentFragment>
 `;

--- a/src/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/components/Card/__snapshots__/Card.test.tsx.snap
@@ -25,26 +25,30 @@ exports[`Card Component renders card correctly 1`] = `
             class="docLink"
           >
             <button
-              class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+              class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
               type="button"
             >
-              <svg
-                aria-label="PiBookOpen"
-                color="#004aaa"
-                fill="currentColor"
-                height="16"
-                role="img"
-                stroke="currentColor"
-                stroke-width="0"
-                style="color: rgb(0, 74, 170);"
-                viewBox="0 0 256 256"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                class="mia-platform-btn-icon"
               >
-                <path
-                  d="M224,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H32A16,16,0,0,0,16,64V192a16,16,0,0,0,16,16H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h64a16,16,0,0,0,16-16V64A16,16,0,0,0,224,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
-                />
-              </svg>
+                <svg
+                  aria-label="PiBookOpen"
+                  color="#004aaa"
+                  fill="currentColor"
+                  height="16"
+                  role="img"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  style="color: rgb(0, 74, 170);"
+                  viewBox="0 0 256 256"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M224,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H32A16,16,0,0,0,16,64V192a16,16,0,0,0,16,16H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h64a16,16,0,0,0,16-16V64A16,16,0,0,0,224,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
+                  />
+                </svg>
+              </span>
             </button>
           </div>
         </div>
@@ -114,26 +118,30 @@ exports[`Card Component renders header only 1`] = `
             class="docLink"
           >
             <button
-              class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+              class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
               type="button"
             >
-              <svg
-                aria-label="PiBookOpen"
-                color="#004aaa"
-                fill="currentColor"
-                height="16"
-                role="img"
-                stroke="currentColor"
-                stroke-width="0"
-                style="color: rgb(0, 74, 170);"
-                viewBox="0 0 256 256"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                class="mia-platform-btn-icon"
               >
-                <path
-                  d="M224,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H32A16,16,0,0,0,16,64V192a16,16,0,0,0,16,16H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h64a16,16,0,0,0,16-16V64A16,16,0,0,0,224,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
-                />
-              </svg>
+                <svg
+                  aria-label="PiBookOpen"
+                  color="#004aaa"
+                  fill="currentColor"
+                  height="16"
+                  role="img"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  style="color: rgb(0, 74, 170);"
+                  viewBox="0 0 256 256"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M224,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H32A16,16,0,0,0,16,64V192a16,16,0,0,0,16,16H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h64a16,16,0,0,0,16-16V64A16,16,0,0,0,224,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
+                  />
+                </svg>
+              </span>
             </button>
           </div>
         </div>

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -316,7 +316,7 @@ describe('Dropdown Component', () => {
         const secondUpdatedStillSelected = await screen.findByRole('menuitem', { name: /Label 2/ })
         expect(firstUpdatedDeSelected).toMatchSnapshot('after second click render Label 1 is deselected')
         expect(secondUpdatedStillSelected).toMatchSnapshot('after second click render Label 2 is selected')
-      })
+      }, 10000)
     })
   })
 })

--- a/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -33,92 +33,97 @@ exports[`Modal Component renders fullscreen modal correctly (with empty header) 
             tabindex="0"
           />
           <div
-            class="mia-platform-modal-content"
+            style="outline: none;"
+            tabindex="-1"
           >
-            <button
-              aria-label="Close"
-              class="mia-platform-modal-close"
-              type="button"
+            <div
+              class="mia-platform-modal-content"
             >
-              <span
-                class="mia-platform-modal-close-x"
+              <button
+                aria-label="Close"
+                class="mia-platform-modal-close"
+                type="button"
               >
                 <span
-                  aria-label="close"
-                  class="anticon anticon-close mia-platform-modal-close-icon"
-                  role="img"
+                  class="mia-platform-modal-close-x"
                 >
-                  <svg
-                    aria-hidden="true"
-                    data-icon="close"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
+                  <span
+                    aria-label="close"
+                    class="anticon anticon-close mia-platform-modal-close-icon"
+                    role="img"
                   >
-                    <path
-                      d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      data-icon="close"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                      />
+                    </svg>
+                  </span>
                 </span>
-              </span>
-            </button>
-            <div
-              class="mia-platform-modal-header"
-            >
+              </button>
               <div
-                class="mia-platform-modal-title"
-                id="test-id"
+                class="mia-platform-modal-header"
               >
                 <div
-                  class="title"
-                />
-              </div>
-            </div>
-            <div
-              class="mia-platform-modal-body"
-            >
-              <div
-                class="body"
-              >
-                <div
-                  class="content"
+                  class="mia-platform-modal-title"
+                  id="test-id"
                 >
-                  Modal Content
+                  <div
+                    class="title"
+                  />
                 </div>
               </div>
-            </div>
-            <div
-              class="mia-platform-modal-footer"
-            >
               <div
-                class="footer"
+                class="mia-platform-modal-body"
               >
                 <div
-                  class="footerButtons"
+                  class="body"
                 >
-                  <button
-                    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
-                    type="button"
+                  <div
+                    class="content"
                   >
-                    <div
-                      class="buttonText"
-                    >
-                      OK
-                    </div>
-                  </button>
-                  <button
-                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
-                    type="button"
+                    Modal Content
+                  </div>
+                </div>
+              </div>
+              <div
+                class="mia-platform-modal-footer"
+              >
+                <div
+                  class="footer"
+                >
+                  <div
+                    class="footerButtons"
                   >
-                    <div
-                      class="buttonText"
+                    <button
+                      class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+                      type="button"
                     >
-                      Cancel
-                    </div>
-                  </button>
+                      <div
+                        class="buttonText"
+                      >
+                        OK
+                      </div>
+                    </button>
+                    <button
+                      class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                      type="button"
+                    >
+                      <div
+                        class="buttonText"
+                      >
+                        Cancel
+                      </div>
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
@@ -162,103 +167,112 @@ exports[`Modal Component renders large modal correctly (with empty footer) 1`] =
             tabindex="0"
           />
           <div
-            class="mia-platform-modal-content"
+            style="outline: none;"
+            tabindex="-1"
           >
-            <button
-              aria-label="Close"
-              class="mia-platform-modal-close"
-              type="button"
+            <div
+              class="mia-platform-modal-content"
             >
-              <span
-                class="mia-platform-modal-close-x"
+              <button
+                aria-label="Close"
+                class="mia-platform-modal-close"
+                type="button"
               >
                 <span
-                  aria-label="close"
-                  class="anticon anticon-close mia-platform-modal-close-icon"
-                  role="img"
+                  class="mia-platform-modal-close-x"
                 >
-                  <svg
-                    aria-hidden="true"
-                    data-icon="close"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
+                  <span
+                    aria-label="close"
+                    class="anticon anticon-close mia-platform-modal-close-icon"
+                    role="img"
                   >
-                    <path
-                      d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      data-icon="close"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                      />
+                    </svg>
+                  </span>
                 </span>
-              </span>
-            </button>
-            <div
-              class="mia-platform-modal-header"
-            >
+              </button>
               <div
-                class="mia-platform-modal-title"
-                id="test-id"
+                class="mia-platform-modal-header"
               >
                 <div
-                  class="title"
+                  class="mia-platform-modal-title"
+                  id="test-id"
                 >
-                  <h4
-                    aria-label="Modal Title"
-                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
-                    role="h4"
-                  >
-                    Modal Title
-                  </h4>
                   <div
-                    class="docLink"
+                    class="title"
                   >
-                    <button
-                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
-                      type="button"
+                    <h4
+                      aria-label="Modal Title"
+                      class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
+                      role="h4"
                     >
-                      <svg
-                        aria-label="PiBookOpen"
-                        color="#004aaa"
-                        fill="currentColor"
-                        height="16"
-                        role="img"
-                        stroke="currentColor"
-                        stroke-width="0"
-                        style="color: rgb(0, 74, 170);"
-                        viewBox="0 0 256 256"
-                        width="16"
-                        xmlns="http://www.w3.org/2000/svg"
+                      Modal Title
+                    </h4>
+                    <div
+                      class="docLink"
+                    >
+                      <button
+                        class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+                        type="button"
                       >
-                        <path
-                          d="M224,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H32A16,16,0,0,0,16,64V192a16,16,0,0,0,16,16H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h64a16,16,0,0,0,16-16V64A16,16,0,0,0,224,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
-                        />
-                      </svg>
-                    </button>
+                        <span
+                          class="mia-platform-btn-icon"
+                        >
+                          <svg
+                            aria-label="PiBookOpen"
+                            color="#004aaa"
+                            fill="currentColor"
+                            height="16"
+                            role="img"
+                            stroke="currentColor"
+                            stroke-width="0"
+                            style="color: rgb(0, 74, 170);"
+                            viewBox="0 0 256 256"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M224,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H32A16,16,0,0,0,16,64V192a16,16,0,0,0,16,16H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h64a16,16,0,0,0,16-16V64A16,16,0,0,0,224,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="mia-platform-modal-body"
-            >
               <div
-                class="body"
+                class="mia-platform-modal-body"
               >
                 <div
-                  class="content"
+                  class="body"
                 >
-                  Modal Content
+                  <div
+                    class="content"
+                  >
+                    Modal Content
+                  </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="mia-platform-modal-footer"
-            >
               <div
-                class="footer"
-              />
+                class="mia-platform-modal-footer"
+              >
+                <div
+                  class="footer"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -300,139 +314,148 @@ exports[`Modal Component renders modal with aside fixed 1`] = `
             tabindex="0"
           />
           <div
-            class="mia-platform-modal-content"
+            style="outline: none;"
+            tabindex="-1"
           >
-            <button
-              aria-label="Close"
-              class="mia-platform-modal-close"
-              type="button"
+            <div
+              class="mia-platform-modal-content"
             >
-              <span
-                class="mia-platform-modal-close-x"
+              <button
+                aria-label="Close"
+                class="mia-platform-modal-close"
+                type="button"
               >
                 <span
-                  aria-label="close"
-                  class="anticon anticon-close mia-platform-modal-close-icon"
-                  role="img"
+                  class="mia-platform-modal-close-x"
                 >
-                  <svg
-                    aria-hidden="true"
-                    data-icon="close"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
+                  <span
+                    aria-label="close"
+                    class="anticon anticon-close mia-platform-modal-close-icon"
+                    role="img"
                   >
-                    <path
-                      d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      data-icon="close"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                      />
+                    </svg>
+                  </span>
                 </span>
-              </span>
-            </button>
-            <div
-              class="mia-platform-modal-header"
-            >
+              </button>
               <div
-                class="mia-platform-modal-title"
-                id="test-id"
+                class="mia-platform-modal-header"
               >
                 <div
-                  class="title"
+                  class="mia-platform-modal-title"
+                  id="test-id"
                 >
-                  <h4
-                    aria-label="Modal Title"
-                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
-                    role="h4"
-                  >
-                    Modal Title
-                  </h4>
                   <div
-                    class="docLink"
+                    class="title"
+                  >
+                    <h4
+                      aria-label="Modal Title"
+                      class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
+                      role="h4"
+                    >
+                      Modal Title
+                    </h4>
+                    <div
+                      class="docLink"
+                    >
+                      <button
+                        class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+                        type="button"
+                      >
+                        <span
+                          class="mia-platform-btn-icon"
+                        >
+                          <svg
+                            aria-label="PiBookOpen"
+                            color="#004aaa"
+                            fill="currentColor"
+                            height="16"
+                            role="img"
+                            stroke="currentColor"
+                            stroke-width="0"
+                            style="color: rgb(0, 74, 170);"
+                            viewBox="0 0 256 256"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M224,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H32A16,16,0,0,0,16,64V192a16,16,0,0,0,16,16H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h64a16,16,0,0,0,16-16V64A16,16,0,0,0,224,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="mia-platform-modal-body"
+              >
+                <div
+                  class="body bodyWithAsideOpened"
+                >
+                  <div
+                    class="content"
+                  >
+                    Modal Content
+                  </div>
+                  <aside
+                    class="aside"
+                  >
+                    <div
+                      class="mia-platform-typography bodyM"
+                      role="paragraph"
+                    >
+                      Modal Aside Title
+                    </div>
+                    <div>
+                      Modal Aside Content
+                    </div>
+                  </aside>
+                </div>
+              </div>
+              <div
+                class="mia-platform-modal-footer"
+              >
+                <div
+                  class="footer"
+                >
+                  <div
+                    class="footerButtons"
                   >
                     <button
-                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+                      class="mia-platform-btn mia-platform-btn-primary button buttonMd"
                       type="button"
                     >
-                      <svg
-                        aria-label="PiBookOpen"
-                        color="#004aaa"
-                        fill="currentColor"
-                        height="16"
-                        role="img"
-                        stroke="currentColor"
-                        stroke-width="0"
-                        style="color: rgb(0, 74, 170);"
-                        viewBox="0 0 256 256"
-                        width="16"
-                        xmlns="http://www.w3.org/2000/svg"
+                      <div
+                        class="buttonText"
                       >
-                        <path
-                          d="M224,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H32A16,16,0,0,0,16,64V192a16,16,0,0,0,16,16H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h64a16,16,0,0,0,16-16V64A16,16,0,0,0,224,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
-                        />
-                      </svg>
+                        OK
+                      </div>
+                    </button>
+                    <button
+                      class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                      type="button"
+                    >
+                      <div
+                        class="buttonText"
+                      >
+                        Cancel
+                      </div>
                     </button>
                   </div>
-                </div>
-              </div>
-            </div>
-            <div
-              class="mia-platform-modal-body"
-            >
-              <div
-                class="body bodyWithAsideOpened"
-              >
-                <div
-                  class="content"
-                >
-                  Modal Content
-                </div>
-                <aside
-                  class="aside"
-                >
-                  <div
-                    class="mia-platform-typography bodyM"
-                    role="paragraph"
-                  >
-                    Modal Aside Title
-                  </div>
-                  <div>
-                    Modal Aside Content
-                  </div>
-                </aside>
-              </div>
-            </div>
-            <div
-              class="mia-platform-modal-footer"
-            >
-              <div
-                class="footer"
-              >
-                <div
-                  class="footerButtons"
-                >
-                  <button
-                    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
-                    type="button"
-                  >
-                    <div
-                      class="buttonText"
-                    >
-                      OK
-                    </div>
-                  </button>
-                  <button
-                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
-                    type="button"
-                  >
-                    <div
-                      class="buttonText"
-                    >
-                      Cancel
-                    </div>
-                  </button>
                 </div>
               </div>
             </div>
@@ -476,169 +499,178 @@ exports[`Modal Component renders modal with aside openable 1`] = `
             tabindex="0"
           />
           <div
-            class="mia-platform-modal-content"
+            style="outline: none;"
+            tabindex="-1"
           >
-            <button
-              aria-label="Close"
-              class="mia-platform-modal-close"
-              type="button"
+            <div
+              class="mia-platform-modal-content"
             >
-              <span
-                class="mia-platform-modal-close-x"
+              <button
+                aria-label="Close"
+                class="mia-platform-modal-close"
+                type="button"
               >
                 <span
-                  aria-label="close"
-                  class="anticon anticon-close mia-platform-modal-close-icon"
-                  role="img"
+                  class="mia-platform-modal-close-x"
                 >
-                  <svg
-                    aria-hidden="true"
-                    data-icon="close"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
+                  <span
+                    aria-label="close"
+                    class="anticon anticon-close mia-platform-modal-close-icon"
+                    role="img"
                   >
-                    <path
-                      d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      data-icon="close"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                      />
+                    </svg>
+                  </span>
                 </span>
-              </span>
-            </button>
-            <div
-              class="mia-platform-modal-header"
-            >
+              </button>
               <div
-                class="mia-platform-modal-title"
-                id="test-id"
+                class="mia-platform-modal-header"
               >
                 <div
-                  class="title"
+                  class="mia-platform-modal-title"
+                  id="test-id"
                 >
-                  <h4
-                    aria-label="Modal Title"
-                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
-                    role="h4"
-                  >
-                    Modal Title
-                  </h4>
                   <div
-                    class="docLink"
+                    class="title"
+                  >
+                    <h4
+                      aria-label="Modal Title"
+                      class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
+                      role="h4"
+                    >
+                      Modal Title
+                    </h4>
+                    <div
+                      class="docLink"
+                    >
+                      <button
+                        class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+                        type="button"
+                      >
+                        <span
+                          class="mia-platform-btn-icon"
+                        >
+                          <svg
+                            aria-label="PiBookOpen"
+                            color="#004aaa"
+                            fill="currentColor"
+                            height="16"
+                            role="img"
+                            stroke="currentColor"
+                            stroke-width="0"
+                            style="color: rgb(0, 74, 170);"
+                            viewBox="0 0 256 256"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M224,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H32A16,16,0,0,0,16,64V192a16,16,0,0,0,16,16H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h64a16,16,0,0,0,16-16V64A16,16,0,0,0,224,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="mia-platform-modal-body"
+              >
+                <div
+                  class="body bodyWithAsideClosed"
+                >
+                  <div
+                    class="content contentWrapper"
+                  >
+                    <div
+                      class="content"
+                    >
+                      Modal Content
+                    </div>
+                    <div
+                      class="asideLabelWrapper"
+                    >
+                      <div
+                        class="asideLabel"
+                      >
+                        <svg
+                          aria-label="PiCaretLeft"
+                          color="currentColor"
+                          fill="currentColor"
+                          height="16"
+                          role="img"
+                          stroke="currentColor"
+                          stroke-width="0"
+                          style="color: currentColor;"
+                          viewBox="0 0 256 256"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M165.66,202.34a8,8,0,0,1-11.32,11.32l-80-80a8,8,0,0,1,0-11.32l80-80a8,8,0,0,1,11.32,11.32L91.31,128Z"
+                          />
+                        </svg>
+                        Open
+                      </div>
+                    </div>
+                  </div>
+                  <aside
+                    class="aside"
+                  >
+                    <div
+                      class="mia-platform-typography bodyM"
+                      role="paragraph"
+                    >
+                      Modal Aside Title
+                    </div>
+                    <div>
+                      Modal Aside Content
+                    </div>
+                  </aside>
+                </div>
+              </div>
+              <div
+                class="mia-platform-modal-footer"
+              >
+                <div
+                  class="footer"
+                >
+                  <div
+                    class="footerButtons"
                   >
                     <button
-                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+                      class="mia-platform-btn mia-platform-btn-primary button buttonMd"
                       type="button"
                     >
-                      <svg
-                        aria-label="PiBookOpen"
-                        color="#004aaa"
-                        fill="currentColor"
-                        height="16"
-                        role="img"
-                        stroke="currentColor"
-                        stroke-width="0"
-                        style="color: rgb(0, 74, 170);"
-                        viewBox="0 0 256 256"
-                        width="16"
-                        xmlns="http://www.w3.org/2000/svg"
+                      <div
+                        class="buttonText"
                       >
-                        <path
-                          d="M224,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H32A16,16,0,0,0,16,64V192a16,16,0,0,0,16,16H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h64a16,16,0,0,0,16-16V64A16,16,0,0,0,224,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
-                        />
-                      </svg>
+                        OK
+                      </div>
+                    </button>
+                    <button
+                      class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                      type="button"
+                    >
+                      <div
+                        class="buttonText"
+                      >
+                        Cancel
+                      </div>
                     </button>
                   </div>
-                </div>
-              </div>
-            </div>
-            <div
-              class="mia-platform-modal-body"
-            >
-              <div
-                class="body bodyWithAsideClosed"
-              >
-                <div
-                  class="content contentWrapper"
-                >
-                  <div
-                    class="content"
-                  >
-                    Modal Content
-                  </div>
-                  <div
-                    class="asideLabelWrapper"
-                  >
-                    <div
-                      class="asideLabel"
-                    >
-                      <svg
-                        aria-label="PiCaretLeft"
-                        color="currentColor"
-                        fill="currentColor"
-                        height="16"
-                        role="img"
-                        stroke="currentColor"
-                        stroke-width="0"
-                        style="color: currentColor;"
-                        viewBox="0 0 256 256"
-                        width="16"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M165.66,202.34a8,8,0,0,1-11.32,11.32l-80-80a8,8,0,0,1,0-11.32l80-80a8,8,0,0,1,11.32,11.32L91.31,128Z"
-                        />
-                      </svg>
-                      Open
-                    </div>
-                  </div>
-                </div>
-                <aside
-                  class="aside"
-                >
-                  <div
-                    class="mia-platform-typography bodyM"
-                    role="paragraph"
-                  >
-                    Modal Aside Title
-                  </div>
-                  <div>
-                    Modal Aside Content
-                  </div>
-                </aside>
-              </div>
-            </div>
-            <div
-              class="mia-platform-modal-footer"
-            >
-              <div
-                class="footer"
-              >
-                <div
-                  class="footerButtons"
-                >
-                  <button
-                    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
-                    type="button"
-                  >
-                    <div
-                      class="buttonText"
-                    >
-                      OK
-                    </div>
-                  </button>
-                  <button
-                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
-                    type="button"
-                  >
-                    <div
-                      class="buttonText"
-                    >
-                      Cancel
-                    </div>
-                  </button>
                 </div>
               </div>
             </div>
@@ -682,169 +714,178 @@ exports[`Modal Component renders modal with aside openable 2`] = `
             tabindex="0"
           />
           <div
-            class="mia-platform-modal-content"
+            style="outline: none;"
+            tabindex="-1"
           >
-            <button
-              aria-label="Close"
-              class="mia-platform-modal-close"
-              type="button"
+            <div
+              class="mia-platform-modal-content"
             >
-              <span
-                class="mia-platform-modal-close-x"
+              <button
+                aria-label="Close"
+                class="mia-platform-modal-close"
+                type="button"
               >
                 <span
-                  aria-label="close"
-                  class="anticon anticon-close mia-platform-modal-close-icon"
-                  role="img"
+                  class="mia-platform-modal-close-x"
                 >
-                  <svg
-                    aria-hidden="true"
-                    data-icon="close"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
+                  <span
+                    aria-label="close"
+                    class="anticon anticon-close mia-platform-modal-close-icon"
+                    role="img"
                   >
-                    <path
-                      d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      data-icon="close"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                      />
+                    </svg>
+                  </span>
                 </span>
-              </span>
-            </button>
-            <div
-              class="mia-platform-modal-header"
-            >
+              </button>
               <div
-                class="mia-platform-modal-title"
-                id="test-id"
+                class="mia-platform-modal-header"
               >
                 <div
-                  class="title"
+                  class="mia-platform-modal-title"
+                  id="test-id"
                 >
-                  <h4
-                    aria-label="Modal Title"
-                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
-                    role="h4"
-                  >
-                    Modal Title
-                  </h4>
                   <div
-                    class="docLink"
+                    class="title"
+                  >
+                    <h4
+                      aria-label="Modal Title"
+                      class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
+                      role="h4"
+                    >
+                      Modal Title
+                    </h4>
+                    <div
+                      class="docLink"
+                    >
+                      <button
+                        class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+                        type="button"
+                      >
+                        <span
+                          class="mia-platform-btn-icon"
+                        >
+                          <svg
+                            aria-label="PiBookOpen"
+                            color="#004aaa"
+                            fill="currentColor"
+                            height="16"
+                            role="img"
+                            stroke="currentColor"
+                            stroke-width="0"
+                            style="color: rgb(0, 74, 170);"
+                            viewBox="0 0 256 256"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M224,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H32A16,16,0,0,0,16,64V192a16,16,0,0,0,16,16H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h64a16,16,0,0,0,16-16V64A16,16,0,0,0,224,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="mia-platform-modal-body"
+              >
+                <div
+                  class="body bodyWithAsideOpened"
+                >
+                  <div
+                    class="content contentWrapper"
+                  >
+                    <div
+                      class="content"
+                    >
+                      Modal Content
+                    </div>
+                    <div
+                      class="asideLabelWrapper"
+                    >
+                      <div
+                        class="asideLabel"
+                      >
+                        Close
+                        <svg
+                          aria-label="PiCaretRight"
+                          color="currentColor"
+                          fill="currentColor"
+                          height="16"
+                          role="img"
+                          stroke="currentColor"
+                          stroke-width="0"
+                          style="color: currentColor;"
+                          viewBox="0 0 256 256"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M181.66,133.66l-80,80a8,8,0,0,1-11.32-11.32L164.69,128,90.34,53.66a8,8,0,0,1,11.32-11.32l80,80A8,8,0,0,1,181.66,133.66Z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <aside
+                    class="aside"
+                  >
+                    <div
+                      class="mia-platform-typography bodyM"
+                      role="paragraph"
+                    >
+                      Modal Aside Title
+                    </div>
+                    <div>
+                      Modal Aside Content
+                    </div>
+                  </aside>
+                </div>
+              </div>
+              <div
+                class="mia-platform-modal-footer"
+              >
+                <div
+                  class="footer"
+                >
+                  <div
+                    class="footerButtons"
                   >
                     <button
-                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+                      class="mia-platform-btn mia-platform-btn-primary button buttonMd"
                       type="button"
                     >
-                      <svg
-                        aria-label="PiBookOpen"
-                        color="#004aaa"
-                        fill="currentColor"
-                        height="16"
-                        role="img"
-                        stroke="currentColor"
-                        stroke-width="0"
-                        style="color: rgb(0, 74, 170);"
-                        viewBox="0 0 256 256"
-                        width="16"
-                        xmlns="http://www.w3.org/2000/svg"
+                      <div
+                        class="buttonText"
                       >
-                        <path
-                          d="M224,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H32A16,16,0,0,0,16,64V192a16,16,0,0,0,16,16H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h64a16,16,0,0,0,16-16V64A16,16,0,0,0,224,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
-                        />
-                      </svg>
+                        OK
+                      </div>
+                    </button>
+                    <button
+                      class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                      type="button"
+                    >
+                      <div
+                        class="buttonText"
+                      >
+                        Cancel
+                      </div>
                     </button>
                   </div>
-                </div>
-              </div>
-            </div>
-            <div
-              class="mia-platform-modal-body"
-            >
-              <div
-                class="body bodyWithAsideOpened"
-              >
-                <div
-                  class="content contentWrapper"
-                >
-                  <div
-                    class="content"
-                  >
-                    Modal Content
-                  </div>
-                  <div
-                    class="asideLabelWrapper"
-                  >
-                    <div
-                      class="asideLabel"
-                    >
-                      Close
-                      <svg
-                        aria-label="PiCaretRight"
-                        color="currentColor"
-                        fill="currentColor"
-                        height="16"
-                        role="img"
-                        stroke="currentColor"
-                        stroke-width="0"
-                        style="color: currentColor;"
-                        viewBox="0 0 256 256"
-                        width="16"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M181.66,133.66l-80,80a8,8,0,0,1-11.32-11.32L164.69,128,90.34,53.66a8,8,0,0,1,11.32-11.32l80,80A8,8,0,0,1,181.66,133.66Z"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                </div>
-                <aside
-                  class="aside"
-                >
-                  <div
-                    class="mia-platform-typography bodyM"
-                    role="paragraph"
-                  >
-                    Modal Aside Title
-                  </div>
-                  <div>
-                    Modal Aside Content
-                  </div>
-                </aside>
-              </div>
-            </div>
-            <div
-              class="mia-platform-modal-footer"
-            >
-              <div
-                class="footer"
-              >
-                <div
-                  class="footerButtons"
-                >
-                  <button
-                    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
-                    type="button"
-                  >
-                    <div
-                      class="buttonText"
-                    >
-                      OK
-                    </div>
-                  </button>
-                  <button
-                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
-                    type="button"
-                  >
-                    <div
-                      class="buttonText"
-                    >
-                      Cancel
-                    </div>
-                  </button>
                 </div>
               </div>
             </div>
@@ -888,67 +929,72 @@ exports[`Modal Component renders modal with body full width 1`] = `
             tabindex="0"
           />
           <div
-            class="mia-platform-modal-content"
+            style="outline: none;"
+            tabindex="-1"
           >
-            <button
-              aria-label="Close"
-              class="mia-platform-modal-close"
-              type="button"
+            <div
+              class="mia-platform-modal-content"
             >
-              <span
-                class="mia-platform-modal-close-x"
+              <button
+                aria-label="Close"
+                class="mia-platform-modal-close"
+                type="button"
               >
                 <span
-                  aria-label="close"
-                  class="anticon anticon-close mia-platform-modal-close-icon"
-                  role="img"
+                  class="mia-platform-modal-close-x"
                 >
-                  <svg
-                    aria-hidden="true"
-                    data-icon="close"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
+                  <span
+                    aria-label="close"
+                    class="anticon anticon-close mia-platform-modal-close-icon"
+                    role="img"
                   >
-                    <path
-                      d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      data-icon="close"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                      />
+                    </svg>
+                  </span>
                 </span>
-              </span>
-            </button>
-            <div
-              class="mia-platform-modal-header"
-            >
+              </button>
               <div
-                class="mia-platform-modal-title"
-                id="test-id"
+                class="mia-platform-modal-header"
               >
                 <div
-                  class="title"
-                />
+                  class="mia-platform-modal-title"
+                  id="test-id"
+                >
+                  <div
+                    class="title"
+                  />
+                </div>
               </div>
-            </div>
-            <div
-              class="mia-platform-modal-body"
-            >
               <div
-                class="body bodyFullWidth"
+                class="mia-platform-modal-body"
               >
                 <div
-                  class="content"
+                  class="body bodyFullWidth"
+                >
+                  <div
+                    class="content"
+                  />
+                </div>
+              </div>
+              <div
+                class="mia-platform-modal-footer"
+              >
+                <div
+                  class="footer"
                 />
               </div>
-            </div>
-            <div
-              class="mia-platform-modal-footer"
-            >
-              <div
-                class="footer"
-              />
             </div>
           </div>
           <div
@@ -990,148 +1036,157 @@ exports[`Modal Component renders modal with custom footer 1`] = `
             tabindex="0"
           />
           <div
-            class="mia-platform-modal-content"
+            style="outline: none;"
+            tabindex="-1"
           >
-            <button
-              aria-label="Close"
-              class="mia-platform-modal-close"
-              type="button"
+            <div
+              class="mia-platform-modal-content"
             >
-              <span
-                class="mia-platform-modal-close-x"
+              <button
+                aria-label="Close"
+                class="mia-platform-modal-close"
+                type="button"
               >
                 <span
-                  aria-label="close"
-                  class="anticon anticon-close mia-platform-modal-close-icon"
-                  role="img"
+                  class="mia-platform-modal-close-x"
                 >
-                  <svg
-                    aria-hidden="true"
-                    data-icon="close"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
+                  <span
+                    aria-label="close"
+                    class="anticon anticon-close mia-platform-modal-close-icon"
+                    role="img"
                   >
-                    <path
-                      d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      data-icon="close"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                      />
+                    </svg>
+                  </span>
                 </span>
-              </span>
-            </button>
-            <div
-              class="mia-platform-modal-header"
-            >
+              </button>
               <div
-                class="mia-platform-modal-title"
-                id="test-id"
+                class="mia-platform-modal-header"
               >
                 <div
-                  class="title"
+                  class="mia-platform-modal-title"
+                  id="test-id"
                 >
-                  <h4
-                    aria-label="Modal Title"
-                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
-                    role="h4"
-                  >
-                    Modal Title
-                  </h4>
                   <div
-                    class="docLink"
+                    class="title"
                   >
-                    <button
-                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
-                      type="button"
+                    <h4
+                      aria-label="Modal Title"
+                      class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
+                      role="h4"
                     >
-                      <svg
-                        aria-label="PiBookOpen"
-                        color="#004aaa"
-                        fill="currentColor"
-                        height="16"
-                        role="img"
-                        stroke="currentColor"
-                        stroke-width="0"
-                        style="color: rgb(0, 74, 170);"
-                        viewBox="0 0 256 256"
-                        width="16"
-                        xmlns="http://www.w3.org/2000/svg"
+                      Modal Title
+                    </h4>
+                    <div
+                      class="docLink"
+                    >
+                      <button
+                        class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+                        type="button"
                       >
-                        <path
-                          d="M224,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H32A16,16,0,0,0,16,64V192a16,16,0,0,0,16,16H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h64a16,16,0,0,0,16-16V64A16,16,0,0,0,224,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
-                        />
-                      </svg>
-                    </button>
+                        <span
+                          class="mia-platform-btn-icon"
+                        >
+                          <svg
+                            aria-label="PiBookOpen"
+                            color="#004aaa"
+                            fill="currentColor"
+                            height="16"
+                            role="img"
+                            stroke="currentColor"
+                            stroke-width="0"
+                            style="color: rgb(0, 74, 170);"
+                            viewBox="0 0 256 256"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M224,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H32A16,16,0,0,0,16,64V192a16,16,0,0,0,16,16H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h64a16,16,0,0,0,16-16V64A16,16,0,0,0,224,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="mia-platform-modal-body"
-            >
               <div
-                class="body"
+                class="mia-platform-modal-body"
               >
                 <div
-                  class="content"
+                  class="body"
                 >
-                  Modal Content
+                  <div
+                    class="content"
+                  >
+                    Modal Content
+                  </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="mia-platform-modal-footer"
-            >
               <div
-                class="footer"
+                class="mia-platform-modal-footer"
               >
                 <div
-                  class="footerButtons"
+                  class="footer"
                 >
-                  <button
-                    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
-                    type="button"
+                  <div
+                    class="footerButtons"
                   >
-                    <div
-                      class="buttonText"
+                    <button
+                      class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+                      type="button"
                     >
-                      Button 1
-                    </div>
-                  </button>
-                  <button
-                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
-                    type="button"
-                  >
-                    <div
-                      class="buttonText"
+                      <div
+                        class="buttonText"
+                      >
+                        Button 1
+                      </div>
+                    </button>
+                    <button
+                      class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                      type="button"
                     >
-                      Button 2
-                    </div>
-                  </button>
-                  <button
-                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
-                    type="button"
-                  >
-                    <div
-                      class="buttonText"
+                      <div
+                        class="buttonText"
+                      >
+                        Button 2
+                      </div>
+                    </button>
+                    <button
+                      class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                      type="button"
                     >
-                      Button 3
-                    </div>
-                  </button>
-                  <button
-                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
-                    type="button"
-                  >
-                    <div
-                      class="buttonText"
+                      <div
+                        class="buttonText"
+                      >
+                        Button 3
+                      </div>
+                    </button>
+                    <button
+                      class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                      type="button"
                     >
-                      Button 4
-                    </div>
-                  </button>
+                      <div
+                        class="buttonText"
+                      >
+                        Button 4
+                      </div>
+                    </button>
+                  </div>
+                  Footer Extra
                 </div>
-                Footer Extra
               </div>
             </div>
           </div>
@@ -1174,37 +1229,42 @@ exports[`Modal Component renders not closable modal 1`] = `
             tabindex="0"
           />
           <div
-            class="mia-platform-modal-content"
+            style="outline: none;"
+            tabindex="-1"
           >
             <div
-              class="mia-platform-modal-header"
+              class="mia-platform-modal-content"
             >
               <div
-                class="mia-platform-modal-title"
-                id="test-id"
+                class="mia-platform-modal-header"
               >
                 <div
-                  class="title"
-                />
+                  class="mia-platform-modal-title"
+                  id="test-id"
+                >
+                  <div
+                    class="title"
+                  />
+                </div>
               </div>
-            </div>
-            <div
-              class="mia-platform-modal-body"
-            >
               <div
-                class="body"
+                class="mia-platform-modal-body"
               >
                 <div
-                  class="content"
+                  class="body"
+                >
+                  <div
+                    class="content"
+                  />
+                </div>
+              </div>
+              <div
+                class="mia-platform-modal-footer"
+              >
+                <div
+                  class="footer"
                 />
               </div>
-            </div>
-            <div
-              class="mia-platform-modal-footer"
-            >
-              <div
-                class="footer"
-              />
             </div>
           </div>
           <div
@@ -1246,126 +1306,135 @@ exports[`Modal Component renders small modal correctly (with children, docLink, 
             tabindex="0"
           />
           <div
-            class="mia-platform-modal-content"
+            style="outline: none;"
+            tabindex="-1"
           >
-            <button
-              aria-label="Close"
-              class="mia-platform-modal-close"
-              type="button"
+            <div
+              class="mia-platform-modal-content"
             >
-              <span
-                class="mia-platform-modal-close-x"
+              <button
+                aria-label="Close"
+                class="mia-platform-modal-close"
+                type="button"
               >
                 <span
-                  aria-label="close"
-                  class="anticon anticon-close mia-platform-modal-close-icon"
-                  role="img"
+                  class="mia-platform-modal-close-x"
                 >
-                  <svg
-                    aria-hidden="true"
-                    data-icon="close"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
+                  <span
+                    aria-label="close"
+                    class="anticon anticon-close mia-platform-modal-close-icon"
+                    role="img"
                   >
-                    <path
-                      d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      data-icon="close"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                      />
+                    </svg>
+                  </span>
                 </span>
-              </span>
-            </button>
-            <div
-              class="mia-platform-modal-header"
-            >
+              </button>
               <div
-                class="mia-platform-modal-title"
-                id="test-id"
+                class="mia-platform-modal-header"
               >
                 <div
-                  class="title"
+                  class="mia-platform-modal-title"
+                  id="test-id"
                 >
-                  <h4
-                    aria-label="Modal Title"
-                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
-                    role="h4"
-                  >
-                    Modal Title
-                  </h4>
                   <div
-                    class="docLink"
+                    class="title"
                   >
-                    <button
-                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
-                      type="button"
+                    <h4
+                      aria-label="Modal Title"
+                      class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
+                      role="h4"
                     >
-                      <svg
-                        aria-label="PiBookOpen"
-                        color="#004aaa"
-                        fill="currentColor"
-                        height="16"
-                        role="img"
-                        stroke="currentColor"
-                        stroke-width="0"
-                        style="color: rgb(0, 74, 170);"
-                        viewBox="0 0 256 256"
-                        width="16"
-                        xmlns="http://www.w3.org/2000/svg"
+                      Modal Title
+                    </h4>
+                    <div
+                      class="docLink"
+                    >
+                      <button
+                        class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+                        type="button"
                       >
-                        <path
-                          d="M224,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H32A16,16,0,0,0,16,64V192a16,16,0,0,0,16,16H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h64a16,16,0,0,0,16-16V64A16,16,0,0,0,224,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
-                        />
-                      </svg>
-                    </button>
+                        <span
+                          class="mia-platform-btn-icon"
+                        >
+                          <svg
+                            aria-label="PiBookOpen"
+                            color="#004aaa"
+                            fill="currentColor"
+                            height="16"
+                            role="img"
+                            stroke="currentColor"
+                            stroke-width="0"
+                            style="color: rgb(0, 74, 170);"
+                            viewBox="0 0 256 256"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M224,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H32A16,16,0,0,0,16,64V192a16,16,0,0,0,16,16H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h64a16,16,0,0,0,16-16V64A16,16,0,0,0,224,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="mia-platform-modal-body"
-            >
               <div
-                class="body"
+                class="mia-platform-modal-body"
               >
                 <div
-                  class="content"
+                  class="body"
                 >
-                  Modal Content
+                  <div
+                    class="content"
+                  >
+                    Modal Content
+                  </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="mia-platform-modal-footer"
-            >
               <div
-                class="footer"
+                class="mia-platform-modal-footer"
               >
                 <div
-                  class="footerButtons"
+                  class="footer"
                 >
-                  <button
-                    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
-                    type="button"
+                  <div
+                    class="footerButtons"
                   >
-                    <div
-                      class="buttonText"
+                    <button
+                      class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+                      type="button"
                     >
-                      OK
-                    </div>
-                  </button>
-                  <button
-                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
-                    type="button"
-                  >
-                    <div
-                      class="buttonText"
+                      <div
+                        class="buttonText"
+                      >
+                        OK
+                      </div>
+                    </button>
+                    <button
+                      class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                      type="button"
                     >
-                      Cancel
-                    </div>
-                  </button>
+                      <div
+                        class="buttonText"
+                      >
+                        Cancel
+                      </div>
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/components/Table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/Table/__snapshots__/Table.test.tsx.snap
@@ -53,19 +53,19 @@ exports[`Table Component renders actions correctly 1`] = `
                     >
                       Field 4
                     </th>
-                    <td
+                    <th
                       class="mia-platform-table-cell"
                       style="text-align: right;"
                     />
-                    <td
+                    <th
                       class="mia-platform-table-cell"
                       style="text-align: right;"
                     />
-                    <td
+                    <th
                       class="mia-platform-table-cell"
                       style="text-align: right;"
                     />
-                    <td
+                    <th
                       class="mia-platform-table-cell"
                       style="text-align: right;"
                     />
@@ -211,26 +211,30 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
-                          <svg
-                            aria-label="PiArrowRight"
-                            color="currentColor"
-                            fill="currentColor"
-                            height="16"
-                            role="img"
-                            stroke="currentColor"
-                            stroke-width="0"
-                            style="color: currentColor;"
-                            viewBox="0 0 256 256"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="mia-platform-btn-icon"
                           >
-                            <path
-                              d="M221.66,133.66l-72,72a8,8,0,0,1-11.32-11.32L196.69,136H40a8,8,0,0,1,0-16H196.69L138.34,61.66a8,8,0,0,1,11.32-11.32l72,72A8,8,0,0,1,221.66,133.66Z"
-                            />
-                          </svg>
+                            <svg
+                              aria-label="PiArrowRight"
+                              color="currentColor"
+                              fill="currentColor"
+                              height="16"
+                              role="img"
+                              stroke="currentColor"
+                              stroke-width="0"
+                              style="color: currentColor;"
+                              viewBox="0 0 256 256"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M221.66,133.66l-72,72a8,8,0,0,1-11.32-11.32L196.69,136H40a8,8,0,0,1,0-16H196.69L138.34,61.66a8,8,0,0,1,11.32-11.32l72,72A8,8,0,0,1,221.66,133.66Z"
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </td>
@@ -242,26 +246,30 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
-                          <svg
-                            aria-label="PiCircleHalfTilt"
-                            color="currentColor"
-                            fill="currentColor"
-                            height="16"
-                            role="img"
-                            stroke="currentColor"
-                            stroke-width="0"
-                            style="color: currentColor;"
-                            viewBox="0 0 256 256"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="mia-platform-btn-icon"
                           >
-                            <path
-                              d="M201.54,54.46A104,104,0,0,0,54.46,201.54,104,104,0,0,0,201.54,54.46ZM184,195.87a87.16,87.16,0,0,1-16,10.5V99.31l16-16Zm-80-32.56,16-16v68.28a88.37,88.37,0,0,1-16-3ZM88,206.37a87,87,0,0,1-16.3-10.76L88,179.31Zm48-75.06,16-16v97.32a88.37,88.37,0,0,1-16,3ZM40,128A88,88,0,0,1,184.3,60.39L60.38,184.31A87.34,87.34,0,0,1,40,128Zm160,50.59V77.41a88,88,0,0,1,0,101.18Z"
-                            />
-                          </svg>
+                            <svg
+                              aria-label="PiCircleHalfTilt"
+                              color="currentColor"
+                              fill="currentColor"
+                              height="16"
+                              role="img"
+                              stroke="currentColor"
+                              stroke-width="0"
+                              style="color: currentColor;"
+                              viewBox="0 0 256 256"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M201.54,54.46A104,104,0,0,0,54.46,201.54,104,104,0,0,0,201.54,54.46ZM184,195.87a87.16,87.16,0,0,1-16,10.5V99.31l16-16Zm-80-32.56,16-16v68.28a88.37,88.37,0,0,1-16-3ZM88,206.37a87,87,0,0,1-16.3-10.76L88,179.31Zm48-75.06,16-16v97.32a88.37,88.37,0,0,1-16,3ZM40,128A88,88,0,0,1,184.3,60.39L60.38,184.31A87.34,87.34,0,0,1,40,128Zm160,50.59V77.41a88,88,0,0,1,0,101.18Z"
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </td>
@@ -273,26 +281,30 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
-                          <svg
-                            aria-label="PiPencilSimpleLine"
-                            color="currentColor"
-                            fill="currentColor"
-                            height="16"
-                            role="img"
-                            stroke="currentColor"
-                            stroke-width="0"
-                            style="color: currentColor;"
-                            viewBox="0 0 256 256"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="mia-platform-btn-icon"
                           >
-                            <path
-                              d="M227.32,73.37,182.63,28.69a16,16,0,0,0-22.63,0L36.69,152A15.86,15.86,0,0,0,32,163.31V208a16,16,0,0,0,16,16H216a8,8,0,0,0,0-16H115.32l112-112A16,16,0,0,0,227.32,73.37ZM92.69,208H48V163.31l88-88L180.69,120ZM192,108.69,147.32,64l24-24L216,84.69Z"
-                            />
-                          </svg>
+                            <svg
+                              aria-label="PiPencilSimpleLine"
+                              color="currentColor"
+                              fill="currentColor"
+                              height="16"
+                              role="img"
+                              stroke="currentColor"
+                              stroke-width="0"
+                              style="color: currentColor;"
+                              viewBox="0 0 256 256"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M227.32,73.37,182.63,28.69a16,16,0,0,0-22.63,0L36.69,152A15.86,15.86,0,0,0,32,163.31V208a16,16,0,0,0,16,16H216a8,8,0,0,0,0-16H115.32l112-112A16,16,0,0,0,227.32,73.37ZM92.69,208H48V163.31l88-88L180.69,120ZM192,108.69,147.32,64l24-24L216,84.69Z"
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </td>
@@ -304,26 +316,30 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-background-ghost mia-platform-btn-dangerous button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost mia-platform-btn-dangerous button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
-                          <svg
-                            aria-label="PiTrash"
-                            color="currentColor"
-                            fill="currentColor"
-                            height="16"
-                            role="img"
-                            stroke="currentColor"
-                            stroke-width="0"
-                            style="color: currentColor;"
-                            viewBox="0 0 256 256"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="mia-platform-btn-icon"
                           >
-                            <path
-                              d="M216,48H176V40a24,24,0,0,0-24-24H104A24,24,0,0,0,80,40v8H40a8,8,0,0,0,0,16h8V208a16,16,0,0,0,16,16H192a16,16,0,0,0,16-16V64h8a8,8,0,0,0,0-16ZM96,40a8,8,0,0,1,8-8h48a8,8,0,0,1,8,8v8H96Zm96,168H64V64H192ZM112,104v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Zm48,0v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Z"
-                            />
-                          </svg>
+                            <svg
+                              aria-label="PiTrash"
+                              color="currentColor"
+                              fill="currentColor"
+                              height="16"
+                              role="img"
+                              stroke="currentColor"
+                              stroke-width="0"
+                              style="color: currentColor;"
+                              viewBox="0 0 256 256"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M216,48H176V40a24,24,0,0,0-24-24H104A24,24,0,0,0,80,40v8H40a8,8,0,0,0,0,16h8V208a16,16,0,0,0,16,16H192a16,16,0,0,0,16-16V64h8a8,8,0,0,0,0-16ZM96,40a8,8,0,0,1,8-8h48a8,8,0,0,1,8,8v8H96Zm96,168H64V64H192ZM112,104v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Zm48,0v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Z"
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </td>
@@ -360,26 +376,30 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
-                          <svg
-                            aria-label="PiArrowRight"
-                            color="currentColor"
-                            fill="currentColor"
-                            height="16"
-                            role="img"
-                            stroke="currentColor"
-                            stroke-width="0"
-                            style="color: currentColor;"
-                            viewBox="0 0 256 256"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="mia-platform-btn-icon"
                           >
-                            <path
-                              d="M221.66,133.66l-72,72a8,8,0,0,1-11.32-11.32L196.69,136H40a8,8,0,0,1,0-16H196.69L138.34,61.66a8,8,0,0,1,11.32-11.32l72,72A8,8,0,0,1,221.66,133.66Z"
-                            />
-                          </svg>
+                            <svg
+                              aria-label="PiArrowRight"
+                              color="currentColor"
+                              fill="currentColor"
+                              height="16"
+                              role="img"
+                              stroke="currentColor"
+                              stroke-width="0"
+                              style="color: currentColor;"
+                              viewBox="0 0 256 256"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M221.66,133.66l-72,72a8,8,0,0,1-11.32-11.32L196.69,136H40a8,8,0,0,1,0-16H196.69L138.34,61.66a8,8,0,0,1,11.32-11.32l72,72A8,8,0,0,1,221.66,133.66Z"
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </td>
@@ -391,26 +411,30 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
-                          <svg
-                            aria-label="PiCircleHalfTilt"
-                            color="currentColor"
-                            fill="currentColor"
-                            height="16"
-                            role="img"
-                            stroke="currentColor"
-                            stroke-width="0"
-                            style="color: currentColor;"
-                            viewBox="0 0 256 256"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="mia-platform-btn-icon"
                           >
-                            <path
-                              d="M201.54,54.46A104,104,0,0,0,54.46,201.54,104,104,0,0,0,201.54,54.46ZM184,195.87a87.16,87.16,0,0,1-16,10.5V99.31l16-16Zm-80-32.56,16-16v68.28a88.37,88.37,0,0,1-16-3ZM88,206.37a87,87,0,0,1-16.3-10.76L88,179.31Zm48-75.06,16-16v97.32a88.37,88.37,0,0,1-16,3ZM40,128A88,88,0,0,1,184.3,60.39L60.38,184.31A87.34,87.34,0,0,1,40,128Zm160,50.59V77.41a88,88,0,0,1,0,101.18Z"
-                            />
-                          </svg>
+                            <svg
+                              aria-label="PiCircleHalfTilt"
+                              color="currentColor"
+                              fill="currentColor"
+                              height="16"
+                              role="img"
+                              stroke="currentColor"
+                              stroke-width="0"
+                              style="color: currentColor;"
+                              viewBox="0 0 256 256"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M201.54,54.46A104,104,0,0,0,54.46,201.54,104,104,0,0,0,201.54,54.46ZM184,195.87a87.16,87.16,0,0,1-16,10.5V99.31l16-16Zm-80-32.56,16-16v68.28a88.37,88.37,0,0,1-16-3ZM88,206.37a87,87,0,0,1-16.3-10.76L88,179.31Zm48-75.06,16-16v97.32a88.37,88.37,0,0,1-16,3ZM40,128A88,88,0,0,1,184.3,60.39L60.38,184.31A87.34,87.34,0,0,1,40,128Zm160,50.59V77.41a88,88,0,0,1,0,101.18Z"
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </td>
@@ -422,26 +446,30 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
-                          <svg
-                            aria-label="PiPencilSimpleLine"
-                            color="currentColor"
-                            fill="currentColor"
-                            height="16"
-                            role="img"
-                            stroke="currentColor"
-                            stroke-width="0"
-                            style="color: currentColor;"
-                            viewBox="0 0 256 256"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="mia-platform-btn-icon"
                           >
-                            <path
-                              d="M227.32,73.37,182.63,28.69a16,16,0,0,0-22.63,0L36.69,152A15.86,15.86,0,0,0,32,163.31V208a16,16,0,0,0,16,16H216a8,8,0,0,0,0-16H115.32l112-112A16,16,0,0,0,227.32,73.37ZM92.69,208H48V163.31l88-88L180.69,120ZM192,108.69,147.32,64l24-24L216,84.69Z"
-                            />
-                          </svg>
+                            <svg
+                              aria-label="PiPencilSimpleLine"
+                              color="currentColor"
+                              fill="currentColor"
+                              height="16"
+                              role="img"
+                              stroke="currentColor"
+                              stroke-width="0"
+                              style="color: currentColor;"
+                              viewBox="0 0 256 256"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M227.32,73.37,182.63,28.69a16,16,0,0,0-22.63,0L36.69,152A15.86,15.86,0,0,0,32,163.31V208a16,16,0,0,0,16,16H216a8,8,0,0,0,0-16H115.32l112-112A16,16,0,0,0,227.32,73.37ZM92.69,208H48V163.31l88-88L180.69,120ZM192,108.69,147.32,64l24-24L216,84.69Z"
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </td>
@@ -453,26 +481,30 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-background-ghost mia-platform-btn-dangerous button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost mia-platform-btn-dangerous button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
-                          <svg
-                            aria-label="PiTrash"
-                            color="currentColor"
-                            fill="currentColor"
-                            height="16"
-                            role="img"
-                            stroke="currentColor"
-                            stroke-width="0"
-                            style="color: currentColor;"
-                            viewBox="0 0 256 256"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="mia-platform-btn-icon"
                           >
-                            <path
-                              d="M216,48H176V40a24,24,0,0,0-24-24H104A24,24,0,0,0,80,40v8H40a8,8,0,0,0,0,16h8V208a16,16,0,0,0,16,16H192a16,16,0,0,0,16-16V64h8a8,8,0,0,0,0-16ZM96,40a8,8,0,0,1,8-8h48a8,8,0,0,1,8,8v8H96Zm96,168H64V64H192ZM112,104v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Zm48,0v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Z"
-                            />
-                          </svg>
+                            <svg
+                              aria-label="PiTrash"
+                              color="currentColor"
+                              fill="currentColor"
+                              height="16"
+                              role="img"
+                              stroke="currentColor"
+                              stroke-width="0"
+                              style="color: currentColor;"
+                              viewBox="0 0 256 256"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M216,48H176V40a24,24,0,0,0-24-24H104A24,24,0,0,0,80,40v8H40a8,8,0,0,0,0,16h8V208a16,16,0,0,0,16,16H192a16,16,0,0,0,16-16V64h8a8,8,0,0,0,0-16ZM96,40a8,8,0,0,1,8-8h48a8,8,0,0,1,8,8v8H96Zm96,168H64V64H192ZM112,104v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Zm48,0v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Z"
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </td>
@@ -509,26 +541,30 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
-                          <svg
-                            aria-label="PiArrowRight"
-                            color="currentColor"
-                            fill="currentColor"
-                            height="16"
-                            role="img"
-                            stroke="currentColor"
-                            stroke-width="0"
-                            style="color: currentColor;"
-                            viewBox="0 0 256 256"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="mia-platform-btn-icon"
                           >
-                            <path
-                              d="M221.66,133.66l-72,72a8,8,0,0,1-11.32-11.32L196.69,136H40a8,8,0,0,1,0-16H196.69L138.34,61.66a8,8,0,0,1,11.32-11.32l72,72A8,8,0,0,1,221.66,133.66Z"
-                            />
-                          </svg>
+                            <svg
+                              aria-label="PiArrowRight"
+                              color="currentColor"
+                              fill="currentColor"
+                              height="16"
+                              role="img"
+                              stroke="currentColor"
+                              stroke-width="0"
+                              style="color: currentColor;"
+                              viewBox="0 0 256 256"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M221.66,133.66l-72,72a8,8,0,0,1-11.32-11.32L196.69,136H40a8,8,0,0,1,0-16H196.69L138.34,61.66a8,8,0,0,1,11.32-11.32l72,72A8,8,0,0,1,221.66,133.66Z"
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </td>
@@ -540,26 +576,30 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
-                          <svg
-                            aria-label="PiCircleHalfTilt"
-                            color="currentColor"
-                            fill="currentColor"
-                            height="16"
-                            role="img"
-                            stroke="currentColor"
-                            stroke-width="0"
-                            style="color: currentColor;"
-                            viewBox="0 0 256 256"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="mia-platform-btn-icon"
                           >
-                            <path
-                              d="M201.54,54.46A104,104,0,0,0,54.46,201.54,104,104,0,0,0,201.54,54.46ZM184,195.87a87.16,87.16,0,0,1-16,10.5V99.31l16-16Zm-80-32.56,16-16v68.28a88.37,88.37,0,0,1-16-3ZM88,206.37a87,87,0,0,1-16.3-10.76L88,179.31Zm48-75.06,16-16v97.32a88.37,88.37,0,0,1-16,3ZM40,128A88,88,0,0,1,184.3,60.39L60.38,184.31A87.34,87.34,0,0,1,40,128Zm160,50.59V77.41a88,88,0,0,1,0,101.18Z"
-                            />
-                          </svg>
+                            <svg
+                              aria-label="PiCircleHalfTilt"
+                              color="currentColor"
+                              fill="currentColor"
+                              height="16"
+                              role="img"
+                              stroke="currentColor"
+                              stroke-width="0"
+                              style="color: currentColor;"
+                              viewBox="0 0 256 256"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M201.54,54.46A104,104,0,0,0,54.46,201.54,104,104,0,0,0,201.54,54.46ZM184,195.87a87.16,87.16,0,0,1-16,10.5V99.31l16-16Zm-80-32.56,16-16v68.28a88.37,88.37,0,0,1-16-3ZM88,206.37a87,87,0,0,1-16.3-10.76L88,179.31Zm48-75.06,16-16v97.32a88.37,88.37,0,0,1-16,3ZM40,128A88,88,0,0,1,184.3,60.39L60.38,184.31A87.34,87.34,0,0,1,40,128Zm160,50.59V77.41a88,88,0,0,1,0,101.18Z"
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </td>
@@ -571,27 +611,31 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           disabled=""
                           type="button"
                         >
-                          <svg
-                            aria-label="PiPencilSimpleLine"
-                            color="currentColor"
-                            fill="currentColor"
-                            height="16"
-                            role="img"
-                            stroke="currentColor"
-                            stroke-width="0"
-                            style="color: currentColor;"
-                            viewBox="0 0 256 256"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="mia-platform-btn-icon"
                           >
-                            <path
-                              d="M227.32,73.37,182.63,28.69a16,16,0,0,0-22.63,0L36.69,152A15.86,15.86,0,0,0,32,163.31V208a16,16,0,0,0,16,16H216a8,8,0,0,0,0-16H115.32l112-112A16,16,0,0,0,227.32,73.37ZM92.69,208H48V163.31l88-88L180.69,120ZM192,108.69,147.32,64l24-24L216,84.69Z"
-                            />
-                          </svg>
+                            <svg
+                              aria-label="PiPencilSimpleLine"
+                              color="currentColor"
+                              fill="currentColor"
+                              height="16"
+                              role="img"
+                              stroke="currentColor"
+                              stroke-width="0"
+                              style="color: currentColor;"
+                              viewBox="0 0 256 256"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M227.32,73.37,182.63,28.69a16,16,0,0,0-22.63,0L36.69,152A15.86,15.86,0,0,0,32,163.31V208a16,16,0,0,0,16,16H216a8,8,0,0,0,0-16H115.32l112-112A16,16,0,0,0,227.32,73.37ZM92.69,208H48V163.31l88-88L180.69,120ZM192,108.69,147.32,64l24-24L216,84.69Z"
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </td>
@@ -603,26 +647,30 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-background-ghost mia-platform-btn-dangerous button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost mia-platform-btn-dangerous button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
-                          <svg
-                            aria-label="PiTrash"
-                            color="currentColor"
-                            fill="currentColor"
-                            height="16"
-                            role="img"
-                            stroke="currentColor"
-                            stroke-width="0"
-                            style="color: currentColor;"
-                            viewBox="0 0 256 256"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="mia-platform-btn-icon"
                           >
-                            <path
-                              d="M216,48H176V40a24,24,0,0,0-24-24H104A24,24,0,0,0,80,40v8H40a8,8,0,0,0,0,16h8V208a16,16,0,0,0,16,16H192a16,16,0,0,0,16-16V64h8a8,8,0,0,0,0-16ZM96,40a8,8,0,0,1,8-8h48a8,8,0,0,1,8,8v8H96Zm96,168H64V64H192ZM112,104v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Zm48,0v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Z"
-                            />
-                          </svg>
+                            <svg
+                              aria-label="PiTrash"
+                              color="currentColor"
+                              fill="currentColor"
+                              height="16"
+                              role="img"
+                              stroke="currentColor"
+                              stroke-width="0"
+                              style="color: currentColor;"
+                              viewBox="0 0 256 256"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M216,48H176V40a24,24,0,0,0-24-24H104A24,24,0,0,0,80,40v8H40a8,8,0,0,0,0,16h8V208a16,16,0,0,0,16,16H192a16,16,0,0,0,16-16V64h8a8,8,0,0,0,0-16ZM96,40a8,8,0,0,1,8-8h48a8,8,0,0,1,8,8v8H96Zm96,168H64V64H192ZM112,104v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Zm48,0v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Z"
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </td>
@@ -659,26 +707,30 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
-                          <svg
-                            aria-label="PiArrowRight"
-                            color="currentColor"
-                            fill="currentColor"
-                            height="16"
-                            role="img"
-                            stroke="currentColor"
-                            stroke-width="0"
-                            style="color: currentColor;"
-                            viewBox="0 0 256 256"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="mia-platform-btn-icon"
                           >
-                            <path
-                              d="M221.66,133.66l-72,72a8,8,0,0,1-11.32-11.32L196.69,136H40a8,8,0,0,1,0-16H196.69L138.34,61.66a8,8,0,0,1,11.32-11.32l72,72A8,8,0,0,1,221.66,133.66Z"
-                            />
-                          </svg>
+                            <svg
+                              aria-label="PiArrowRight"
+                              color="currentColor"
+                              fill="currentColor"
+                              height="16"
+                              role="img"
+                              stroke="currentColor"
+                              stroke-width="0"
+                              style="color: currentColor;"
+                              viewBox="0 0 256 256"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M221.66,133.66l-72,72a8,8,0,0,1-11.32-11.32L196.69,136H40a8,8,0,0,1,0-16H196.69L138.34,61.66a8,8,0,0,1,11.32-11.32l72,72A8,8,0,0,1,221.66,133.66Z"
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </td>
@@ -690,26 +742,30 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
-                          <svg
-                            aria-label="PiCircleHalfTilt"
-                            color="currentColor"
-                            fill="currentColor"
-                            height="16"
-                            role="img"
-                            stroke="currentColor"
-                            stroke-width="0"
-                            style="color: currentColor;"
-                            viewBox="0 0 256 256"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="mia-platform-btn-icon"
                           >
-                            <path
-                              d="M201.54,54.46A104,104,0,0,0,54.46,201.54,104,104,0,0,0,201.54,54.46ZM184,195.87a87.16,87.16,0,0,1-16,10.5V99.31l16-16Zm-80-32.56,16-16v68.28a88.37,88.37,0,0,1-16-3ZM88,206.37a87,87,0,0,1-16.3-10.76L88,179.31Zm48-75.06,16-16v97.32a88.37,88.37,0,0,1-16,3ZM40,128A88,88,0,0,1,184.3,60.39L60.38,184.31A87.34,87.34,0,0,1,40,128Zm160,50.59V77.41a88,88,0,0,1,0,101.18Z"
-                            />
-                          </svg>
+                            <svg
+                              aria-label="PiCircleHalfTilt"
+                              color="currentColor"
+                              fill="currentColor"
+                              height="16"
+                              role="img"
+                              stroke="currentColor"
+                              stroke-width="0"
+                              style="color: currentColor;"
+                              viewBox="0 0 256 256"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M201.54,54.46A104,104,0,0,0,54.46,201.54,104,104,0,0,0,201.54,54.46ZM184,195.87a87.16,87.16,0,0,1-16,10.5V99.31l16-16Zm-80-32.56,16-16v68.28a88.37,88.37,0,0,1-16-3ZM88,206.37a87,87,0,0,1-16.3-10.76L88,179.31Zm48-75.06,16-16v97.32a88.37,88.37,0,0,1-16,3ZM40,128A88,88,0,0,1,184.3,60.39L60.38,184.31A87.34,87.34,0,0,1,40,128Zm160,50.59V77.41a88,88,0,0,1,0,101.18Z"
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </td>
@@ -721,26 +777,30 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
-                          <svg
-                            aria-label="PiPencilSimpleLine"
-                            color="currentColor"
-                            fill="currentColor"
-                            height="16"
-                            role="img"
-                            stroke="currentColor"
-                            stroke-width="0"
-                            style="color: currentColor;"
-                            viewBox="0 0 256 256"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="mia-platform-btn-icon"
                           >
-                            <path
-                              d="M227.32,73.37,182.63,28.69a16,16,0,0,0-22.63,0L36.69,152A15.86,15.86,0,0,0,32,163.31V208a16,16,0,0,0,16,16H216a8,8,0,0,0,0-16H115.32l112-112A16,16,0,0,0,227.32,73.37ZM92.69,208H48V163.31l88-88L180.69,120ZM192,108.69,147.32,64l24-24L216,84.69Z"
-                            />
-                          </svg>
+                            <svg
+                              aria-label="PiPencilSimpleLine"
+                              color="currentColor"
+                              fill="currentColor"
+                              height="16"
+                              role="img"
+                              stroke="currentColor"
+                              stroke-width="0"
+                              style="color: currentColor;"
+                              viewBox="0 0 256 256"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M227.32,73.37,182.63,28.69a16,16,0,0,0-22.63,0L36.69,152A15.86,15.86,0,0,0,32,163.31V208a16,16,0,0,0,16,16H216a8,8,0,0,0,0-16H115.32l112-112A16,16,0,0,0,227.32,73.37ZM92.69,208H48V163.31l88-88L180.69,120ZM192,108.69,147.32,64l24-24L216,84.69Z"
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </td>
@@ -752,26 +812,30 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-background-ghost mia-platform-btn-dangerous button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost mia-platform-btn-dangerous button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
-                          <svg
-                            aria-label="PiTrash"
-                            color="currentColor"
-                            fill="currentColor"
-                            height="16"
-                            role="img"
-                            stroke="currentColor"
-                            stroke-width="0"
-                            style="color: currentColor;"
-                            viewBox="0 0 256 256"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="mia-platform-btn-icon"
                           >
-                            <path
-                              d="M216,48H176V40a24,24,0,0,0-24-24H104A24,24,0,0,0,80,40v8H40a8,8,0,0,0,0,16h8V208a16,16,0,0,0,16,16H192a16,16,0,0,0,16-16V64h8a8,8,0,0,0,0-16ZM96,40a8,8,0,0,1,8-8h48a8,8,0,0,1,8,8v8H96Zm96,168H64V64H192ZM112,104v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Zm48,0v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Z"
-                            />
-                          </svg>
+                            <svg
+                              aria-label="PiTrash"
+                              color="currentColor"
+                              fill="currentColor"
+                              height="16"
+                              role="img"
+                              stroke="currentColor"
+                              stroke-width="0"
+                              style="color: currentColor;"
+                              viewBox="0 0 256 256"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M216,48H176V40a24,24,0,0,0-24-24H104A24,24,0,0,0,80,40v8H40a8,8,0,0,0,0,16h8V208a16,16,0,0,0,16,16H192a16,16,0,0,0,16-16V64h8a8,8,0,0,0,0-16ZM96,40a8,8,0,0,1,8-8h48a8,8,0,0,1,8,8v8H96Zm96,168H64V64H192ZM112,104v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Zm48,0v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Z"
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </td>
@@ -1910,7 +1974,7 @@ exports[`Table Component renders expandable rows correctly 1`] = `
                   class="mia-platform-table-thead"
                 >
                   <tr>
-                    <td
+                    <th
                       class="mia-platform-table-cell mia-platform-table-row-expand-icon-cell"
                     />
                     <th

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,7 +29,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ant-design/colors@npm:^7.0.0, @ant-design/colors@npm:^7.0.2":
+"@ant-design/colors@npm:^7.0.0":
   version: 7.0.2
   resolution: "@ant-design/colors@npm:7.0.2"
   dependencies:
@@ -38,9 +38,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ant-design/cssinjs@npm:^1.18.2":
-  version: 1.20.0
-  resolution: "@ant-design/cssinjs@npm:1.20.0"
+"@ant-design/colors@npm:^7.0.2":
+  version: 7.1.0
+  resolution: "@ant-design/colors@npm:7.1.0"
+  dependencies:
+    "@ctrl/tinycolor": "npm:^3.6.1"
+  checksum: 10/207f6d98e9d7f85c676279d516d87b6faa1794fdcbef17779dbc09ab033ca2dff048dc7bce71cb7095fcc053a84a65aff4d786e5b55af24a372a8bfa0ebf8fc8
+  languageName: node
+  linkType: hard
+
+"@ant-design/cssinjs@npm:^1.19.1":
+  version: 1.21.1
+  resolution: "@ant-design/cssinjs@npm:1.21.1"
   dependencies:
     "@babel/runtime": "npm:^7.11.1"
     "@emotion/hash": "npm:^0.8.0"
@@ -48,11 +57,11 @@ __metadata:
     classnames: "npm:^2.3.1"
     csstype: "npm:^3.1.3"
     rc-util: "npm:^5.35.0"
-    stylis: "npm:^4.0.13"
+    stylis: "npm:^4.3.3"
   peerDependencies:
     react: ">=16.0.0"
     react-dom: ">=16.0.0"
-  checksum: 10/2d8130b34f2354ed7d775e42770ea756aa41ae9570714087ecb5aa210135a465812aae1a85c9e7e99e6ecb28812ae36c56beb341b93ef1f201491f835dee9bb6
+  checksum: 10/c26b84ec05df784ed83496463a5eb9db21c6ca3a4710aaec7af07090b562cf1bdabd7543b92e8c64da4dc8ac5be88baf94bda53cee1ca83428e45133389079b8
   languageName: node
   linkType: hard
 
@@ -63,25 +72,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ant-design/icons@npm:^5.2.6":
-  version: 5.3.7
-  resolution: "@ant-design/icons@npm:5.3.7"
+"@ant-design/icons@npm:^5.3.6":
+  version: 5.4.0
+  resolution: "@ant-design/icons@npm:5.4.0"
   dependencies:
     "@ant-design/colors": "npm:^7.0.0"
     "@ant-design/icons-svg": "npm:^4.4.0"
-    "@babel/runtime": "npm:^7.11.2"
+    "@babel/runtime": "npm:^7.24.8"
     classnames: "npm:^2.2.6"
     rc-util: "npm:^5.31.1"
   peerDependencies:
     react: ">=16.0.0"
     react-dom: ">=16.0.0"
-  checksum: 10/64cf5f9b1c95bef51e07cfd27883dd10b8b6d9d6dcd1607dcec8e2351d8c5c41cc2ec60c6a53101d22177c2f6da0cc8ca5c902eb054243a278a860e030aab575
+  checksum: 10/63471e5c23762c733148246150452f75af0ccbe320a19d9044355cd9f1b36663afbe84faa3fd21a3a2f8eaf908c68f9e42466da560d6ddfd973ad9763d29c06f
   languageName: node
   linkType: hard
 
-"@ant-design/react-slick@npm:~1.0.2":
-  version: 1.0.2
-  resolution: "@ant-design/react-slick@npm:1.0.2"
+"@ant-design/react-slick@npm:~1.1.2":
+  version: 1.1.2
+  resolution: "@ant-design/react-slick@npm:1.1.2"
   dependencies:
     "@babel/runtime": "npm:^7.10.4"
     classnames: "npm:^2.2.5"
@@ -90,7 +99,7 @@ __metadata:
     throttle-debounce: "npm:^5.0.0"
   peerDependencies:
     react: ">=16.9.0"
-  checksum: 10/cbac98c50950fe3dc09dac9ff7ec6d48199af3c51cca4a5dd8735ddbad45cef8d64bde8f5609cce411d6bb6ffd0d449764b491ebd697b251c3e17cc6fe302481
+  checksum: 10/b38e44630936c8fa3b055c9f7cdbd510b78d18ce31fe32165be4d0e8d082ee735216daa9228881d41b79e85f22eac8deee182ed8103f23108517c72606348132
   languageName: node
   linkType: hard
 
@@ -1525,6 +1534,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.24.4, @babel/runtime@npm:^7.24.5, @babel/runtime@npm:^7.24.8":
+  version: 7.25.4
+  resolution: "@babel/runtime@npm:7.25.4"
+  dependencies:
+    regenerator-runtime: "npm:^0.14.0"
+  checksum: 10/70d2a420c24a3289ea6c4addaf3a1c4186bc3d001c92445faa3cd7601d7d2fbdb32c63b3a26b9771e20ff2f511fa76b726bf256f823cdb95bc37b8eadbd02f70
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.22.5, @babel/template@npm:^7.24.6, @babel/template@npm:^7.3.3":
   version: 7.24.6
   resolution: "@babel/template@npm:7.24.6"
@@ -2531,7 +2549,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^7.17.0"
     "@typescript-eslint/parser": "npm:^7.15.0"
     "@vitejs/plugin-react-swc": "npm:^3.6.0"
-    antd: "npm:5.13.0"
+    antd: "npm:5.17.0"
     classnames: "npm:^2.5.1"
     eslint: "npm:^8.57.0"
     eslint-plugin-import: "npm:^2.29.1"
@@ -3273,7 +3291,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rc-component/color-picker@npm:~1.5.1":
+"@rc-component/async-validator@npm:^5.0.3":
+  version: 5.0.4
+  resolution: "@rc-component/async-validator@npm:5.0.4"
+  dependencies:
+    "@babel/runtime": "npm:^7.24.4"
+  checksum: 10/b5e4431a073ec047a3fd1425f30d38bb600d5ad3fc180ec7afa977a6361d7e83df30d66ce9c637910907b6a50debf8bb64d7378fe3d39b352c395144a2eaf1d5
+  languageName: node
+  linkType: hard
+
+"@rc-component/color-picker@npm:~1.5.3":
   version: 1.5.3
   resolution: "@rc-component/color-picker@npm:1.5.3"
   dependencies:
@@ -3338,25 +3365,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rc-component/tour@npm:~1.12.1":
-  version: 1.12.3
-  resolution: "@rc-component/tour@npm:1.12.3"
+"@rc-component/tour@npm:~1.14.2":
+  version: 1.14.2
+  resolution: "@rc-component/tour@npm:1.14.2"
   dependencies:
     "@babel/runtime": "npm:^7.18.0"
     "@rc-component/portal": "npm:^1.0.0-9"
-    "@rc-component/trigger": "npm:^1.3.6"
+    "@rc-component/trigger": "npm:^2.0.0"
     classnames: "npm:^2.3.2"
     rc-util: "npm:^5.24.4"
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/650f7e5c3567e1910ec6a6c312632937aa041ac0008568290385be07384469ddc482aeb517d88f59d66377579adbab25585364a4c21d416a10a1c2c80e3436a7
+  checksum: 10/2409e511eb2d5c55031af07b2c53650cfa15af744a524ae05d6f034a789f182979219a6316e62a323d6f041f3a2d198809333867334954a55917a55abc3ac6b8
   languageName: node
   linkType: hard
 
-"@rc-component/trigger@npm:^1.17.0, @rc-component/trigger@npm:^1.18.0, @rc-component/trigger@npm:^1.18.2, @rc-component/trigger@npm:^1.3.6, @rc-component/trigger@npm:^1.5.0, @rc-component/trigger@npm:^1.7.0":
-  version: 1.18.3
-  resolution: "@rc-component/trigger@npm:1.18.3"
+"@rc-component/trigger@npm:^2.0.0, @rc-component/trigger@npm:^2.1.1":
+  version: 2.2.1
+  resolution: "@rc-component/trigger@npm:2.2.1"
   dependencies:
     "@babel/runtime": "npm:^7.23.2"
     "@rc-component/portal": "npm:^1.1.0"
@@ -3367,7 +3394,7 @@ __metadata:
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/1db49fa11a9c5a87def9b1ebd9e1f1401f21a1e6c7f84195138ae7ad3e65e240b7848ed16682bba91837e1ecca8f6fa0c58076564dbe00f55a63c7672b2cbc66
+  checksum: 10/d7835a7219c8f19adf913f219f1f7281a37b837fd9c793d68e62347eb07cb04740e1dfde0049ff2fee9d21e9c6aef5ea97210c810f0fb81ebf55f321ecddab3c
   languageName: node
   linkType: hard
 
@@ -5915,61 +5942,62 @@ __metadata:
   languageName: node
   linkType: hard
 
-"antd@npm:5.13.0":
-  version: 5.13.0
-  resolution: "antd@npm:5.13.0"
+"antd@npm:5.17.0":
+  version: 5.17.0
+  resolution: "antd@npm:5.17.0"
   dependencies:
     "@ant-design/colors": "npm:^7.0.2"
-    "@ant-design/cssinjs": "npm:^1.18.2"
-    "@ant-design/icons": "npm:^5.2.6"
-    "@ant-design/react-slick": "npm:~1.0.2"
+    "@ant-design/cssinjs": "npm:^1.19.1"
+    "@ant-design/icons": "npm:^5.3.6"
+    "@ant-design/react-slick": "npm:~1.1.2"
+    "@babel/runtime": "npm:^7.24.5"
     "@ctrl/tinycolor": "npm:^3.6.1"
-    "@rc-component/color-picker": "npm:~1.5.1"
+    "@rc-component/color-picker": "npm:~1.5.3"
     "@rc-component/mutate-observer": "npm:^1.1.0"
-    "@rc-component/tour": "npm:~1.12.1"
-    "@rc-component/trigger": "npm:^1.18.2"
+    "@rc-component/tour": "npm:~1.14.2"
+    "@rc-component/trigger": "npm:^2.1.1"
     classnames: "npm:^2.5.1"
     copy-to-clipboard: "npm:^3.3.3"
     dayjs: "npm:^1.11.10"
     qrcode.react: "npm:^3.1.0"
-    rc-cascader: "npm:~3.21.0"
-    rc-checkbox: "npm:~3.1.0"
-    rc-collapse: "npm:~3.7.2"
-    rc-dialog: "npm:~9.3.4"
-    rc-drawer: "npm:~7.0.0"
-    rc-dropdown: "npm:~4.1.0"
-    rc-field-form: "npm:~1.41.0"
-    rc-image: "npm:~7.5.1"
-    rc-input: "npm:~1.4.3"
-    rc-input-number: "npm:~8.6.1"
-    rc-mentions: "npm:~2.10.1"
-    rc-menu: "npm:~9.12.4"
+    rc-cascader: "npm:~3.25.0"
+    rc-checkbox: "npm:~3.2.0"
+    rc-collapse: "npm:~3.7.3"
+    rc-dialog: "npm:~9.4.0"
+    rc-drawer: "npm:~7.1.0"
+    rc-dropdown: "npm:~4.2.0"
+    rc-field-form: "npm:~2.0.0"
+    rc-image: "npm:~7.6.0"
+    rc-input: "npm:~1.4.5"
+    rc-input-number: "npm:~9.0.0"
+    rc-mentions: "npm:~2.11.1"
+    rc-menu: "npm:~9.13.0"
     rc-motion: "npm:^2.9.0"
-    rc-notification: "npm:~5.3.0"
+    rc-notification: "npm:~5.4.0"
     rc-pagination: "npm:~4.0.4"
-    rc-picker: "npm:~3.14.6"
-    rc-progress: "npm:~3.5.1"
+    rc-picker: "npm:~4.5.0"
+    rc-progress: "npm:~4.0.0"
     rc-rate: "npm:~2.12.0"
     rc-resize-observer: "npm:^1.4.0"
-    rc-segmented: "npm:~2.2.2"
-    rc-select: "npm:~14.11.0"
-    rc-slider: "npm:~10.5.0"
+    rc-segmented: "npm:~2.3.0"
+    rc-select: "npm:~14.13.1"
+    rc-slider: "npm:~10.6.2"
     rc-steps: "npm:~6.0.1"
     rc-switch: "npm:~4.1.0"
-    rc-table: "npm:~7.37.0"
-    rc-tabs: "npm:~14.0.0"
+    rc-table: "npm:~7.45.5"
+    rc-tabs: "npm:~15.0.0 "
     rc-textarea: "npm:~1.6.3"
-    rc-tooltip: "npm:~6.1.3"
-    rc-tree: "npm:~5.8.2"
-    rc-tree-select: "npm:~5.17.0"
+    rc-tooltip: "npm:~6.2.0"
+    rc-tree: "npm:~5.8.5"
+    rc-tree-select: "npm:~5.20.0"
     rc-upload: "npm:~4.5.2"
-    rc-util: "npm:^5.38.1"
+    rc-util: "npm:^5.39.1"
     scroll-into-view-if-needed: "npm:^3.1.0"
     throttle-debounce: "npm:^5.0.0"
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/69c17e5b138f0e6b36128ec93f217a0249c61c2e78dca9544abcdbc9c278155b041b21de1b9ace4bd50edd80d5a09ff9f496b6b0cadafde218a31565d6b45003
+  checksum: 10/1afa1fe63826f77e1c20babf6b15ec2a721f7173f2e71dc31a662982763d55f4583f5ce558dc2b8409aa3663917fa25a48b5747793d9e8641516157ff1c63de5
   languageName: node
   linkType: hard
 
@@ -6220,13 +6248,6 @@ __metadata:
   version: 1.0.1
   resolution: "async-limiter@npm:1.0.1"
   checksum: 10/2b849695b465d93ad44c116220dee29a5aeb63adac16c1088983c339b0de57d76e82533e8e364a93a9f997f28bbfc6a92948cefc120652bd07f3b59f8d75cf2b
-  languageName: node
-  linkType: hard
-
-"async-validator@npm:^4.1.0":
-  version: 4.2.5
-  resolution: "async-validator@npm:4.2.5"
-  checksum: 10/d77e43bb637d550ff445c93bb688665aa8fd2b85b5990dde5601ab79bb0f36cf8511592353d9b04df882e89702a9ae148443d77b5e74a0cfc31dcbd782abfddd
   languageName: node
   linkType: hard
 
@@ -7248,9 +7269,9 @@ __metadata:
   linkType: hard
 
 "dayjs@npm:^1.11.10":
-  version: 1.11.11
-  resolution: "dayjs@npm:1.11.11"
-  checksum: 10/f03948b172fbeed229837965988d1d5bac99c72a31c28731a457303259439f2f36289186489ae140adbeb10f591a926908c8de5d81eb449a2edbf5cbd6e9e30c
+  version: 1.11.13
+  resolution: "dayjs@npm:1.11.13"
+  checksum: 10/7374d63ab179b8d909a95e74790def25c8986e329ae989840bacb8b1888be116d20e1c4eee75a69ea0dfbae13172efc50ef85619d304ee7ca3c01d5878b704f5
   languageName: node
   linkType: hard
 
@@ -12952,26 +12973,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-cascader@npm:~3.21.0":
-  version: 3.21.2
-  resolution: "rc-cascader@npm:3.21.2"
+"rc-cascader@npm:~3.25.0":
+  version: 3.25.0
+  resolution: "rc-cascader@npm:3.25.0"
   dependencies:
     "@babel/runtime": "npm:^7.12.5"
     array-tree-filter: "npm:^2.1.0"
     classnames: "npm:^2.3.1"
-    rc-select: "npm:~14.11.0"
+    rc-select: "npm:~14.13.0"
     rc-tree: "npm:~5.8.1"
     rc-util: "npm:^5.37.0"
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/2640379d9a896586e429f94d8cab9503b52336d841ec1694d5d62eb91ed8137795c3fba8380efb43d7333a917f08d698984143e6cef7cbdd0662cba00866992a
+  checksum: 10/029250563c6b246568b47a81a168701aa64520e8a5e9a33999af86cc284a9eef8c1381c42ed98d56079c760f7d3ca230de4d5d80f99798dd61e7dce829a75a17
   languageName: node
   linkType: hard
 
-"rc-checkbox@npm:~3.1.0":
-  version: 3.1.0
-  resolution: "rc-checkbox@npm:3.1.0"
+"rc-checkbox@npm:~3.2.0":
+  version: 3.2.0
+  resolution: "rc-checkbox@npm:3.2.0"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
     classnames: "npm:^2.3.2"
@@ -12979,11 +13000,11 @@ __metadata:
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/f15dd3e3e3120567b633392e37c6d904f2b3c32eb752f4197231b6d79bfa257bde9cd32616ad08c0ad5b053d7b197c9e0684479053b4dea384e466ab53f5c7b4
+  checksum: 10/58e3ec5094ad9be8d0855bfc3446af0cb3b36e201bc5d6da606e75c48890a588cc6851af618884028a0c594ade41c39cf60d35d942eac0a233e0460e8981051b
   languageName: node
   linkType: hard
 
-"rc-collapse@npm:~3.7.2":
+"rc-collapse@npm:~3.7.3":
   version: 3.7.3
   resolution: "rc-collapse@npm:3.7.3"
   dependencies:
@@ -12998,9 +13019,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-dialog@npm:~9.3.4":
-  version: 9.3.4
-  resolution: "rc-dialog@npm:9.3.4"
+"rc-dialog@npm:~9.4.0":
+  version: 9.4.0
+  resolution: "rc-dialog@npm:9.4.0"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
     "@rc-component/portal": "npm:^1.0.0-8"
@@ -13010,75 +13031,75 @@ __metadata:
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/3b6a322b31cdfe868da727845e0eeed780c293e447d908a2ae61457f987ac192525ad8ca1d082ba174a424fc27ca2732e98a0654ea8d55daeb965fce852c53c5
+  checksum: 10/ecff15ae26df104e42581482f32fa06a718cf5c01440b6d1556b080dd4cfc80a96fcd648b626f34b6b549a9968503f193f309a9e9004e669ead9a70e27e4a4f4
   languageName: node
   linkType: hard
 
-"rc-drawer@npm:~7.0.0":
-  version: 7.0.0
-  resolution: "rc-drawer@npm:7.0.0"
+"rc-drawer@npm:~7.1.0":
+  version: 7.1.0
+  resolution: "rc-drawer@npm:7.1.0"
   dependencies:
-    "@babel/runtime": "npm:^7.10.1"
+    "@babel/runtime": "npm:^7.23.9"
     "@rc-component/portal": "npm:^1.1.1"
     classnames: "npm:^2.2.6"
     rc-motion: "npm:^2.6.1"
-    rc-util: "npm:^5.36.0"
+    rc-util: "npm:^5.38.1"
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/6396ddd14d7bf8916eb37749f33e50cb1f74bc937513a353bbbcfdcf9c03ef970e6ae941cf2232e4495cc7e77a5cd911489bd3fdfe8d19570fcd699c98b22af3
+  checksum: 10/6d37b35e3a9abd0e105f91f388c818dcd7d6e9a5805a9bb0909b01e96e47437af2010e29c05648d15ece37e0768ff752e15f498ced69a476c20b9ea06c5e636f
   languageName: node
   linkType: hard
 
-"rc-dropdown@npm:~4.1.0":
-  version: 4.1.0
-  resolution: "rc-dropdown@npm:4.1.0"
+"rc-dropdown@npm:~4.2.0":
+  version: 4.2.0
+  resolution: "rc-dropdown@npm:4.2.0"
   dependencies:
     "@babel/runtime": "npm:^7.18.3"
-    "@rc-component/trigger": "npm:^1.7.0"
+    "@rc-component/trigger": "npm:^2.0.0"
     classnames: "npm:^2.2.6"
     rc-util: "npm:^5.17.0"
   peerDependencies:
     react: ">=16.11.0"
     react-dom: ">=16.11.0"
-  checksum: 10/b9d65a4deda9dda043c54630ca000f847ff257c1433f3cbf19c81bef1dbfb005528583078976a17ea3dfaca550a267dade39fb0f9aa4b7a17cc76dff1ba30c45
+  checksum: 10/92aa4b13abf7814b5a692d9a902ea2c282289fb8a2a4325a28c8e6cb6f07ffda3e0c3bed64702bf9ddda3acb94f31337649af2e7024c13664ab4f2df4610ff80
   languageName: node
   linkType: hard
 
-"rc-field-form@npm:~1.41.0":
-  version: 1.41.0
-  resolution: "rc-field-form@npm:1.41.0"
+"rc-field-form@npm:~2.0.0":
+  version: 2.0.1
+  resolution: "rc-field-form@npm:2.0.1"
   dependencies:
     "@babel/runtime": "npm:^7.18.0"
-    async-validator: "npm:^4.1.0"
+    "@rc-component/async-validator": "npm:^5.0.3"
     rc-util: "npm:^5.32.2"
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/62a7c47a4426050d113caae087b56396736a1d4518c98a9fe2c604314ab8779a3b4b2a12fdc960f64c933051f36bdad1f2049b6318e06d00d71de1824818fe7d
+  checksum: 10/d38a7363e57a6f5b173e47d58d1ee1a98254db7c2e14a4f59c11436b79d162360c63bbf7e7bc62b8fa53abd4c70cbd57c0e9bc7dcc81ad7f28d17ae86d77b294
   languageName: node
   linkType: hard
 
-"rc-image@npm:~7.5.1":
-  version: 7.5.1
-  resolution: "rc-image@npm:7.5.1"
+"rc-image@npm:~7.6.0":
+  version: 7.6.0
+  resolution: "rc-image@npm:7.6.0"
   dependencies:
     "@babel/runtime": "npm:^7.11.2"
     "@rc-component/portal": "npm:^1.0.2"
     classnames: "npm:^2.2.6"
-    rc-dialog: "npm:~9.3.4"
+    rc-dialog: "npm:~9.4.0"
     rc-motion: "npm:^2.6.2"
     rc-util: "npm:^5.34.1"
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/c9d5f8fe1ba5db4f51e4dd527a996ec93eb85b970b3fc0e3dc327665edd06fd2ed169161c1276aa1e798dc9d1bcf7a011baf10c5b34445d907922d3ae79bc403
+  checksum: 10/7452ac4d946edd806cbd81bd19db427639438dcc7f73c61de8929d2c604dc69c8960ed589685095ec9d183b009872aa53146ae7a63e2d5c1f8fdf2c1d1390f67
   languageName: node
   linkType: hard
 
-"rc-input-number@npm:~8.6.1":
-  version: 8.6.1
-  resolution: "rc-input-number@npm:8.6.1"
+"rc-input-number@npm:~9.0.0":
+  version: 9.0.0
+  resolution: "rc-input-number@npm:9.0.0"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
     "@rc-component/mini-decimal": "npm:^1.0.1"
@@ -13088,11 +13109,11 @@ __metadata:
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/5d63ebcf6cd5198ee974675bc552482f7496a230253abb246a6b5b7e8febb444959dd4c137bb1d4ad78fc6abf42d273ff5d8477789651fd111dd25f71d0b4ff2
+  checksum: 10/5b02990b351dc214f75b68c74e815b26e44c134932fcf264c635ff7a2fb9f2fd8636300a5285b8a1dc042c96a3f2e64ea59ba8aa0bf10e81abcf0ae1f7c9f167
   languageName: node
   linkType: hard
 
-"rc-input@npm:~1.4.0, rc-input@npm:~1.4.3":
+"rc-input@npm:~1.4.0, rc-input@npm:~1.4.5":
   version: 1.4.5
   resolution: "rc-input@npm:1.4.5"
   dependencies:
@@ -13106,30 +13127,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-mentions@npm:~2.10.1":
-  version: 2.10.1
-  resolution: "rc-mentions@npm:2.10.1"
+"rc-mentions@npm:~2.11.1":
+  version: 2.11.1
+  resolution: "rc-mentions@npm:2.11.1"
   dependencies:
     "@babel/runtime": "npm:^7.22.5"
-    "@rc-component/trigger": "npm:^1.5.0"
+    "@rc-component/trigger": "npm:^2.0.0"
     classnames: "npm:^2.2.6"
     rc-input: "npm:~1.4.0"
-    rc-menu: "npm:~9.12.0"
+    rc-menu: "npm:~9.13.0"
     rc-textarea: "npm:~1.6.1"
     rc-util: "npm:^5.34.1"
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/597b440e96e0d5f411928088262423e2725c48c3ba34096cf62a843fe79d98c93e81f471cad40dc68435b97053c3c80f22dbc03ef0520224d610874e259c9af4
+  checksum: 10/5bf5a69008467cbb613c5d327824318fe8181466c6f352c71bd9bc9076d772c098940b7322373c7b9326dacc8dc5dd14e6feca8a5d0be506cbd061bb1f05b061
   languageName: node
   linkType: hard
 
-"rc-menu@npm:~9.12.0, rc-menu@npm:~9.12.4":
-  version: 9.12.4
-  resolution: "rc-menu@npm:9.12.4"
+"rc-menu@npm:~9.13.0":
+  version: 9.13.0
+  resolution: "rc-menu@npm:9.13.0"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
-    "@rc-component/trigger": "npm:^1.17.0"
+    "@rc-component/trigger": "npm:^2.0.0"
     classnames: "npm:2.x"
     rc-motion: "npm:^2.4.3"
     rc-overflow: "npm:^1.3.1"
@@ -13137,7 +13158,7 @@ __metadata:
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/5c4b5a4e8afb6f6fed20f483023e9ca7bca814b183deeac49b7a94ae6adc1934de38d7ffd205258b70c26eeb0e945f543ce3d60b83e8c4c10037043166a6cbd0
+  checksum: 10/afabaadadf662b67461bd7a6bfce982fdc0d6093e3e3d86049cd070e0acd7cd7c68fe76aaa59c7accda6fae657d7eec500728c717c82ea843f7eb58d60b8b30e
   languageName: node
   linkType: hard
 
@@ -13155,9 +13176,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-notification@npm:~5.3.0":
-  version: 5.3.0
-  resolution: "rc-notification@npm:5.3.0"
+"rc-notification@npm:~5.4.0":
+  version: 5.4.0
+  resolution: "rc-notification@npm:5.4.0"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
     classnames: "npm:2.x"
@@ -13166,11 +13187,11 @@ __metadata:
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/ef02031b469374a664481c8b29a2a45763a9f38f5fdafbde89638f81db936cd65a866e59ed160730a13354a46cb288a7b43f798c096c52a4e4ab797cb2e3ae1c
+  checksum: 10/ab31506b55df40b03638abffcad434ffd6684253b117543d2254a785e57db284d0be074fca8ab36172813e776a591f2f0e373a6b6058ae9732a626d5237b2e15
   languageName: node
   linkType: hard
 
-"rc-overflow@npm:^1.3.1":
+"rc-overflow@npm:^1.3.1, rc-overflow@npm:^1.3.2":
   version: 1.3.2
   resolution: "rc-overflow@npm:1.3.2"
   dependencies:
@@ -13199,14 +13220,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-picker@npm:~3.14.6":
-  version: 3.14.7
-  resolution: "rc-picker@npm:3.14.7"
+"rc-picker@npm:~4.5.0":
+  version: 4.5.0
+  resolution: "rc-picker@npm:4.5.0"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
-    "@rc-component/trigger": "npm:^1.5.0"
+    "@rc-component/trigger": "npm:^2.0.0"
     classnames: "npm:^2.2.1"
-    rc-util: "npm:^5.30.0"
+    rc-overflow: "npm:^1.3.2"
+    rc-resize-observer: "npm:^1.4.0"
+    rc-util: "npm:^5.38.1"
   peerDependencies:
     date-fns: ">= 2.x"
     dayjs: ">= 1.x"
@@ -13223,13 +13246,13 @@ __metadata:
       optional: true
     moment:
       optional: true
-  checksum: 10/0fe1bf73d17f480df3d76fd925dbf26dabaee5bd7c1f4c72a72c1010809cdb6b999ab8eec6acd670cd9729a3f2b57fd75e3f88f45b5840a78aab4e04ad611ed9
+  checksum: 10/6d4fa172a38ed0dada38a96a34df39ea8d7c3a555f9f26c033222936c8ec7a960a27ca0f8a6ae71cee9b833c4b032762093e6f789f3b6c5235b35f0a14d0679e
   languageName: node
   linkType: hard
 
-"rc-progress@npm:~3.5.1":
-  version: 3.5.1
-  resolution: "rc-progress@npm:3.5.1"
+"rc-progress@npm:~4.0.0":
+  version: 4.0.0
+  resolution: "rc-progress@npm:4.0.0"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
     classnames: "npm:^2.2.6"
@@ -13237,7 +13260,7 @@ __metadata:
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/e6e34acdec07443ef850ddd12e0678533ff706ea4f7d2fa3d500df76aeafdf08f5297353e902d891f354c464931a69b3d568f4e17204436d3a6d30b37a241bb8
+  checksum: 10/c65efbc45fced051715647538c1ebe70a6da761ca6691455d72d38dcbba41d5bb5e7f7de38d4bb8e8939645a2cd120e8d5b2b8690b6d6bb4fa4cf6848700a2d8
   languageName: node
   linkType: hard
 
@@ -13270,9 +13293,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-segmented@npm:~2.2.2":
-  version: 2.2.2
-  resolution: "rc-segmented@npm:2.2.2"
+"rc-segmented@npm:~2.3.0":
+  version: 2.3.0
+  resolution: "rc-segmented@npm:2.3.0"
   dependencies:
     "@babel/runtime": "npm:^7.11.1"
     classnames: "npm:^2.2.1"
@@ -13281,16 +13304,16 @@ __metadata:
   peerDependencies:
     react: ">=16.0.0"
     react-dom: ">=16.0.0"
-  checksum: 10/9622336ccb966bc8a0397ccb9cf9e2e05abad2bc448e229390be7a79f40f2a8853d3109b50670b7c0a920c759d5c16be3f9c39b603c83310f39d5f49358107eb
+  checksum: 10/4cacfc629f547c6d2a159e91808c718f3bcf7dce1d5ebb05419766c72ea34de09b1ac8648e80dfc26fd8f3a8f760296f979723d8841f65dfa6fc20e930203449
   languageName: node
   linkType: hard
 
-"rc-select@npm:~14.11.0, rc-select@npm:~14.11.0-0":
-  version: 14.11.0
-  resolution: "rc-select@npm:14.11.0"
+"rc-select@npm:~14.13.0, rc-select@npm:~14.13.1":
+  version: 14.13.4
+  resolution: "rc-select@npm:14.13.4"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
-    "@rc-component/trigger": "npm:^1.5.0"
+    "@rc-component/trigger": "npm:^2.1.1"
     classnames: "npm:2.x"
     rc-motion: "npm:^2.0.1"
     rc-overflow: "npm:^1.3.1"
@@ -13299,21 +13322,21 @@ __metadata:
   peerDependencies:
     react: "*"
     react-dom: "*"
-  checksum: 10/2d0cbb41c50c7f1bbee0787b93e5879a683db6b9e609754d8b6c468592db504a34c3618b1d3bbdead9ae9084439454a36d06ca5bbfc9098ac70c6146a3478fd2
+  checksum: 10/9c7aa2aeb52377a2b313b6a9c502d3a888595546a250f65ddae0b2c9c5480f2a354b887a665e1b8111ef59ed78b0ec0356d1f55ae16db56d70f32b30cde4c03e
   languageName: node
   linkType: hard
 
-"rc-slider@npm:~10.5.0":
-  version: 10.5.0
-  resolution: "rc-slider@npm:10.5.0"
+"rc-slider@npm:~10.6.2":
+  version: 10.6.2
+  resolution: "rc-slider@npm:10.6.2"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
     classnames: "npm:^2.2.5"
-    rc-util: "npm:^5.27.0"
+    rc-util: "npm:^5.36.0"
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/9fe5b45a0e199311d665312e9940a59e007b81bfdd868cfecb70f4f95299b5447ee2a7c5a4c90a0ee7bbffad9dfa73cc01c779946adc4ca4fe22d2cf02bac046
+  checksum: 10/ee5ec34fe940487a44cb03e89abf4199cbae990a334756fa9536a158d3a790cb7c1ebf321fc8048050a0cefa86138e097eb11bcc135bdb10db287b0738370790
   languageName: node
   linkType: hard
 
@@ -13345,38 +13368,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-table@npm:~7.37.0":
-  version: 7.37.0
-  resolution: "rc-table@npm:7.37.0"
+"rc-table@npm:~7.45.5":
+  version: 7.45.7
+  resolution: "rc-table@npm:7.45.7"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
     "@rc-component/context": "npm:^1.4.0"
     classnames: "npm:^2.2.5"
     rc-resize-observer: "npm:^1.1.0"
     rc-util: "npm:^5.37.0"
-    rc-virtual-list: "npm:^3.11.1"
+    rc-virtual-list: "npm:^3.14.2"
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/6ea27fdaff95bde3854555f6bc28a828a25126c72d5a7a2f0f7da95d2d5c9b70f8580b3c6a5e2dbe5493ed1ab927033cdfe3f56ed45695134fb6c744424c4629
+  checksum: 10/5193406895f826bbe66dd0efaffe90eb7b33dac69445fdae2df40a98133207360adeeb43a9f0221ff9bbaf9a1ecdff300ee5f17c3c9245580b5c6a113a685c9e
   languageName: node
   linkType: hard
 
-"rc-tabs@npm:~14.0.0":
-  version: 14.0.0
-  resolution: "rc-tabs@npm:14.0.0"
+"rc-tabs@npm:~15.0.0 ":
+  version: 15.0.0
+  resolution: "rc-tabs@npm:15.0.0"
   dependencies:
     "@babel/runtime": "npm:^7.11.2"
     classnames: "npm:2.x"
-    rc-dropdown: "npm:~4.1.0"
-    rc-menu: "npm:~9.12.0"
+    rc-dropdown: "npm:~4.2.0"
+    rc-menu: "npm:~9.13.0"
     rc-motion: "npm:^2.6.2"
     rc-resize-observer: "npm:^1.0.0"
     rc-util: "npm:^5.34.1"
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/2749eace691dd1344a92e465b24304feb6d34746f99c7f388cb4d226a63caded397ffb97398def753c1ddead801b613804cf3fe5e6acf1d62159066cd59c7ca0
+  checksum: 10/0db4b6491635c0dbffd9404c702732c3b63c5f3e49ecffbaa9ec2bee22fb52584c133ef3c52c6fa343dcdb2b0bab406450470cae4132965613e055d95c1066f9
   languageName: node
   linkType: hard
 
@@ -13396,37 +13419,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-tooltip@npm:~6.1.3":
-  version: 6.1.3
-  resolution: "rc-tooltip@npm:6.1.3"
+"rc-tooltip@npm:~6.2.0":
+  version: 6.2.0
+  resolution: "rc-tooltip@npm:6.2.0"
   dependencies:
     "@babel/runtime": "npm:^7.11.2"
-    "@rc-component/trigger": "npm:^1.18.0"
+    "@rc-component/trigger": "npm:^2.0.0"
     classnames: "npm:^2.3.1"
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/cf98afe8ad44d5fa9e68ba33e58a763d63a66239c947a2a4ef90bd74ec480466ed876bb2c29b9e1203ff35e728f2b641aa8067fcbfd21fdbbb37b1a7b13d55dc
+  checksum: 10/2be8fd3da8666df1d83485e5532e11eacf4dd3686efed9b4f0bc78caeb647196cac62104e54b9ce5dbc3051a9df70e07e54557f3273b632bb474a73c8bca0a2d
   languageName: node
   linkType: hard
 
-"rc-tree-select@npm:~5.17.0":
-  version: 5.17.0
-  resolution: "rc-tree-select@npm:5.17.0"
+"rc-tree-select@npm:~5.20.0":
+  version: 5.20.0
+  resolution: "rc-tree-select@npm:5.20.0"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
     classnames: "npm:2.x"
-    rc-select: "npm:~14.11.0-0"
+    rc-select: "npm:~14.13.0"
     rc-tree: "npm:~5.8.1"
     rc-util: "npm:^5.16.1"
   peerDependencies:
     react: "*"
     react-dom: "*"
-  checksum: 10/b9b22057265812837655ba4938fcbe550bfc987715053f0cf6ea1f8ced1b1b5c3da1bc4d7e4e64f2bf1bc5b079e1bc412aa3e42c763fe80165638bed8b89053f
+  checksum: 10/ba701485168ee86ccd322a828c2818512bb879a913fb858887bcbbb2635d077d5d725fc3fb270f3ee4933aceab3ca0d31c712583f86f4bac884596e90338ee65
   languageName: node
   linkType: hard
 
-"rc-tree@npm:~5.8.1, rc-tree@npm:~5.8.2":
+"rc-tree@npm:~5.8.1, rc-tree@npm:~5.8.5":
   version: 5.8.8
   resolution: "rc-tree@npm:5.8.8"
   dependencies:
@@ -13469,7 +13492,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-util@npm:^5.28.0, rc-util@npm:^5.38.1":
+"rc-util@npm:^5.28.0, rc-util@npm:^5.39.1":
+  version: 5.43.0
+  resolution: "rc-util@npm:5.43.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.18.3"
+    react-is: "npm:^18.2.0"
+  peerDependencies:
+    react: ">=16.9.0"
+    react-dom: ">=16.9.0"
+  checksum: 10/6d5be9d79182c6b4c5a033ad6517b2940d3d2ac42a8e77ef5735591d182f8236f61bc7628d61e82a122d2046ec849462f3fe57c08d3a2a20279646785c34ec4a
+  languageName: node
+  linkType: hard
+
+"rc-util@npm:^5.38.1":
   version: 5.42.1
   resolution: "rc-util@npm:5.42.1"
   dependencies:
@@ -13482,7 +13518,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-virtual-list@npm:^3.11.1, rc-virtual-list@npm:^3.5.1, rc-virtual-list@npm:^3.5.2":
+"rc-virtual-list@npm:^3.14.2":
+  version: 3.14.5
+  resolution: "rc-virtual-list@npm:3.14.5"
+  dependencies:
+    "@babel/runtime": "npm:^7.20.0"
+    classnames: "npm:^2.2.6"
+    rc-resize-observer: "npm:^1.0.0"
+    rc-util: "npm:^5.36.0"
+  peerDependencies:
+    react: ">=16.9.0"
+    react-dom: ">=16.9.0"
+  checksum: 10/6e5b8030d1ac8fff49cefc97d5ec5284e4fe0f2712a362ac52dd228379769eaa82bfe29c00336c871cdad19f73d1a88390dc6e016ae2bc1042e831f62ad6f39d
+  languageName: node
+  linkType: hard
+
+"rc-virtual-list@npm:^3.5.1, rc-virtual-list@npm:^3.5.2":
   version: 3.14.2
   resolution: "rc-virtual-list@npm:3.14.2"
   dependencies:
@@ -14899,10 +14950,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stylis@npm:^4.0.13":
-  version: 4.3.2
-  resolution: "stylis@npm:4.3.2"
-  checksum: 10/4d3e3cb5cbfc7abdf14e424c8631a15fd15cbf0357ffc641c319587e00c2d1036b1a71cb88b42411bc3ce10d7730ad3fb9789b034d11365e8a19d23f56486c77
+"stylis@npm:^4.3.3":
+  version: 4.3.4
+  resolution: "stylis@npm:4.3.4"
+  checksum: 10/69b902a3c9fc3329c8ddb18d422f8130068356dd4d4a20ae245953679cc88ae08d49c55e32b0b57c8fe8a76f2ed7f32697240b8db4d368a25fc2db045ebaeba8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! -->

### Description

Remove extra padding from buttons with only icon.

I've also updated antd to v5.17 to leverage the new `Button#iconPosition` prop and remove our custom code

### Checklist

<!-- For further details regarding standards and conventions adopted in this repository please take a look at the CONTRIBUTING.md file. -->

- [x] commit message and branch name follow conventions
- [x] tests are included
- [x] changes are accessible and documented from components stories
- [x] typings are updated or integrated accordingly with your changes
- [x] all added components are exported from index file (if necessary)
- [x] all added files include Apache 2.0 license
- [x] you are not committing extraneous files or sensitive data
- [x] the browser console does not have any logged errors
- [x] necessary labels have been applied to this pull request (enhancement, bug, ecc.)
