### PR TITLE
fixed fullscreen modal regression with antd 5.13->5.17 update

### DIFF
--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -186,6 +186,11 @@
   height: 100% !important;
   max-width: 100%;
 
+  > div {
+    width: 100%;
+    height: 100%;
+  }
+
   :global(.mia-platform-modal-content) {
     border-radius: 0;
   }

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -186,13 +186,9 @@
   height: 100% !important;
   max-width: 100%;
 
-  > div {
-    width: 100%;
-    height: 100%;
-  }
-
   :global(.mia-platform-modal-content) {
     border-radius: 0;
+    height: 100vh;
   }
 }
 


### PR DESCRIPTION
The update of the Ant Design library from version 5.13 to 5.17 in [this commit](https://github.com/mia-platform/design-system/commit/016533a47b8a97f6ac38f3fc10a6ba6ed669cf28#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L50) has secretly changed the implementation of the Ant modal by adding an extra wrapper around the ant-modal-content element. The CSS fix present here restores the correct functionality of the fullscreen modal.

<img width="1679" alt="Screenshot 2024-09-03 alle 12 03 00" src="https://github.com/user-attachments/assets/ac7baecc-8530-4456-9bbf-2bcb7173db2c">
