### PR TITLE
feat(Dropdown): including "selectable" prop, defaults to true

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -124,8 +124,8 @@ export const Disabled: Story = {
   },
 }
 
-export const OptionsAreNotSelectable: Story = {
+export const SelectionIsNotPersisted: Story = {
   args: {
-    selectable: false,
+    persistSelection: false,
   },
 }

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -123,3 +123,9 @@ export const Disabled: Story = {
     isDisabled: true,
   },
 }
+
+export const OptionsAreNotSelectable: Story = {
+  args: {
+    selectable: false,
+  },
+}

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -275,6 +275,46 @@ describe('Dropdown Component', () => {
         expect(firstUpdated).toMatchSnapshot('after click render Label 1 is not selected')
         expect(secondUpdated).toMatchSnapshot('after click render Label 2 is selected')
       })
+
+      it('does not highlight elements if selectable is set to false', async() => {
+        const onClick = jest.fn()
+        const props: DropdownProps = {
+          ...defaultProps,
+          onClick,
+          selectable: false,
+        }
+
+        renderDropdown({ props })
+        const button = screen.getByText('test-trigger-button')
+        userEvent.click(button)
+        const el = await screen.findByRole('menuitem', { name: 'Label 1' })
+        expect(el).toMatchSnapshot('at first render Label 1 is not selected')
+
+        userEvent.click(el)
+
+        // eslint-disable-next-line max-nested-callbacks
+        await waitFor(() => expect(onClick).toHaveBeenCalled())
+
+        userEvent.click(button)
+        const firstUpdated = await screen.findByRole('menuitem', { name: 'Label 1' })
+        expect(firstUpdated).toMatchSnapshot('after click render Label 1 is still not selected')
+      })
+
+      it('render and ignores "initialSelectedItems" prop if "selectable" is true', async() => {
+        const onClick = jest.fn()
+        const props: DropdownProps = {
+          ...defaultProps,
+          initialSelectedItems: ['1'],
+          onClick,
+          selectable: true,
+        }
+
+        renderDropdown({ props })
+        const button = screen.getByText('test-trigger-button')
+        userEvent.click(button)
+        const el = await screen.findByRole('menuitem', { name: 'Label 1' })
+        expect(el).toMatchSnapshot('at first render Label 1 is not selected')
+      })
     })
 
     describe('multiple mode', () => {
@@ -317,6 +357,31 @@ describe('Dropdown Component', () => {
         expect(firstUpdatedDeSelected).toMatchSnapshot('after second click render Label 1 is deselected')
         expect(secondUpdatedStillSelected).toMatchSnapshot('after second click render Label 2 is selected')
       }, 10000)
+
+      it('is ignored if "selectable" is set to false', async() => {
+        const onClick = jest.fn()
+        const props: DropdownProps = {
+          ...defaultProps,
+          multiple: true,
+          onClick,
+          selectable: false,
+        }
+
+        renderDropdown({ props })
+        const button = screen.getByText('test-trigger-button')
+        userEvent.click(button)
+        const el = await screen.findByRole('menuitem', { name: 'Label 1' })
+        expect(el).toMatchSnapshot('at first render Label 1 is not selected')
+
+        userEvent.click(el)
+
+        // eslint-disable-next-line max-nested-callbacks
+        await waitFor(() => expect(onClick).toHaveBeenCalled())
+
+        userEvent.click(button)
+        const firstUpdated = await screen.findByRole('menuitem', { name: 'Label 1' })
+        expect(firstUpdated).toMatchSnapshot('after click render Label 1 is still not selected')
+      })
     })
   })
 })

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -300,13 +300,13 @@ describe('Dropdown Component', () => {
         expect(firstUpdated).toMatchSnapshot('after click render Label 1 is still not selected')
       })
 
