### PR TITLE
fix(Modal): fixed title in aside in case of scrollable content

### DIFF
--- a/src/components/Modal/Modal.Body.tsx
+++ b/src/components/Modal/Modal.Body.tsx
@@ -75,7 +75,7 @@ export const Body = ({
     const modalAside = (
       <aside className={styles.aside}>
         <BodyM>{extTitle}</BodyM>
-        {extChildren}
+        <div className={styles.asideBody}>{extChildren}</div>
       </aside>
     )
 

--- a/src/components/Modal/Modal.mocks.tsx
+++ b/src/components/Modal/Modal.mocks.tsx
@@ -26,6 +26,16 @@ import { ModalProps } from './Modal.props'
 import { Table } from '../Table'
 import { useModal } from '../../hooks/useModal'
 
+const longText = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque vel dolor ac sem congue ornare rhoncus quis tortor.
+Vivamus hendrerit sed nisl eget gravida. Nunc dolor elit, condimentum non ante vitae, ullamcorper dignissim dolor.
+Quisque ornare interdum massa blandit accumsan. Morbi viverra, urna ut consequat maximus, risus eros molestie augue, at posuere lacus nunc id ex.
+Aenean et ante augue. Donec vitae pretium tellus, mattis placerat nisl. Phasellus dolor urna, porttitor a tempus at, scelerisque id nisi.
+In ac libero quis neque tempor iaculis sit amet non sapien. Aenean quis neque varius, efficitur erat et, faucibus tortor.
+Etiam at mi lacinia, gravida diam ac, sodales elit. Maecenas vitae rutrum nisl.
+Nunc pellentesque, arcu vitae bibendum rutrum, mi sapien aliquam ipsum, sit amet mollis quam orci quis est.
+Curabitur sagittis mauris volutpat lorem elementum, nec porttitor eros commodo. Suspendisse lorem orci, commodo mollis quam eget, facilisis tincidunt mauris.
+Ut in feugiat nunc, in eleifend ex.`
+
 export const children = (
   <>
     {'Modal Content'}
@@ -58,15 +68,7 @@ export const childrenLong = (
       data={data}
       rowKey={rowKey}
     />
-    {`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque vel dolor ac sem congue ornare rhoncus quis tortor.
-Vivamus hendrerit sed nisl eget gravida. Nunc dolor elit, condimentum non ante vitae, ullamcorper dignissim dolor.
-Quisque ornare interdum massa blandit accumsan. Morbi viverra, urna ut consequat maximus, risus eros molestie augue, at posuere lacus nunc id ex.
-Aenean et ante augue. Donec vitae pretium tellus, mattis placerat nisl. Phasellus dolor urna, porttitor a tempus at, scelerisque id nisi.
-In ac libero quis neque tempor iaculis sit amet non sapien. Aenean quis neque varius, efficitur erat et, faucibus tortor.
-Etiam at mi lacinia, gravida diam ac, sodales elit. Maecenas vitae rutrum nisl.
-Nunc pellentesque, arcu vitae bibendum rutrum, mi sapien aliquam ipsum, sit amet mollis quam orci quis est.
-Curabitur sagittis mauris volutpat lorem elementum, nec porttitor eros commodo. Suspendisse lorem orci, commodo mollis quam eget, facilisis tincidunt mauris.
-Ut in feugiat nunc, in eleifend ex.`}
+    {longText}
   </>
 )
 
@@ -80,6 +82,12 @@ export const asideOpenable = {
   children: <div>Modal Aside Content</div>,
   labelClose: 'Close',
   labelOpen: 'Open',
+  title: 'Modal Aside Title',
+}
+
+export const asideWithLongContent = {
+  children: <div>{longText}</div>,
+  isFixed: true,
   title: 'Modal Aside Title',
 }
 

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -118,6 +118,10 @@
       overflow-y: auto;
     }
 
+    .asideBody {
+      overflow-y: auto;
+    }
+
     .asideLabel {
       display: flex;
       align-items: center;

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -20,7 +20,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { useEffect } from 'react'
 
-import { WithOpenButton, asideFixed, asideOpenable, children, childrenFullWidth, childrenLong, docLink, footer, footerCustom, footerLoading, title } from './Modal.mocks'
+import { WithOpenButton, asideFixed, asideOpenable, asideWithLongContent, children, childrenFullWidth, childrenLong, docLink, footer, footerCustom, footerLoading, title } from './Modal.mocks'
 import { Button } from '../Button'
 import { Modal } from '.'
 import { defaults } from './Modal'
@@ -145,6 +145,16 @@ export const WithAsideOpenable: Story = {
   args: {
     ...meta.args,
     aside: asideOpenable,
+    children: childrenLong,
+    size: Modal.Size.Large,
+  },
+  decorators: [(_, { args }) => <WithOpenButton {...args} />],
+}
+
+export const WithScrollableAside: Story = {
+  args: {
+    ...meta.args,
+    aside: asideWithLongContent,
     children: childrenLong,
     size: Modal.Size.Large,
   },

--- a/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -415,8 +415,12 @@ exports[`Modal Component renders modal with aside fixed 1`] = `
                   >
                     Modal Aside Title
                   </div>
-                  <div>
-                    Modal Aside Content
+                  <div
+                    class="asideBody"
+                  >
+                    <div>
+                      Modal Aside Content
+                    </div>
                   </div>
                 </aside>
               </div>
@@ -628,8 +632,12 @@ exports[`Modal Component renders modal with aside openable 1`] = `
                   >
                     Modal Aside Title
                   </div>
-                  <div>
-                    Modal Aside Content
+                  <div
+                    class="asideBody"
+                  >
+                    <div>
+                      Modal Aside Content
+                    </div>
                   </div>
                 </aside>
               </div>
@@ -841,8 +849,12 @@ exports[`Modal Component renders modal with aside openable 2`] = `
                   >
                     Modal Aside Title
                   </div>
-                  <div>
-                    Modal Aside Content
+                  <div
+                    class="asideBody"
+                  >
+                    <div>
+                      Modal Aside Content
+                    </div>
                   </div>
                 </aside>
               </div>


### PR DESCRIPTION
### Description

<!-- Please provide a brief description of your changes. Summarize the rationale and impact on the codebase. E.g.

##### <Changed component name>
    - change 1
    - change 2
    - ...
-->

#### Modal

In case the lateral text (`aside.content`) contains a long text that needs scrolling, the title (`aside.title`) does not scroll with the rest of the container.

Also including a new Storybook test (_With Scrollable Aside_) to show the result.

[Screencast from 19-09-2024 16:44:49.webm](https://github.com/user-attachments/assets/ab30b779-1835-446e-9b6c-a9a1d61c2008)


### Addressed issue

Closes #597 

<!-- Link to the issue, if present. E.g. 
    Closes #XYZ
-->

### [IMPORTANT] PR Checklist

- [X] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [X] PR title follows the `<type>(<scope>): <subject>` structure
- [X] The PR has been labeled according to the type of changes (e.g., enhancement, bug).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [X] Changes are covered by tests 
- [X] Changes to components are accessible and documented in the Storybook
- [ ] Typings have been updated
- [ ] New components are exported from the `index` file
- [ ] New files include the Apache 2.0 License disclaimer
- [X] The browser console does not contain errors
