### PR TITLE
fix: icon type as ReactElement

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ReactNode, useContext } from 'react'
+import { ReactElement, useContext } from 'react'
 import { IconContext } from 'react-icons'
 
 import { IconProps } from './Icon.props'
@@ -43,22 +43,25 @@ import { IconProps } from './Icon.props'
  * const App = () => <Icon component={PiAddressBook} />
  * ```
  *
- * @returns {ReactNode} Icon component
+ * @returns {ReactElement} Icon component
  */
 export const Icon = ({
   component,
   size = 24,
   color,
-}: IconProps): ReactNode => {
+}: IconProps): ReactElement => {
   const { size: defaultSize, className } = useContext(IconContext)
+  const IconComponent = component
 
-  return component?.({
-    'aria-label': component.name,
-    className,
-    color: color ?? 'currentColor',
-    height: size ?? defaultSize,
-    role: 'img',
-    size: size ?? defaultSize,
-    width: size ?? defaultSize,
-  })
+  return (
+    <IconComponent
+      aria-label={component.name}
+      className={className}
+      color={color ?? 'currentColor'}
+      height={size ?? defaultSize}
+      role={'img'}
+      size={size ?? defaultSize}
+      width={size ?? defaultSize}
+    />
+  )
 }


### PR DESCRIPTION
### Description

Fixed returned type of Icon Component to be ReactElement

##### <Changed component name>
    - Icon

### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g., enhancement, bug).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [x] Changes are covered by tests 
- [x] Changes to components are accessible and documented in the Storybook
- [x] Typings have been updated
- [x] New components are exported from the `index` file
- [x] New files include the Apache 2.0 License disclaimer
- [x] The browser console does not contain errors