-      it('render and ignores "initialSelectedItems" prop if "selectable" is true', async() => {
+      it('render and ignores "initialSelectedItems" prop if "selectable" is false', async() => {
         const onClick = jest.fn()
         const props: DropdownProps = {
           ...defaultProps,
           initialSelectedItems: ['1'],
           onClick,
-          selectable: true,
+          selectable: false,
         }
 
         renderDropdown({ props })

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -276,12 +276,12 @@ describe('Dropdown Component', () => {
         expect(secondUpdated).toMatchSnapshot('after click render Label 2 is selected')
       })
 
-      it('does not highlight elements if selectable is set to false', async() => {
+      it('does not highlight elements if persistSelection is set to false', async() => {
         const onClick = jest.fn()
         const props: DropdownProps = {
           ...defaultProps,
           onClick,
-          selectable: false,
+          persistSelection: false,
         }
 
         renderDropdown({ props })
@@ -300,13 +300,13 @@ describe('Dropdown Component', () => {
         expect(firstUpdated).toMatchSnapshot('after click render Label 1 is still not selected')
       })
 
-      it('render and ignores "initialSelectedItems" prop if "selectable" is false', async() => {
+      it('render and ignores "initialSelectedItems" prop if "persistSelection" is false', async() => {
         const onClick = jest.fn()
         const props: DropdownProps = {
           ...defaultProps,
           initialSelectedItems: ['1'],
           onClick,
-          selectable: false,
+          persistSelection: false,
         }
 
         renderDropdown({ props })
@@ -358,13 +358,13 @@ describe('Dropdown Component', () => {
         expect(secondUpdatedStillSelected).toMatchSnapshot('after second click render Label 2 is selected')
       }, 10000)
 
-      it('is ignored if "selectable" is set to false', async() => {
+      it('is ignored if "persistSelection" is set to false', async() => {
         const onClick = jest.fn()
         const props: DropdownProps = {
           ...defaultProps,
           multiple: true,
           onClick,
-          selectable: false,
+          persistSelection: false,
         }
 
         renderDropdown({ props })

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -70,10 +70,16 @@ export const Dropdown = ({
   /* istanbul ignore next */
   const innerNode = useMemo(() => (children ? <span>{children}</span> : null), [children])
 
-  const [selectedItems, setSelectedItems] = useState<string[]>(initialSelectedItems)
+  const [selectedItems, setSelectedItems] = useState<string[]>(selectable ? initialSelectedItems : [])
   const updateSelectedItems = useCallback(
-    (itemId: string) => setSelectedItems(prevItems => (multiple ? pushOrRemove(prevItems, itemId) : [itemId])),
-    [multiple]
+    (itemId: string) => {
+      if (!selectable) {
+        return
+      }
+
+      setSelectedItems(prevItems => (multiple ? pushOrRemove(prevItems, itemId) : [itemId]))
+    },
+    [multiple, selectable]
   )
 
   const onAntdMenuClick = useCallback(
@@ -94,8 +100,8 @@ export const Dropdown = ({
     /* istanbul ignore next */
     getPopupContainer: (triggerNode: HTMLElement) => (document.querySelector(`.${uniqueClassName}`) || triggerNode) as HTMLElement,
     onClick: onAntdMenuClick,
-    selectedKeys: selectable ? selectedItems : [],
-  }), [antdItems, onAntdMenuClick, selectable, selectedItems, uniqueClassName])
+    selectedKeys: selectedItems,
+  }), [antdItems, onAntdMenuClick, selectedItems, uniqueClassName])
 
   const classes = useMemo(() => classNames(styles.dropdownWrapper, uniqueClassName), [uniqueClassName])
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -60,6 +60,7 @@ export const Dropdown = ({
   getPopupContainer,
   initialSelectedItems = defaults.initialSelectedItems,
   multiple,
+  selectable = true,
 }: DropdownProps): ReactElement => {
   const uniqueClassName = useMemo(() => `dropdown-${crypto.randomUUID()}`, [])
 
@@ -93,8 +94,8 @@ export const Dropdown = ({
     /* istanbul ignore next */
     getPopupContainer: (triggerNode: HTMLElement) => (document.querySelector(`.${uniqueClassName}`) || triggerNode) as HTMLElement,
     onClick: onAntdMenuClick,
-    selectedKeys: selectedItems,
-  }), [antdItems, onAntdMenuClick, selectedItems, uniqueClassName])
+    selectedKeys: selectable ? selectedItems : [],
+  }), [antdItems, onAntdMenuClick, selectable, selectedItems, uniqueClassName])
 
   const classes = useMemo(() => classNames(styles.dropdownWrapper, uniqueClassName), [uniqueClassName])
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -60,7 +60,7 @@ export const Dropdown = ({
   getPopupContainer,
   initialSelectedItems = defaults.initialSelectedItems,
   multiple,
-  selectable = true,
+  persistSelection = true,
 }: DropdownProps): ReactElement => {
   const uniqueClassName = useMemo(() => `dropdown-${crypto.randomUUID()}`, [])
 
@@ -70,16 +70,16 @@ export const Dropdown = ({
   /* istanbul ignore next */
   const innerNode = useMemo(() => (children ? <span>{children}</span> : null), [children])
 
-  const [selectedItems, setSelectedItems] = useState<string[]>(selectable ? initialSelectedItems : [])
+  const [selectedItems, setSelectedItems] = useState<string[]>(persistSelection ? initialSelectedItems : [])
   const updateSelectedItems = useCallback(
     (itemId: string) => {
-      if (!selectable) {
+      if (!persistSelection) {
         return
       }
 
       setSelectedItems(prevItems => (multiple ? pushOrRemove(prevItems, itemId) : [itemId]))
     },
-    [multiple, selectable]
+    [multiple, persistSelection]
   )
 
   const onAntdMenuClick = useCallback(

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -1,5 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Dropdown Component highlights selectedItems multiple mode is ignored if "selectable" is set to false: after click render Label 1 is still not selected 1`] = `
+<li
+  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-active mia-platform-dropdown-menu-item-only-child"
+  data-menu-id="rc-menu-uuid-test-1"
+  role="menuitem"
+  tabindex="-1"
+>
+  <span
+    class="mia-platform-dropdown-menu-title-content"
+  >
+    <div
+      class="itemRowContainer"
+    >
+      <div
+        class="labelsContainer horizontalContainer"
+      >
+        <span
+          class="primaryLabel"
+        >
+          Label 1
+        </span>
+      </div>
+    </div>
+  </span>
+</li>
+`;
+
+exports[`Dropdown Component highlights selectedItems multiple mode is ignored if "selectable" is set to false: at first render Label 1 is not selected 1`] = `
+<li
+  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-only-child"
+  data-menu-id="rc-menu-uuid-test-1"
+  role="menuitem"
+  tabindex="-1"
+>
+  <span
+    class="mia-platform-dropdown-menu-title-content"
+  >
+    <div
+      class="itemRowContainer"
+    >
+      <div
+        class="labelsContainer horizontalContainer"
+      >
+        <span
+          class="primaryLabel"
+        >
+          Label 1
+        </span>
+      </div>
+    </div>
+  </span>
+</li>
+`;
+
 exports[`Dropdown Component highlights selectedItems multiple mode renders proper highlight: after click render Label 1 is selected 1`] = `
 <li
   class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-selected mia-platform-dropdown-menu-item-only-child"
@@ -129,6 +183,87 @@ exports[`Dropdown Component highlights selectedItems multiple mode renders prope
 `;
 
 exports[`Dropdown Component highlights selectedItems multiple mode renders proper highlight: first render with pre-selected label 1 1`] = `
+<li
+  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-selected mia-platform-dropdown-menu-item-only-child"
+  data-menu-id="rc-menu-uuid-test-1"
+  role="menuitem"
+  tabindex="-1"
+>
+  <span
+    class="mia-platform-dropdown-menu-title-content"
+  >
+    <div
+      class="itemRowContainer"
+    >
+      <div
+        class="labelsContainer horizontalContainer"
+      >
+        <span
+          class="primaryLabel"
+        >
+          Label 1
+        </span>
+      </div>
+    </div>
+  </span>
+</li>
+`;
+
+exports[`Dropdown Component highlights selectedItems single mode does not highlight elements if selectable is set to false: after click render Label 1 is still not selected 1`] = `
+<li
+  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-active mia-platform-dropdown-menu-item-only-child"
+  data-menu-id="rc-menu-uuid-test-1"
+  role="menuitem"
+  tabindex="-1"
+>
+  <span
+    class="mia-platform-dropdown-menu-title-content"
+  >
+    <div
+      class="itemRowContainer"
+    >
+      <div
+        class="labelsContainer horizontalContainer"
+      >
+        <span
+          class="primaryLabel"
+        >
+          Label 1
+        </span>
+      </div>
+    </div>
+  </span>
+</li>
+`;
+
+exports[`Dropdown Component highlights selectedItems single mode does not highlight elements if selectable is set to false: at first render Label 1 is not selected 1`] = `
+<li
+  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-only-child"
+  data-menu-id="rc-menu-uuid-test-1"
+  role="menuitem"
+  tabindex="-1"
+>
+  <span
+    class="mia-platform-dropdown-menu-title-content"
+  >
+    <div
+      class="itemRowContainer"
+    >
+      <div
+        class="labelsContainer horizontalContainer"
+      >
+        <span
+          class="primaryLabel"
+        >
+          Label 1
+        </span>
+      </div>
+    </div>
+  </span>
+</li>
+`;
+
+exports[`Dropdown Component highlights selectedItems single mode render and ignores "initialSelectedItems" prop if "selectable" is true: at first render Label 1 is not selected 1`] = `
 <li
   class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-selected mia-platform-dropdown-menu-item-only-child"
   data-menu-id="rc-menu-uuid-test-1"

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -263,9 +263,9 @@ exports[`Dropdown Component highlights selectedItems single mode does not highli
 </li>
 `;
 
-exports[`Dropdown Component highlights selectedItems single mode render and ignores "initialSelectedItems" prop if "selectable" is true: at first render Label 1 is not selected 1`] = `
+exports[`Dropdown Component highlights selectedItems single mode render and ignores "initialSelectedItems" prop if "selectable" is false: at first render Label 1 is not selected 1`] = `
 <li
-  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-selected mia-platform-dropdown-menu-item-only-child"
+  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-only-child"
   data-menu-id="rc-menu-uuid-test-1"
   role="menuitem"
   tabindex="-1"

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Dropdown Component highlights selectedItems multiple mode is ignored if "selectable" is set to false: after click render Label 1 is still not selected 1`] = `
+exports[`Dropdown Component highlights selectedItems multiple mode is ignored if "persistSelection" is set to false: after click render Label 1 is still not selected 1`] = `
 <li
   class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-active mia-platform-dropdown-menu-item-only-child"
   data-menu-id="rc-menu-uuid-test-1"
@@ -27,7 +27,7 @@ exports[`Dropdown Component highlights selectedItems multiple mode is ignored if
 </li>
 `;
 
-exports[`Dropdown Component highlights selectedItems multiple mode is ignored if "selectable" is set to false: at first render Label 1 is not selected 1`] = `
+exports[`Dropdown Component highlights selectedItems multiple mode is ignored if "persistSelection" is set to false: at first render Label 1 is not selected 1`] = `
 <li
   class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-only-child"
   data-menu-id="rc-menu-uuid-test-1"
@@ -209,7 +209,7 @@ exports[`Dropdown Component highlights selectedItems multiple mode renders prope
 </li>
 `;
 
-exports[`Dropdown Component highlights selectedItems single mode does not highlight elements if selectable is set to false: after click render Label 1 is still not selected 1`] = `
+exports[`Dropdown Component highlights selectedItems single mode does not highlight elements if persistSelection is set to false: after click render Label 1 is still not selected 1`] = `
 <li
   class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-active mia-platform-dropdown-menu-item-only-child"
   data-menu-id="rc-menu-uuid-test-1"
@@ -236,7 +236,7 @@ exports[`Dropdown Component highlights selectedItems single mode does not highli
 </li>
 `;
 
-exports[`Dropdown Component highlights selectedItems single mode does not highlight elements if selectable is set to false: at first render Label 1 is not selected 1`] = `
+exports[`Dropdown Component highlights selectedItems single mode does not highlight elements if persistSelection is set to false: at first render Label 1 is not selected 1`] = `
 <li
   class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-only-child"
   data-menu-id="rc-menu-uuid-test-1"
@@ -263,7 +263,7 @@ exports[`Dropdown Component highlights selectedItems single mode does not highli
 </li>
 `;
 
-exports[`Dropdown Component highlights selectedItems single mode render and ignores "initialSelectedItems" prop if "selectable" is false: at first render Label 1 is not selected 1`] = `
+exports[`Dropdown Component highlights selectedItems single mode render and ignores "initialSelectedItems" prop if "persistSelection" is false: at first render Label 1 is not selected 1`] = `
 <li
   class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-only-child"
   data-menu-id="rc-menu-uuid-test-1"

--- a/src/components/Dropdown/props.ts
+++ b/src/components/Dropdown/props.ts
@@ -108,6 +108,13 @@ export type DropdownProps = {
   children?: ReactElement,
 
   /**
+   * Set to `true` to keep the selected value highlighted after the selection.
+   * Useful in case you need to keep the selected option after the dropdown is closed.
+   * Defaults to `true`.
+   */
+  selectable?: boolean,
+
+  /**
    * List of items to be shown as selected at first render
    */
   initialSelectedItems?: string[],
@@ -129,6 +136,8 @@ export type DropdownProps = {
 
   /**
    * control whether to allow multiple highlight selection.
+   *
+   * _NOTE_: this property does not work if _selectable_ is set to `true`
    */
   multiple?: boolean
 

--- a/src/components/Dropdown/props.ts
+++ b/src/components/Dropdown/props.ts
@@ -112,10 +112,12 @@ export type DropdownProps = {
    * Useful in case you need to keep the selected option after the dropdown is closed.
    * Defaults to `true`.
    */
-  selectable?: boolean,
+  persistSelection?: boolean,
 
   /**
-   * List of items to be shown as selected at first render
+   * List of items to be shown as selected at first render.
+   *
+   * _NOTE_: this property does not work if _persistSelection_ is set to `false`
    */
   initialSelectedItems?: string[],
 
@@ -137,7 +139,7 @@ export type DropdownProps = {
   /**
    * control whether to allow multiple highlight selection.
    *
-   * _NOTE_: this property does not work if _selectable_ is set to `true`
+   * _NOTE_: this property does not work if _persistSelection_ is set to `false`
    */
   multiple?: boolean
 


### PR DESCRIPTION
### Description

<!-- Please provide a brief description of your changes. Summarize the rationale and impact on the codebase. E.g.

##### <Changed component name>
    - change 1
    - change 2
    - ...
-->

#### Dropdown

Including new prop, called **selectable**, if not included it defaults to `true`. 

When set to `false`, any selection will not be saved. This might be useful in case a dropdown is used as a selection menu (and we do not need to show any previous selection when re-opening the menu).

Includes tests and storybook.

### Addressed issue

<!-- Link to the issue, if present. E.g. 
    Closes #XYZ
-->

### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g., enhancement, bug).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [X] Changes are covered by tests 
- [X] Changes to components are accessible and documented in the Storybook
- [ ] Typings have been updated
- [ ] New components are exported from the `index` file
- [ ] New files include the Apache 2.0 License disclaimer
- [X] The browser console does not contain errors
