### PR TITLE
fix(Modal, Theme Provider): theme variables propagation to outer nodes issue

### DIFF
--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -17,7 +17,7 @@
  */
 
 import { asideFixed, asideOpenable, docLink, footer, footerCustom, title } from './Modal.mocks'
-import { fireEvent, render, screen, waitFor } from '../../test-utils'
+import { fireEvent, render, screen, waitFor, within } from '../../test-utils'
 import { Modal } from '.'
 
 const props = {
@@ -148,5 +148,18 @@ describe('Modal Component', () => {
     expect(screen.getByText(/Modal Aside Content/i)).toBeVisible()
 
     expect(baseElement).toMatchSnapshot()
+  })
+
+  test('renders modal inside specified container node', () => {
+    render(
+      <>
+        <div data-testid="container-div-test-id" id="container-div" />
+        <Modal {...props} getContainer={() => document.getElementById('container-div') || document.body} />
+      </>
+    )
+
+    const container = screen.getByTestId('container-div-test-id')
+    expect(container).toBeInTheDocument()
+    expect(within(container).getByRole('dialog')).toBeInTheDocument()
   })
 })

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -24,11 +24,12 @@ import { Body } from './Modal.Body'
 import { Footer } from './Modal.Footer'
 import { ModalProps } from './Modal.props'
 import { Size } from './Modal.types'
-import { THEME_PROVIDER_STYLE_WRAPPER_NODE } from '../ThemeProvider/ThemeProvider'
+import { ThemeProvider } from '../ThemeProvider'
 import { Title } from './Modal.Title'
 import styles from './Modal.module.css'
 
 const { Small, Large, FullScreen } = Size
+const { StyleWrapperId } = ThemeProvider
 const {
   modal,
   modalSm,
@@ -74,7 +75,7 @@ export const Modal = ({
   ]), [size])
 
   const getContainerFallback = useCallback(() => {
-    return document.getElementById(THEME_PROVIDER_STYLE_WRAPPER_NODE) || document.body
+    return document.getElementById(StyleWrapperId) || document.body
   }, [])
 
   return (

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ReactElement, useMemo } from 'react'
+import { ReactElement, useCallback, useMemo } from 'react'
 import { Modal as AntModal } from 'antd'
 import classNames from 'classnames'
 
@@ -24,6 +24,7 @@ import { Body } from './Modal.Body'
 import { Footer } from './Modal.Footer'
 import { ModalProps } from './Modal.props'
 import { Size } from './Modal.types'
+import { THEME_PROVIDER_STYLE_WRAPPER_NODE } from '../ThemeProvider/ThemeProvider'
 import { Title } from './Modal.Title'
 import styles from './Modal.module.css'
 
@@ -72,6 +73,10 @@ export const Modal = ({
     size === FullScreen && modalFs,
   ]), [size])
 
