### PR TITLE
fix(modal): height issue due to antd version upgrade

### DIFF
--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -188,7 +188,6 @@
 
   :global(.mia-platform-modal-content) {
     border-radius: 0;
-    height: 100vh;
   }
 }
 

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -20,6 +20,10 @@
   padding-bottom: 0;
   overflow: hidden;
 
+  :global(div:has(> div.mia-platform-modal-content)) {
+    height: 100%;
+  }
+
   :global(.mia-platform-modal-close) {
     top: unset;
     inset-inline-end: var(--spacing-padding-xl, 24px);


### PR DESCRIPTION
### Context

The upgrade of the Ant Design library from version 5.13 to 5.17 in [this commit](https://github.com/mia-platform/design-system/commit/016533a47b8a97f6ac38f3fc10a6ba6ed669cf28#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L50) introduced a different version of `rc-dialog`, which places an additional wrapper around dialogs.

![image](https://github.com/user-attachments/assets/47fe1101-e030-415d-a1fc-429495094ce6) 

This wrapper does not have a specified height, preventing all children from adapting their height to previous ancestors.
The new element is inserted as the direct parent of our `.mia-platform-modal-content` node, so the new style introduced by this PR fixes the issue.

### Addressed issue

Closes #596

### Checklist

<!-- For further details regarding standards and conventions adopted in this repository please take a look at the CONTRIBUTING.md file. -->

- [x] commit message and branch name follow conventions
- [ ] tests are included
- [ ] changes are accessible and documented from components stories
- [ ] typings are updated or integrated accordingly with your changes
- [ ] all added components are exported from index file (if necessary)
- [ ] all added files include Apache 2.0 license
- [x] you are not committing extraneous files or sensitive data
- [x] the browser console does not have any logged errors
- [ ] necessary labels have been applied to this pull request (enhancement, bug, ecc.)