+  const getContainerFallback = useCallback(() => {
+    return document.getElementById(THEME_PROVIDER_STYLE_WRAPPER_NODE) || document.body
+  }, [])
+
   return (
     <AntModal
       centered
@@ -79,7 +84,7 @@ export const Modal = ({
       closable={isClosable}
       destroyOnClose={destroyOnClose}
       footer={<Modal.Footer footer={footer} />}
-      getContainer={getContainer}
+      getContainer={getContainer || getContainerFallback}
       keyboard={isClosable}
       maskClosable={isClosable && isMaskClosable}
       open={isVisible}

--- a/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -9,131 +9,129 @@ exports[`Modal Component does not render modal in case it is not visible 1`] = `
 exports[`Modal Component renders fullscreen modal correctly (with empty header) 1`] = `
 <body>
   <div />
-  <div>
+  <div
+    class="mia-platform-modal-root"
+  >
     <div
-      class="mia-platform-modal-root"
+      class="mia-platform-modal-mask"
+    />
+    <div
+      class="mia-platform-modal-wrap mia-platform-modal-centered"
+      tabindex="-1"
     >
       <div
-        class="mia-platform-modal-mask"
-      />
-      <div
-        class="mia-platform-modal-wrap mia-platform-modal-centered"
-        tabindex="-1"
+        aria-labelledby="test-id"
+        aria-modal="true"
+        class="mia-platform-modal modal modalFs"
+        role="dialog"
+        style="width: 520px;"
       >
         <div
-          aria-labelledby="test-id"
-          aria-modal="true"
-          class="mia-platform-modal modal modalFs"
-          role="dialog"
-          style="width: 520px;"
+          aria-hidden="true"
+          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
+          tabindex="0"
+        />
+        <div
+          style="outline: none;"
+          tabindex="-1"
         >
           <div
-            aria-hidden="true"
-            style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-            tabindex="0"
-          />
-          <div
-            style="outline: none;"
-            tabindex="-1"
+            class="mia-platform-modal-content"
           >
-            <div
-              class="mia-platform-modal-content"
+            <button
+              aria-label="Close"
+              class="mia-platform-modal-close"
+              type="button"
             >
-              <button
-                aria-label="Close"
-                class="mia-platform-modal-close"
-                type="button"
+              <span
+                class="mia-platform-modal-close-x"
               >
                 <span
-                  class="mia-platform-modal-close-x"
+                  aria-label="close"
+                  class="anticon anticon-close mia-platform-modal-close-icon"
+                  role="img"
                 >
-                  <span
-                    aria-label="close"
-                    class="anticon anticon-close mia-platform-modal-close-icon"
-                    role="img"
+                  <svg
+                    aria-hidden="true"
+                    data-icon="close"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
                   >
-                    <svg
-                      aria-hidden="true"
-                      data-icon="close"
-                      fill="currentColor"
-                      fill-rule="evenodd"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-                      />
-                    </svg>
-                  </span>
+                    <path
+                      d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                    />
+                  </svg>
                 </span>
-              </button>
+              </span>
+            </button>
+            <div
+              class="mia-platform-modal-header"
+            >
               <div
-                class="mia-platform-modal-header"
+                class="mia-platform-modal-title"
+                id="test-id"
               >
                 <div
-                  class="mia-platform-modal-title"
-                  id="test-id"
+                  class="title"
+                />
+              </div>
+            </div>
+            <div
+              class="mia-platform-modal-body"
+            >
+              <div
+                class="body"
+              >
+                <div
+                  class="content"
                 >
-                  <div
-                    class="title"
-                  />
+                  Modal Content
                 </div>
               </div>
+            </div>
+            <div
+              class="mia-platform-modal-footer"
+            >
               <div
-                class="mia-platform-modal-body"
+                class="footer"
               >
                 <div
-                  class="body"
+                  class="footerButtons"
                 >
-                  <div
-                    class="content"
+                  <button
+                    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+                    type="button"
                   >
-                    Modal Content
-                  </div>
-                </div>
-              </div>
-              <div
-                class="mia-platform-modal-footer"
-              >
-                <div
-                  class="footer"
-                >
-                  <div
-                    class="footerButtons"
+                    <div
+                      class="buttonText"
+                    >
+                      OK
+                    </div>
+                  </button>
+                  <button
+                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                    type="button"
                   >
-                    <button
-                      class="mia-platform-btn mia-platform-btn-primary button buttonMd"
-                      type="button"
+                    <div
+                      class="buttonText"
                     >
-                      <div
-                        class="buttonText"
-                      >
-                        OK
-                      </div>
-                    </button>
-                    <button
-                      class="mia-platform-btn mia-platform-btn-default button buttonMd"
-                      type="button"
-                    >
-                      <div
-                        class="buttonText"
-                      >
-                        Cancel
-                      </div>
-                    </button>
-                  </div>
+                      Cancel
+                    </div>
+                  </button>
                 </div>
               </div>
             </div>
           </div>
-          <div
-            aria-hidden="true"
-            style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-            tabindex="0"
-          />
         </div>
+        <div
+          aria-hidden="true"
+          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
+          tabindex="0"
+        />
       </div>
     </div>
   </div>
@@ -143,144 +141,142 @@ exports[`Modal Component renders fullscreen modal correctly (with empty header) 
 exports[`Modal Component renders large modal correctly (with empty footer) 1`] = `
 <body>
   <div />
-  <div>
+  <div
+    class="mia-platform-modal-root"
+  >
     <div
-      class="mia-platform-modal-root"
+      class="mia-platform-modal-mask"
+    />
+    <div
+      class="mia-platform-modal-wrap mia-platform-modal-centered"
+      tabindex="-1"
     >
       <div
-        class="mia-platform-modal-mask"
-      />
-      <div
-        class="mia-platform-modal-wrap mia-platform-modal-centered"
-        tabindex="-1"
+        aria-labelledby="test-id"
+        aria-modal="true"
+        class="mia-platform-modal modal modalLg"
+        role="dialog"
+        style="width: 520px;"
       >
         <div
-          aria-labelledby="test-id"
-          aria-modal="true"
-          class="mia-platform-modal modal modalLg"
-          role="dialog"
-          style="width: 520px;"
+          aria-hidden="true"
+          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
+          tabindex="0"
+        />
+        <div
+          style="outline: none;"
+          tabindex="-1"
         >
           <div
-            aria-hidden="true"
-            style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-            tabindex="0"
-          />
-          <div
-            style="outline: none;"
-            tabindex="-1"
+            class="mia-platform-modal-content"
           >
-            <div
-              class="mia-platform-modal-content"
+            <button
+              aria-label="Close"
+              class="mia-platform-modal-close"
+              type="button"
             >
-              <button
-                aria-label="Close"
-                class="mia-platform-modal-close"
-                type="button"
+              <span
+                class="mia-platform-modal-close-x"
               >
                 <span
-                  class="mia-platform-modal-close-x"
+                  aria-label="close"
+                  class="anticon anticon-close mia-platform-modal-close-icon"
+                  role="img"
                 >
-                  <span
-                    aria-label="close"
-                    class="anticon anticon-close mia-platform-modal-close-icon"
-                    role="img"
+                  <svg
+                    aria-hidden="true"
+                    data-icon="close"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
                   >
-                    <svg
-                      aria-hidden="true"
-                      data-icon="close"
-                      fill="currentColor"
-                      fill-rule="evenodd"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-                      />
-                    </svg>
-                  </span>
+                    <path
+                      d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                    />
+                  </svg>
                 </span>
-              </button>
+              </span>
+            </button>
+            <div
+              class="mia-platform-modal-header"
+            >
               <div
-                class="mia-platform-modal-header"
+                class="mia-platform-modal-title"
+                id="test-id"
               >
                 <div
-                  class="mia-platform-modal-title"
-                  id="test-id"
+                  class="title"
                 >
-                  <div
-                    class="title"
+                  <h4
+                    aria-label="Modal Title"
+                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
+                    role="h4"
                   >
-                    <h4
-                      aria-label="Modal Title"
-                      class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
-                      role="h4"
+                    Modal Title
+                  </h4>
+                  <div
+                    class="docLink"
+                  >
+                    <button
+                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+                      type="button"
                     >
-                      Modal Title
-                    </h4>
-                    <div
-                      class="docLink"
-                    >
-                      <button
-                        class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
-                        type="button"
+                      <span
+                        class="mia-platform-btn-icon"
                       >
-                        <span
-                          class="mia-platform-btn-icon"
+                        <svg
+                          aria-label="PiBookOpen"
+                          color="#004aaa"
+                          fill="currentColor"
+                          height="16"
+                          role="img"
+                          stroke="currentColor"
+                          stroke-width="0"
+                          style="color: rgb(0, 74, 170);"
+                          viewBox="0 0 256 256"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <svg
-                            aria-label="PiBookOpen"
-                            color="#004aaa"
-                            fill="currentColor"
-                            height="16"
-                            role="img"
-                            stroke="currentColor"
-                            stroke-width="0"
-                            style="color: rgb(0, 74, 170);"
-                            viewBox="0 0 256 256"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M232,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H24a8,8,0,0,0-8,8V200a8,8,0,0,0,8,8H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h72a8,8,0,0,0,8-8V56A8,8,0,0,0,232,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
-                            />
-                          </svg>
-                        </span>
-                      </button>
-                    </div>
+                          <path
+                            d="M232,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H24a8,8,0,0,0-8,8V200a8,8,0,0,0,8,8H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h72a8,8,0,0,0,8-8V56A8,8,0,0,0,232,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
+                          />
+                        </svg>
+                      </span>
+                    </button>
                   </div>
                 </div>
-              </div>
-              <div
-                class="mia-platform-modal-body"
-              >
-                <div
-                  class="body"
-                >
-                  <div
-                    class="content"
-                  >
-                    Modal Content
-                  </div>
-                </div>
-              </div>
-              <div
-                class="mia-platform-modal-footer"
-              >
-                <div
-                  class="footer"
-                />
               </div>
             </div>
+            <div
+              class="mia-platform-modal-body"
+            >
+              <div
+                class="body"
+              >
+                <div
+                  class="content"
+                >
+                  Modal Content
+                </div>
+              </div>
+            </div>
+            <div
+              class="mia-platform-modal-footer"
+            >
+              <div
+                class="footer"
+              />
+            </div>
           </div>
-          <div
-            aria-hidden="true"
-            style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-            tabindex="0"
-          />
         </div>
+        <div
+          aria-hidden="true"
+          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
+          tabindex="0"
+        />
       </div>
     </div>
   </div>
@@ -290,182 +286,180 @@ exports[`Modal Component renders large modal correctly (with empty footer) 1`] =
 exports[`Modal Component renders modal with aside fixed 1`] = `
 <body>
   <div />
-  <div>
+  <div
+    class="mia-platform-modal-root"
+  >
     <div
-      class="mia-platform-modal-root"
+      class="mia-platform-modal-mask"
+    />
+    <div
+      class="mia-platform-modal-wrap mia-platform-modal-centered"
+      tabindex="-1"
     >
       <div
-        class="mia-platform-modal-mask"
-      />
-      <div
-        class="mia-platform-modal-wrap mia-platform-modal-centered"
-        tabindex="-1"
+        aria-labelledby="test-id"
+        aria-modal="true"
+        class="mia-platform-modal modal modalLg"
+        role="dialog"
+        style="width: 520px;"
       >
         <div
-          aria-labelledby="test-id"
-          aria-modal="true"
-          class="mia-platform-modal modal modalLg"
-          role="dialog"
-          style="width: 520px;"
+          aria-hidden="true"
+          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
+          tabindex="0"
+        />
+        <div
+          style="outline: none;"
+          tabindex="-1"
         >
           <div
-            aria-hidden="true"
-            style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-            tabindex="0"
-          />
-          <div
-            style="outline: none;"
-            tabindex="-1"
+            class="mia-platform-modal-content"
           >
-            <div
-              class="mia-platform-modal-content"
+            <button
+              aria-label="Close"
+              class="mia-platform-modal-close"
+              type="button"
             >
-              <button
-                aria-label="Close"
-                class="mia-platform-modal-close"
-                type="button"
+              <span
+                class="mia-platform-modal-close-x"
               >
                 <span
-                  class="mia-platform-modal-close-x"
+                  aria-label="close"
+                  class="anticon anticon-close mia-platform-modal-close-icon"
+                  role="img"
                 >
-                  <span
-                    aria-label="close"
-                    class="anticon anticon-close mia-platform-modal-close-icon"
-                    role="img"
+                  <svg
+                    aria-hidden="true"
+                    data-icon="close"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
                   >
-                    <svg
-                      aria-hidden="true"
-                      data-icon="close"
-                      fill="currentColor"
-                      fill-rule="evenodd"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-                      />
-                    </svg>
-                  </span>
+                    <path
+                      d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                    />
+                  </svg>
                 </span>
-              </button>
+              </span>
+            </button>
+            <div
+              class="mia-platform-modal-header"
+            >
               <div
-                class="mia-platform-modal-header"
+                class="mia-platform-modal-title"
+                id="test-id"
               >
                 <div
-                  class="mia-platform-modal-title"
-                  id="test-id"
+                  class="title"
                 >
-                  <div
-                    class="title"
+                  <h4
+                    aria-label="Modal Title"
+                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
+                    role="h4"
                   >
-                    <h4
-                      aria-label="Modal Title"
-                      class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
-                      role="h4"
+                    Modal Title
+                  </h4>
+                  <div
+                    class="docLink"
+                  >
+                    <button
+                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+                      type="button"
                     >
-                      Modal Title
-                    </h4>
-                    <div
-                      class="docLink"
-                    >
-                      <button
-                        class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
-                        type="button"
+                      <span
+                        class="mia-platform-btn-icon"
                       >
-                        <span
-                          class="mia-platform-btn-icon"
+                        <svg
+                          aria-label="PiBookOpen"
+                          color="#004aaa"
+                          fill="currentColor"
+                          height="16"
+                          role="img"
+                          stroke="currentColor"
+                          stroke-width="0"
+                          style="color: rgb(0, 74, 170);"
+                          viewBox="0 0 256 256"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <svg
-                            aria-label="PiBookOpen"
-                            color="#004aaa"
-                            fill="currentColor"
-                            height="16"
-                            role="img"
-                            stroke="currentColor"
-                            stroke-width="0"
-                            style="color: rgb(0, 74, 170);"
-                            viewBox="0 0 256 256"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M232,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H24a8,8,0,0,0-8,8V200a8,8,0,0,0,8,8H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h72a8,8,0,0,0,8-8V56A8,8,0,0,0,232,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
-                            />
-                          </svg>
-                        </span>
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="mia-platform-modal-body"
-              >
-                <div
-                  class="body bodyWithAsideOpened"
-                >
-                  <div
-                    class="content"
-                  >
-                    Modal Content
-                  </div>
-                  <aside
-                    class="aside"
-                  >
-                    <div
-                      class="mia-platform-typography bodyM"
-                      role="paragraph"
-                    >
-                      Modal Aside Title
-                    </div>
-                    <div>
-                      Modal Aside Content
-                    </div>
-                  </aside>
-                </div>
-              </div>
-              <div
-                class="mia-platform-modal-footer"
-              >
-                <div
-                  class="footer"
-                >
-                  <div
-                    class="footerButtons"
-                  >
-                    <button
-                      class="mia-platform-btn mia-platform-btn-primary button buttonMd"
-                      type="button"
-                    >
-                      <div
-                        class="buttonText"
-                      >
-                        OK
-                      </div>
-                    </button>
-                    <button
-                      class="mia-platform-btn mia-platform-btn-default button buttonMd"
-                      type="button"
-                    >
-                      <div
-                        class="buttonText"
-                      >
-                        Cancel
-                      </div>
+                          <path
+                            d="M232,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H24a8,8,0,0,0-8,8V200a8,8,0,0,0,8,8H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h72a8,8,0,0,0,8-8V56A8,8,0,0,0,232,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
+                          />
+                        </svg>
+                      </span>
                     </button>
                   </div>
                 </div>
               </div>
             </div>
+            <div
+              class="mia-platform-modal-body"
+            >
+              <div
+                class="body bodyWithAsideOpened"
+              >
+                <div
+                  class="content"
+                >
+                  Modal Content
+                </div>
+                <aside
+                  class="aside"
+                >
+                  <div
+                    class="mia-platform-typography bodyM"
+                    role="paragraph"
+                  >
+                    Modal Aside Title
+                  </div>
+                  <div>
+                    Modal Aside Content
+                  </div>
+                </aside>
+              </div>
+            </div>
+            <div
+              class="mia-platform-modal-footer"
+            >
+              <div
+                class="footer"
+              >
+                <div
+                  class="footerButtons"
+                >
+                  <button
+                    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+                    type="button"
+                  >
+                    <div
+                      class="buttonText"
+                    >
+                      OK
+                    </div>
+                  </button>
+                  <button
+                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                    type="button"
+                  >
+                    <div
+                      class="buttonText"
+                    >
+                      Cancel
+                    </div>
+                  </button>
+                </div>
+              </div>
+            </div>
           </div>
-          <div
-            aria-hidden="true"
-            style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-            tabindex="0"
-          />
         </div>
+        <div
+          aria-hidden="true"
+          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
+          tabindex="0"
+        />
       </div>
     </div>
   </div>
@@ -475,212 +469,210 @@ exports[`Modal Component renders modal with aside fixed 1`] = `
 exports[`Modal Component renders modal with aside openable 1`] = `
 <body>
   <div />
-  <div>
+  <div
+    class="mia-platform-modal-root"
+  >
     <div
-      class="mia-platform-modal-root"
+      class="mia-platform-modal-mask"
+    />
+    <div
+      class="mia-platform-modal-wrap mia-platform-modal-centered"
+      tabindex="-1"
     >
       <div
-        class="mia-platform-modal-mask"
-      />
-      <div
-        class="mia-platform-modal-wrap mia-platform-modal-centered"
-        tabindex="-1"
+        aria-labelledby="test-id"
+        aria-modal="true"
+        class="mia-platform-modal modal modalLg"
+        role="dialog"
+        style="width: 520px;"
       >
         <div
-          aria-labelledby="test-id"
-          aria-modal="true"
-          class="mia-platform-modal modal modalLg"
-          role="dialog"
-          style="width: 520px;"
+          aria-hidden="true"
+          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
+          tabindex="0"
+        />
+        <div
+          style="outline: none;"
+          tabindex="-1"
         >
           <div
-            aria-hidden="true"
-            style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-            tabindex="0"
-          />
-          <div
-            style="outline: none;"
-            tabindex="-1"
+            class="mia-platform-modal-content"
           >
-            <div
-              class="mia-platform-modal-content"
+            <button
+              aria-label="Close"
+              class="mia-platform-modal-close"
+              type="button"
             >
-              <button
-                aria-label="Close"
-                class="mia-platform-modal-close"
-                type="button"
+              <span
+                class="mia-platform-modal-close-x"
               >
                 <span
-                  class="mia-platform-modal-close-x"
+                  aria-label="close"
+                  class="anticon anticon-close mia-platform-modal-close-icon"
+                  role="img"
                 >
-                  <span
-                    aria-label="close"
-                    class="anticon anticon-close mia-platform-modal-close-icon"
-                    role="img"
+                  <svg
+                    aria-hidden="true"
+                    data-icon="close"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
                   >
-                    <svg
-                      aria-hidden="true"
-                      data-icon="close"
-                      fill="currentColor"
-                      fill-rule="evenodd"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-                      />
-                    </svg>
-                  </span>
+                    <path
+                      d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                    />
+                  </svg>
                 </span>
-              </button>
+              </span>
+            </button>
+            <div
+              class="mia-platform-modal-header"
+            >
               <div
-                class="mia-platform-modal-header"
+                class="mia-platform-modal-title"
+                id="test-id"
               >
                 <div
-                  class="mia-platform-modal-title"
-                  id="test-id"
+                  class="title"
                 >
-                  <div
-                    class="title"
+                  <h4
+                    aria-label="Modal Title"
+                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
+                    role="h4"
                   >
-                    <h4
-                      aria-label="Modal Title"
-                      class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
-                      role="h4"
-                    >
-                      Modal Title
-                    </h4>
-                    <div
-                      class="docLink"
-                    >
-                      <button
-                        class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
-                        type="button"
-                      >
-                        <span
-                          class="mia-platform-btn-icon"
-                        >
-                          <svg
-                            aria-label="PiBookOpen"
-                            color="#004aaa"
-                            fill="currentColor"
-                            height="16"
-                            role="img"
-                            stroke="currentColor"
-                            stroke-width="0"
-                            style="color: rgb(0, 74, 170);"
-                            viewBox="0 0 256 256"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M232,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H24a8,8,0,0,0-8,8V200a8,8,0,0,0,8,8H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h72a8,8,0,0,0,8-8V56A8,8,0,0,0,232,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
-                            />
-                          </svg>
-                        </span>
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="mia-platform-modal-body"
-              >
-                <div
-                  class="body bodyWithAsideClosed"
-                >
+                    Modal Title
+                  </h4>
                   <div
-                    class="content contentWrapper"
+                    class="docLink"
                   >
-                    <div
-                      class="content"
+                    <button
+                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+                      type="button"
                     >
-                      Modal Content
-                    </div>
-                    <div
-                      class="asideLabelWrapper"
-                    >
-                      <div
-                        class="asideLabel"
+                      <span
+                        class="mia-platform-btn-icon"
                       >
                         <svg
-                          aria-label="PiCaretLeft"
-                          color="currentColor"
+                          aria-label="PiBookOpen"
+                          color="#004aaa"
                           fill="currentColor"
                           height="16"
                           role="img"
                           stroke="currentColor"
                           stroke-width="0"
-                          style="color: currentColor;"
+                          style="color: rgb(0, 74, 170);"
                           viewBox="0 0 256 256"
                           width="16"
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <path
-                            d="M165.66,202.34a8,8,0,0,1-11.32,11.32l-80-80a8,8,0,0,1,0-11.32l80-80a8,8,0,0,1,11.32,11.32L91.31,128Z"
+                            d="M232,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H24a8,8,0,0,0-8,8V200a8,8,0,0,0,8,8H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h72a8,8,0,0,0,8-8V56A8,8,0,0,0,232,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
                           />
                         </svg>
-                        Open
-                      </div>
-                    </div>
-                  </div>
-                  <aside
-                    class="aside"
-                  >
-                    <div
-                      class="mia-platform-typography bodyM"
-                      role="paragraph"
-                    >
-                      Modal Aside Title
-                    </div>
-                    <div>
-                      Modal Aside Content
-                    </div>
-                  </aside>
-                </div>
-              </div>
-              <div
-                class="mia-platform-modal-footer"
-              >
-                <div
-                  class="footer"
-                >
-                  <div
-                    class="footerButtons"
-                  >
-                    <button
-                      class="mia-platform-btn mia-platform-btn-primary button buttonMd"
-                      type="button"
-                    >
-                      <div
-                        class="buttonText"
-                      >
-                        OK
-                      </div>
-                    </button>
-                    <button
-                      class="mia-platform-btn mia-platform-btn-default button buttonMd"
-                      type="button"
-                    >
-                      <div
-                        class="buttonText"
-                      >
-                        Cancel
-                      </div>
+                      </span>
                     </button>
                   </div>
                 </div>
               </div>
             </div>
+            <div
+              class="mia-platform-modal-body"
+            >
+              <div
+                class="body bodyWithAsideClosed"
+              >
+                <div
+                  class="content contentWrapper"
+                >
+                  <div
+                    class="content"
+                  >
+                    Modal Content
+                  </div>
+                  <div
+                    class="asideLabelWrapper"
+                  >
+                    <div
+                      class="asideLabel"
+                    >
+                      <svg
+                        aria-label="PiCaretLeft"
+                        color="currentColor"
+                        fill="currentColor"
+                        height="16"
+                        role="img"
+                        stroke="currentColor"
+                        stroke-width="0"
+                        style="color: currentColor;"
+                        viewBox="0 0 256 256"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M165.66,202.34a8,8,0,0,1-11.32,11.32l-80-80a8,8,0,0,1,0-11.32l80-80a8,8,0,0,1,11.32,11.32L91.31,128Z"
+                        />
+                      </svg>
+                      Open
+                    </div>
+                  </div>
+                </div>
+                <aside
+                  class="aside"
+                >
+                  <div
+                    class="mia-platform-typography bodyM"
+                    role="paragraph"
+                  >
+                    Modal Aside Title
+                  </div>
+                  <div>
+                    Modal Aside Content
+                  </div>
+                </aside>
+              </div>
+            </div>
+            <div
+              class="mia-platform-modal-footer"
+            >
+              <div
+                class="footer"
+              >
+                <div
+                  class="footerButtons"
+                >
+                  <button
+                    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+                    type="button"
+                  >
+                    <div
+                      class="buttonText"
+                    >
+                      OK
+                    </div>
+                  </button>
+                  <button
+                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                    type="button"
+                  >
+                    <div
+                      class="buttonText"
+                    >
+                      Cancel
+                    </div>
+                  </button>
+                </div>
+              </div>
+            </div>
           </div>
-          <div
-            aria-hidden="true"
-            style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-            tabindex="0"
-          />
         </div>
+        <div
+          aria-hidden="true"
+          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
+          tabindex="0"
+        />
       </div>
     </div>
   </div>
@@ -690,212 +682,210 @@ exports[`Modal Component renders modal with aside openable 1`] = `
 exports[`Modal Component renders modal with aside openable 2`] = `
 <body>
   <div />
-  <div>
+  <div
+    class="mia-platform-modal-root"
+  >
     <div
-      class="mia-platform-modal-root"
+      class="mia-platform-modal-mask"
+    />
+    <div
+      class="mia-platform-modal-wrap mia-platform-modal-centered"
+      tabindex="-1"
     >
       <div
-        class="mia-platform-modal-mask"
-      />
-      <div
-        class="mia-platform-modal-wrap mia-platform-modal-centered"
-        tabindex="-1"
+        aria-labelledby="test-id"
+        aria-modal="true"
+        class="mia-platform-modal modal modalLg"
+        role="dialog"
+        style="width: 520px;"
       >
         <div
-          aria-labelledby="test-id"
-          aria-modal="true"
-          class="mia-platform-modal modal modalLg"
-          role="dialog"
-          style="width: 520px;"
+          aria-hidden="true"
+          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
+          tabindex="0"
+        />
+        <div
+          style="outline: none;"
+          tabindex="-1"
         >
           <div
-            aria-hidden="true"
-            style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-            tabindex="0"
-          />
-          <div
-            style="outline: none;"
-            tabindex="-1"
+            class="mia-platform-modal-content"
           >
-            <div
-              class="mia-platform-modal-content"
+            <button
+              aria-label="Close"
+              class="mia-platform-modal-close"
+              type="button"
             >
-              <button
-                aria-label="Close"
-                class="mia-platform-modal-close"
-                type="button"
+              <span
+                class="mia-platform-modal-close-x"
               >
                 <span
-                  class="mia-platform-modal-close-x"
+                  aria-label="close"
+                  class="anticon anticon-close mia-platform-modal-close-icon"
+                  role="img"
                 >
-                  <span
-                    aria-label="close"
-                    class="anticon anticon-close mia-platform-modal-close-icon"
-                    role="img"
+                  <svg
+                    aria-hidden="true"
+                    data-icon="close"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
                   >
-                    <svg
-                      aria-hidden="true"
-                      data-icon="close"
-                      fill="currentColor"
-                      fill-rule="evenodd"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-                      />
-                    </svg>
-                  </span>
+                    <path
+                      d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                    />
+                  </svg>
                 </span>
-              </button>
+              </span>
+            </button>
+            <div
+              class="mia-platform-modal-header"
+            >
               <div
-                class="mia-platform-modal-header"
+                class="mia-platform-modal-title"
+                id="test-id"
               >
                 <div
-                  class="mia-platform-modal-title"
-                  id="test-id"
+                  class="title"
                 >
-                  <div
-                    class="title"
+                  <h4
+                    aria-label="Modal Title"
+                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
+                    role="h4"
                   >
-                    <h4
-                      aria-label="Modal Title"
-                      class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
-                      role="h4"
-                    >
-                      Modal Title
-                    </h4>
-                    <div
-                      class="docLink"
-                    >
-                      <button
-                        class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
-                        type="button"
-                      >
-                        <span
-                          class="mia-platform-btn-icon"
-                        >
-                          <svg
-                            aria-label="PiBookOpen"
-                            color="#004aaa"
-                            fill="currentColor"
-                            height="16"
-                            role="img"
-                            stroke="currentColor"
-                            stroke-width="0"
-                            style="color: rgb(0, 74, 170);"
-                            viewBox="0 0 256 256"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M232,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H24a8,8,0,0,0-8,8V200a8,8,0,0,0,8,8H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h72a8,8,0,0,0,8-8V56A8,8,0,0,0,232,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
-                            />
-                          </svg>
-                        </span>
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="mia-platform-modal-body"
-              >
-                <div
-                  class="body bodyWithAsideOpened"
-                >
+                    Modal Title
+                  </h4>
                   <div
-                    class="content contentWrapper"
+                    class="docLink"
                   >
-                    <div
-                      class="content"
+                    <button
+                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+                      type="button"
                     >
-                      Modal Content
-                    </div>
-                    <div
-                      class="asideLabelWrapper"
-                    >
-                      <div
-                        class="asideLabel"
+                      <span
+                        class="mia-platform-btn-icon"
                       >
-                        Close
                         <svg
-                          aria-label="PiCaretRight"
-                          color="currentColor"
+                          aria-label="PiBookOpen"
+                          color="#004aaa"
                           fill="currentColor"
                           height="16"
                           role="img"
                           stroke="currentColor"
                           stroke-width="0"
-                          style="color: currentColor;"
+                          style="color: rgb(0, 74, 170);"
                           viewBox="0 0 256 256"
                           width="16"
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <path
-                            d="M181.66,133.66l-80,80a8,8,0,0,1-11.32-11.32L164.69,128,90.34,53.66a8,8,0,0,1,11.32-11.32l80,80A8,8,0,0,1,181.66,133.66Z"
+                            d="M232,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H24a8,8,0,0,0-8,8V200a8,8,0,0,0,8,8H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h72a8,8,0,0,0,8-8V56A8,8,0,0,0,232,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
                           />
                         </svg>
-                      </div>
-                    </div>
-                  </div>
-                  <aside
-                    class="aside"
-                  >
-                    <div
-                      class="mia-platform-typography bodyM"
-                      role="paragraph"
-                    >
-                      Modal Aside Title
-                    </div>
-                    <div>
-                      Modal Aside Content
-                    </div>
-                  </aside>
-                </div>
-              </div>
-              <div
-                class="mia-platform-modal-footer"
-              >
-                <div
-                  class="footer"
-                >
-                  <div
-                    class="footerButtons"
-                  >
-                    <button
-                      class="mia-platform-btn mia-platform-btn-primary button buttonMd"
-                      type="button"
-                    >
-                      <div
-                        class="buttonText"
-                      >
-                        OK
-                      </div>
-                    </button>
-                    <button
-                      class="mia-platform-btn mia-platform-btn-default button buttonMd"
-                      type="button"
-                    >
-                      <div
-                        class="buttonText"
-                      >
-                        Cancel
-                      </div>
+                      </span>
                     </button>
                   </div>
                 </div>
               </div>
             </div>
+            <div
+              class="mia-platform-modal-body"
+            >
+              <div
+                class="body bodyWithAsideOpened"
+              >
+                <div
+                  class="content contentWrapper"
+                >
+                  <div
+                    class="content"
+                  >
+                    Modal Content
+                  </div>
+                  <div
+                    class="asideLabelWrapper"
+                  >
+                    <div
+                      class="asideLabel"
+                    >
+                      Close
+                      <svg
+                        aria-label="PiCaretRight"
+                        color="currentColor"
+                        fill="currentColor"
+                        height="16"
+                        role="img"
+                        stroke="currentColor"
+                        stroke-width="0"
+                        style="color: currentColor;"
+                        viewBox="0 0 256 256"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M181.66,133.66l-80,80a8,8,0,0,1-11.32-11.32L164.69,128,90.34,53.66a8,8,0,0,1,11.32-11.32l80,80A8,8,0,0,1,181.66,133.66Z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <aside
+                  class="aside"
+                >
+                  <div
+                    class="mia-platform-typography bodyM"
+                    role="paragraph"
+                  >
+                    Modal Aside Title
+                  </div>
+                  <div>
+                    Modal Aside Content
+                  </div>
+                </aside>
+              </div>
+            </div>
+            <div
+              class="mia-platform-modal-footer"
+            >
+              <div
+                class="footer"
+              >
+                <div
+                  class="footerButtons"
+                >
+                  <button
+                    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+                    type="button"
+                  >
+                    <div
+                      class="buttonText"
+                    >
+                      OK
+                    </div>
+                  </button>
+                  <button
+                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                    type="button"
+                  >
+                    <div
+                      class="buttonText"
+                    >
+                      Cancel
+                    </div>
+                  </button>
+                </div>
+              </div>
+            </div>
           </div>
-          <div
-            aria-hidden="true"
-            style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-            tabindex="0"
-          />
         </div>
+        <div
+          aria-hidden="true"
+          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
+          tabindex="0"
+        />
       </div>
     </div>
   </div>
@@ -905,104 +895,102 @@ exports[`Modal Component renders modal with aside openable 2`] = `
 exports[`Modal Component renders modal with body full width 1`] = `
 <body>
   <div />
-  <div>
+  <div
+    class="mia-platform-modal-root"
+  >
     <div
-      class="mia-platform-modal-root"
+      class="mia-platform-modal-mask"
+    />
+    <div
+      class="mia-platform-modal-wrap mia-platform-modal-centered"
+      tabindex="-1"
     >
       <div
-        class="mia-platform-modal-mask"
-      />
-      <div
-        class="mia-platform-modal-wrap mia-platform-modal-centered"
-        tabindex="-1"
+        aria-labelledby="test-id"
+        aria-modal="true"
+        class="mia-platform-modal modal modalSm"
+        role="dialog"
+        style="width: 520px;"
       >
         <div
-          aria-labelledby="test-id"
-          aria-modal="true"
-          class="mia-platform-modal modal modalSm"
-          role="dialog"
-          style="width: 520px;"
+          aria-hidden="true"
+          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
+          tabindex="0"
+        />
+        <div
+          style="outline: none;"
+          tabindex="-1"
         >
           <div
-            aria-hidden="true"
-            style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-            tabindex="0"
-          />
-          <div
-            style="outline: none;"
-            tabindex="-1"
+            class="mia-platform-modal-content"
           >
-            <div
-              class="mia-platform-modal-content"
+            <button
+              aria-label="Close"
+              class="mia-platform-modal-close"
+              type="button"
             >
-              <button
-                aria-label="Close"
-                class="mia-platform-modal-close"
-                type="button"
+              <span
+                class="mia-platform-modal-close-x"
               >
                 <span
-                  class="mia-platform-modal-close-x"
+                  aria-label="close"
+                  class="anticon anticon-close mia-platform-modal-close-icon"
+                  role="img"
                 >
-                  <span
-                    aria-label="close"
-                    class="anticon anticon-close mia-platform-modal-close-icon"
-                    role="img"
+                  <svg
+                    aria-hidden="true"
+                    data-icon="close"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
                   >
-                    <svg
-                      aria-hidden="true"
-                      data-icon="close"
-                      fill="currentColor"
-                      fill-rule="evenodd"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-                      />
-                    </svg>
-                  </span>
+                    <path
+                      d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                    />
+                  </svg>
                 </span>
-              </button>
+              </span>
+            </button>
+            <div
+              class="mia-platform-modal-header"
+            >
               <div
-                class="mia-platform-modal-header"
+                class="mia-platform-modal-title"
+                id="test-id"
               >
                 <div
-                  class="mia-platform-modal-title"
-                  id="test-id"
-                >
-                  <div
-                    class="title"
-                  />
-                </div>
-              </div>
-              <div
-                class="mia-platform-modal-body"
-              >
-                <div
-                  class="body bodyFullWidth"
-                >
-                  <div
-                    class="content"
-                  />
-                </div>
-              </div>
-              <div
-                class="mia-platform-modal-footer"
-              >
-                <div
-                  class="footer"
+                  class="title"
                 />
               </div>
             </div>
+            <div
+              class="mia-platform-modal-body"
+            >
+              <div
+                class="body bodyFullWidth"
+              >
+                <div
+                  class="content"
+                />
+              </div>
+            </div>
+            <div
+              class="mia-platform-modal-footer"
+            >
+              <div
+                class="footer"
+              />
+            </div>
           </div>
-          <div
-            aria-hidden="true"
-            style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-            tabindex="0"
-          />
         </div>
+        <div
+          aria-hidden="true"
+          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
+          tabindex="0"
+        />
       </div>
     </div>
   </div>
@@ -1012,190 +1000,188 @@ exports[`Modal Component renders modal with body full width 1`] = `
 exports[`Modal Component renders modal with custom footer 1`] = `
 <body>
   <div />
-  <div>
+  <div
+    class="mia-platform-modal-root"
+  >
     <div
-      class="mia-platform-modal-root"
+      class="mia-platform-modal-mask"
+    />
+    <div
+      class="mia-platform-modal-wrap mia-platform-modal-centered"
+      tabindex="-1"
     >
       <div
-        class="mia-platform-modal-mask"
-      />
-      <div
-        class="mia-platform-modal-wrap mia-platform-modal-centered"
-        tabindex="-1"
+        aria-labelledby="test-id"
+        aria-modal="true"
+        class="mia-platform-modal modal modalSm"
+        role="dialog"
+        style="width: 520px;"
       >
         <div
-          aria-labelledby="test-id"
-          aria-modal="true"
-          class="mia-platform-modal modal modalSm"
-          role="dialog"
-          style="width: 520px;"
+          aria-hidden="true"
+          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
+          tabindex="0"
+        />
+        <div
+          style="outline: none;"
+          tabindex="-1"
         >
           <div
-            aria-hidden="true"
-            style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-            tabindex="0"
-          />
-          <div
-            style="outline: none;"
-            tabindex="-1"
+            class="mia-platform-modal-content"
           >
-            <div
-              class="mia-platform-modal-content"
+            <button
+              aria-label="Close"
+              class="mia-platform-modal-close"
+              type="button"
             >
-              <button
-                aria-label="Close"
-                class="mia-platform-modal-close"
-                type="button"
+              <span
+                class="mia-platform-modal-close-x"
               >
                 <span
-                  class="mia-platform-modal-close-x"
+                  aria-label="close"
+                  class="anticon anticon-close mia-platform-modal-close-icon"
+                  role="img"
                 >
-                  <span
-                    aria-label="close"
-                    class="anticon anticon-close mia-platform-modal-close-icon"
-                    role="img"
+                  <svg
+                    aria-hidden="true"
+                    data-icon="close"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
                   >
-                    <svg
-                      aria-hidden="true"
-                      data-icon="close"
-                      fill="currentColor"
-                      fill-rule="evenodd"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-                      />
-                    </svg>
-                  </span>
+                    <path
+                      d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                    />
+                  </svg>
                 </span>
-              </button>
+              </span>
+            </button>
+            <div
+              class="mia-platform-modal-header"
+            >
               <div
-                class="mia-platform-modal-header"
+                class="mia-platform-modal-title"
+                id="test-id"
               >
                 <div
-                  class="mia-platform-modal-title"
-                  id="test-id"
+                  class="title"
                 >
-                  <div
-                    class="title"
+                  <h4
+                    aria-label="Modal Title"
+                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
+                    role="h4"
                   >
-                    <h4
-                      aria-label="Modal Title"
-                      class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
-                      role="h4"
+                    Modal Title
+                  </h4>
+                  <div
+                    class="docLink"
+                  >
+                    <button
+                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+                      type="button"
                     >
-                      Modal Title
-                    </h4>
-                    <div
-                      class="docLink"
-                    >
-                      <button
-                        class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
-                        type="button"
+                      <span
+                        class="mia-platform-btn-icon"
                       >
-                        <span
-                          class="mia-platform-btn-icon"
+                        <svg
+                          aria-label="PiBookOpen"
+                          color="#004aaa"
+                          fill="currentColor"
+                          height="16"
+                          role="img"
+                          stroke="currentColor"
+                          stroke-width="0"
+                          style="color: rgb(0, 74, 170);"
+                          viewBox="0 0 256 256"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <svg
-                            aria-label="PiBookOpen"
-                            color="#004aaa"
-                            fill="currentColor"
-                            height="16"
-                            role="img"
-                            stroke="currentColor"
-                            stroke-width="0"
-                            style="color: rgb(0, 74, 170);"
-                            viewBox="0 0 256 256"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M232,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H24a8,8,0,0,0-8,8V200a8,8,0,0,0,8,8H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h72a8,8,0,0,0,8-8V56A8,8,0,0,0,232,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
-                            />
-                          </svg>
-                        </span>
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="mia-platform-modal-body"
-              >
-                <div
-                  class="body"
-                >
-                  <div
-                    class="content"
-                  >
-                    Modal Content
-                  </div>
-                </div>
-              </div>
-              <div
-                class="mia-platform-modal-footer"
-              >
-                <div
-                  class="footer"
-                >
-                  <div
-                    class="footerButtons"
-                  >
-                    <button
-                      class="mia-platform-btn mia-platform-btn-primary button buttonMd"
-                      type="button"
-                    >
-                      <div
-                        class="buttonText"
-                      >
-                        Button 1
-                      </div>
-                    </button>
-                    <button
-                      class="mia-platform-btn mia-platform-btn-default button buttonMd"
-                      type="button"
-                    >
-                      <div
-                        class="buttonText"
-                      >
-                        Button 2
-                      </div>
-                    </button>
-                    <button
-                      class="mia-platform-btn mia-platform-btn-default button buttonMd"
-                      type="button"
-                    >
-                      <div
-                        class="buttonText"
-                      >
-                        Button 3
-                      </div>
-                    </button>
-                    <button
-                      class="mia-platform-btn mia-platform-btn-default button buttonMd"
-                      type="button"
-                    >
-                      <div
-                        class="buttonText"
-                      >
-                        Button 4
-                      </div>
+                          <path
+                            d="M232,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H24a8,8,0,0,0-8,8V200a8,8,0,0,0,8,8H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h72a8,8,0,0,0,8-8V56A8,8,0,0,0,232,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
+                          />
+                        </svg>
+                      </span>
                     </button>
                   </div>
-                  Footer Extra
                 </div>
               </div>
             </div>
+            <div
+              class="mia-platform-modal-body"
+            >
+              <div
+                class="body"
+              >
+                <div
+                  class="content"
+                >
+                  Modal Content
+                </div>
+              </div>
+            </div>
+            <div
+              class="mia-platform-modal-footer"
+            >
+              <div
+                class="footer"
+              >
+                <div
+                  class="footerButtons"
+                >
+                  <button
+                    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+                    type="button"
+                  >
+                    <div
+                      class="buttonText"
+                    >
+                      Button 1
+                    </div>
+                  </button>
+                  <button
+                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                    type="button"
+                  >
+                    <div
+                      class="buttonText"
+                    >
+                      Button 2
+                    </div>
+                  </button>
+                  <button
+                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                    type="button"
+                  >
+                    <div
+                      class="buttonText"
+                    >
+                      Button 3
+                    </div>
+                  </button>
+                  <button
+                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                    type="button"
+                  >
+                    <div
+                      class="buttonText"
+                    >
+                      Button 4
+                    </div>
+                  </button>
+                </div>
+                Footer Extra
+              </div>
+            </div>
           </div>
-          <div
-            aria-hidden="true"
-            style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-            tabindex="0"
-          />
         </div>
+        <div
+          aria-hidden="true"
+          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
+          tabindex="0"
+        />
       </div>
     </div>
   </div>
@@ -1205,74 +1191,72 @@ exports[`Modal Component renders modal with custom footer 1`] = `
 exports[`Modal Component renders not closable modal 1`] = `
 <body>
   <div />
-  <div>
+  <div
+    class="mia-platform-modal-root"
+  >
     <div
-      class="mia-platform-modal-root"
+      class="mia-platform-modal-mask"
+    />
+    <div
+      class="mia-platform-modal-wrap mia-platform-modal-centered"
+      tabindex="-1"
     >
       <div
-        class="mia-platform-modal-mask"
-      />
-      <div
-        class="mia-platform-modal-wrap mia-platform-modal-centered"
-        tabindex="-1"
+        aria-labelledby="test-id"
+        aria-modal="true"
+        class="mia-platform-modal modal modalSm"
+        role="dialog"
+        style="width: 520px;"
       >
         <div
-          aria-labelledby="test-id"
-          aria-modal="true"
-          class="mia-platform-modal modal modalSm"
-          role="dialog"
-          style="width: 520px;"
+          aria-hidden="true"
+          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
+          tabindex="0"
+        />
+        <div
+          style="outline: none;"
+          tabindex="-1"
         >
           <div
-            aria-hidden="true"
-            style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-            tabindex="0"
-          />
-          <div
-            style="outline: none;"
-            tabindex="-1"
+            class="mia-platform-modal-content"
           >
             <div
-              class="mia-platform-modal-content"
+              class="mia-platform-modal-header"
             >
               <div
-                class="mia-platform-modal-header"
+                class="mia-platform-modal-title"
+                id="test-id"
               >
                 <div
-                  class="mia-platform-modal-title"
-                  id="test-id"
-                >
-                  <div
-                    class="title"
-                  />
-                </div>
-              </div>
-              <div
-                class="mia-platform-modal-body"
-              >
-                <div
-                  class="body"
-                >
-                  <div
-                    class="content"
-                  />
-                </div>
-              </div>
-              <div
-                class="mia-platform-modal-footer"
-              >
-                <div
-                  class="footer"
+                  class="title"
                 />
               </div>
             </div>
+            <div
+              class="mia-platform-modal-body"
+            >
+              <div
+                class="body"
+              >
+                <div
+                  class="content"
+                />
+              </div>
+            </div>
+            <div
+              class="mia-platform-modal-footer"
+            >
+              <div
+                class="footer"
+              />
+            </div>
           </div>
-          <div
-            aria-hidden="true"
-            style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-            tabindex="0"
-          />
         </div>
+        <div
+          aria-hidden="true"
+          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
+          tabindex="0"
+        />
       </div>
     </div>
   </div>
@@ -1282,169 +1266,167 @@ exports[`Modal Component renders not closable modal 1`] = `
 exports[`Modal Component renders small modal correctly (with children, docLink, footer and title) 1`] = `
 <body>
   <div />
-  <div>
+  <div
+    class="mia-platform-modal-root"
+  >
     <div
-      class="mia-platform-modal-root"
+      class="mia-platform-modal-mask"
+    />
+    <div
+      class="mia-platform-modal-wrap mia-platform-modal-centered"
+      tabindex="-1"
     >
       <div
-        class="mia-platform-modal-mask"
-      />
-      <div
-        class="mia-platform-modal-wrap mia-platform-modal-centered"
-        tabindex="-1"
+        aria-labelledby="test-id"
+        aria-modal="true"
+        class="mia-platform-modal modal modalSm"
+        role="dialog"
+        style="width: 520px;"
       >
         <div
-          aria-labelledby="test-id"
-          aria-modal="true"
-          class="mia-platform-modal modal modalSm"
-          role="dialog"
-          style="width: 520px;"
+          aria-hidden="true"
+          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
+          tabindex="0"
+        />
+        <div
+          style="outline: none;"
+          tabindex="-1"
         >
           <div
-            aria-hidden="true"
-            style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-            tabindex="0"
-          />
-          <div
-            style="outline: none;"
-            tabindex="-1"
+            class="mia-platform-modal-content"
           >
-            <div
-              class="mia-platform-modal-content"
+            <button
+              aria-label="Close"
+              class="mia-platform-modal-close"
+              type="button"
             >
-              <button
-                aria-label="Close"
-                class="mia-platform-modal-close"
-                type="button"
+              <span
+                class="mia-platform-modal-close-x"
               >
                 <span
-                  class="mia-platform-modal-close-x"
+                  aria-label="close"
+                  class="anticon anticon-close mia-platform-modal-close-icon"
+                  role="img"
                 >
-                  <span
-                    aria-label="close"
-                    class="anticon anticon-close mia-platform-modal-close-icon"
-                    role="img"
+                  <svg
+                    aria-hidden="true"
+                    data-icon="close"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
                   >
-                    <svg
-                      aria-hidden="true"
-                      data-icon="close"
-                      fill="currentColor"
-                      fill-rule="evenodd"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-                      />
-                    </svg>
-                  </span>
+                    <path
+                      d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                    />
+                  </svg>
                 </span>
-              </button>
+              </span>
+            </button>
+            <div
+              class="mia-platform-modal-header"
+            >
               <div
-                class="mia-platform-modal-header"
+                class="mia-platform-modal-title"
+                id="test-id"
               >
                 <div
-                  class="mia-platform-modal-title"
-                  id="test-id"
+                  class="title"
                 >
-                  <div
-                    class="title"
+                  <h4
+                    aria-label="Modal Title"
+                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
+                    role="h4"
                   >
-                    <h4
-                      aria-label="Modal Title"
-                      class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
-                      role="h4"
+                    Modal Title
+                  </h4>
+                  <div
+                    class="docLink"
+                  >
+                    <button
+                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+                      type="button"
                     >
-                      Modal Title
-                    </h4>
-                    <div
-                      class="docLink"
-                    >
-                      <button
-                        class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
-                        type="button"
+                      <span
+                        class="mia-platform-btn-icon"
                       >
-                        <span
-                          class="mia-platform-btn-icon"
+                        <svg
+                          aria-label="PiBookOpen"
+                          color="#004aaa"
+                          fill="currentColor"
+                          height="16"
+                          role="img"
+                          stroke="currentColor"
+                          stroke-width="0"
+                          style="color: rgb(0, 74, 170);"
+                          viewBox="0 0 256 256"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <svg
-                            aria-label="PiBookOpen"
-                            color="#004aaa"
-                            fill="currentColor"
-                            height="16"
-                            role="img"
-                            stroke="currentColor"
-                            stroke-width="0"
-                            style="color: rgb(0, 74, 170);"
-                            viewBox="0 0 256 256"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M232,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H24a8,8,0,0,0-8,8V200a8,8,0,0,0,8,8H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h72a8,8,0,0,0,8-8V56A8,8,0,0,0,232,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
-                            />
-                          </svg>
-                        </span>
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="mia-platform-modal-body"
-              >
-                <div
-                  class="body"
-                >
-                  <div
-                    class="content"
-                  >
-                    Modal Content
-                  </div>
-                </div>
-              </div>
-              <div
-                class="mia-platform-modal-footer"
-              >
-                <div
-                  class="footer"
-                >
-                  <div
-                    class="footerButtons"
-                  >
-                    <button
-                      class="mia-platform-btn mia-platform-btn-primary button buttonMd"
-                      type="button"
-                    >
-                      <div
-                        class="buttonText"
-                      >
-                        OK
-                      </div>
-                    </button>
-                    <button
-                      class="mia-platform-btn mia-platform-btn-default button buttonMd"
-                      type="button"
-                    >
-                      <div
-                        class="buttonText"
-                      >
-                        Cancel
-                      </div>
+                          <path
+                            d="M232,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H24a8,8,0,0,0-8,8V200a8,8,0,0,0,8,8H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h72a8,8,0,0,0,8-8V56A8,8,0,0,0,232,48ZM96,192H32V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm128,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h64Z"
+                          />
+                        </svg>
+                      </span>
                     </button>
                   </div>
                 </div>
               </div>
             </div>
+            <div
+              class="mia-platform-modal-body"
+            >
+              <div
+                class="body"
+              >
+                <div
+                  class="content"
+                >
+                  Modal Content
+                </div>
+              </div>
+            </div>
+            <div
+              class="mia-platform-modal-footer"
+            >
+              <div
+                class="footer"
+              >
+                <div
+                  class="footerButtons"
+                >
+                  <button
+                    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+                    type="button"
+                  >
+                    <div
+                      class="buttonText"
+                    >
+                      OK
+                    </div>
+                  </button>
+                  <button
+                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                    type="button"
+                  >
+                    <div
+                      class="buttonText"
+                    >
+                      Cancel
+                    </div>
+                  </button>
+                </div>
+              </div>
+            </div>
           </div>
-          <div
-            aria-hidden="true"
-            style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-            tabindex="0"
-          />
         </div>
+        <div
+          aria-hidden="true"
+          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
+          tabindex="0"
+        />
       </div>
     </div>
   </div>

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -26,7 +26,7 @@ import themeToVariables from './utils/themeToVariables'
 import themes from '../../themes'
 
 export const { lightTheme: defaultTheme } = themes
-export const THEME_PROVIDER_STYLE_WRAPPER_NODE = 'theme-provider-style-wrapper-node'
+const THEME_PROVIDER_STYLE_WRAPPER_NODE_ID = 'theme-provider-style-wrapper-node'
 
 /**
  * A context to provide the theme throughout the application.
@@ -51,7 +51,7 @@ export const ThemeProvider = ({
     <ThemeContext.Provider value={theme!}>
       <AntThemeProvider theme={theme}>
         <ReactIconsProvider theme={theme}>
-          <div id={THEME_PROVIDER_STYLE_WRAPPER_NODE} style={style}>
+          <div id={THEME_PROVIDER_STYLE_WRAPPER_NODE_ID} style={style}>
             {children}
           </div>
         </ReactIconsProvider>
@@ -59,3 +59,5 @@ export const ThemeProvider = ({
     </ThemeContext.Provider>
   )
 }
+
+ThemeProvider.StyleWrapperId = THEME_PROVIDER_STYLE_WRAPPER_NODE_ID

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -26,6 +26,7 @@ import themeToVariables from './utils/themeToVariables'
 import themes from '../../themes'
 
 export const { lightTheme: defaultTheme } = themes
+export const THEME_PROVIDER_STYLE_WRAPPER_NODE = 'theme-provider-style-wrapper-node'
 
 /**
  * A context to provide the theme throughout the application.
@@ -50,7 +51,7 @@ export const ThemeProvider = ({
     <ThemeContext.Provider value={theme!}>
       <AntThemeProvider theme={theme}>
         <ReactIconsProvider theme={theme}>
-          <div style={style}>
+          <div id={THEME_PROVIDER_STYLE_WRAPPER_NODE} style={style}>
             {children}
           </div>
         </ReactIconsProvider>


### PR DESCRIPTION
### Description

This PR introduces an _id_ to identify an inner node inside the Theme Provider component. This node acts as a wrapper for "floating" components (like the Modal), which Antd attaches to the document body by default.

##### Theme Provider
- added an _id_ on an already existing inner div used for styling
- assigned this _id_ to a property of the ThemeProvider, so other components can use it

##### Modal
- added a fallback function for the `getContainer` prop. This function looks for the wrapper div we defined in the ThemeProvider, making the assumption that the Modal component will be used inside a ThemeProvider. If the node is not found, it simply returns the document body as default.

### Addressed issue

Closes [553](https://github.com/mia-platform/design-system/issues/553)

### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g., enhancement, bug).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [x] Changes are covered by tests 
- [x] Changes to components are accessible and documented in the Storybook
- [ ] Typings have been updated
- [ ] New components are exported from the `index` file
- [ ] New files include the Apache 2.0 License disclaimer
- [x] The browser console does not contain errors
