### PR TITLE
feat: menu extra with icon + antd upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@fontsource/inter": "^5.0.20",
-    "antd": "5.17.0",
+    "antd": "5.21.0",
     "lodash-es": "^4.17.21",
     "react-icons": "^5.3.0"
   },

--- a/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -138,7 +138,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 1`] = `
               class="breadcrumbItemLabelText"
             >
               <div
-                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
                 role="paragraph"
               >
                 Text 1
@@ -221,7 +221,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 1`] = `
             class="breadcrumbItemLabelText"
           >
             <div
-              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
               role="paragraph"
             >
               Text 8
@@ -250,7 +250,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 1`] = `
               class="breadcrumbItemLabelText"
             >
               <div
-                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
                 role="paragraph"
               >
                 Text 1
@@ -272,7 +272,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 1`] = `
               class="breadcrumbItemLabelText"
             >
               <div
-                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
                 role="paragraph"
               >
                 Text 2
@@ -294,7 +294,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 1`] = `
               class="breadcrumbItemLabelText"
             >
               <div
-                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
                 role="paragraph"
               >
                 Text 3
@@ -332,7 +332,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 1`] = `
               class="breadcrumbItemLabelText"
             >
               <div
-                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
                 role="paragraph"
               >
                 Text 4
@@ -351,7 +351,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 1`] = `
             class="breadcrumbItemLabelText"
           >
             <div
-              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
               role="paragraph"
             >
               Text 5
@@ -389,7 +389,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 1`] = `
             class="breadcrumbItemLabelText"
           >
             <div
-              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
               role="paragraph"
             >
               Item 1
@@ -414,7 +414,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 1`] = `
               class="breadcrumbItemLabelText"
             >
               <div
-                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
                 role="paragraph"
               >
                 Text 7
@@ -433,7 +433,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 1`] = `
             class="breadcrumbItemLabelText"
           >
             <div
-              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
               role="paragraph"
             >
               Text 8
@@ -471,7 +471,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 2`] = `
               class="breadcrumbItemLabelText"
             >
               <div
-                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
                 role="paragraph"
               >
                 Text 1
@@ -554,7 +554,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 2`] = `
             class="breadcrumbItemLabelText"
           >
             <div
-              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
               role="paragraph"
             >
               Text 8
@@ -583,7 +583,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 2`] = `
               class="breadcrumbItemLabelText"
             >
               <div
-                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
                 role="paragraph"
               >
                 Text 1
@@ -605,7 +605,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 2`] = `
               class="breadcrumbItemLabelText"
             >
               <div
-                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
                 role="paragraph"
               >
                 Text 2
@@ -627,7 +627,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 2`] = `
               class="breadcrumbItemLabelText"
             >
               <div
-                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
                 role="paragraph"
               >
                 Text 3
@@ -665,7 +665,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 2`] = `
               class="breadcrumbItemLabelText"
             >
               <div
-                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
                 role="paragraph"
               >
                 Text 4
@@ -684,7 +684,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 2`] = `
             class="breadcrumbItemLabelText"
           >
             <div
-              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
               role="paragraph"
             >
               Text 5
@@ -722,7 +722,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 2`] = `
             class="breadcrumbItemLabelText"
           >
             <div
-              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
               role="paragraph"
             >
               Item 1
@@ -747,7 +747,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 2`] = `
               class="breadcrumbItemLabelText"
             >
               <div
-                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
                 role="paragraph"
               >
                 Text 7
@@ -766,7 +766,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 2`] = `
             class="breadcrumbItemLabelText"
           >
             <div
-              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
               role="paragraph"
             >
               Text 8
@@ -805,7 +805,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 2`] = `
                 class="mia-platform-dropdown-menu-title-content"
               >
                 <div
-                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyS"
+                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyS"
                   role="paragraph"
                 >
                   Text 2
@@ -822,7 +822,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 2`] = `
                 class="mia-platform-dropdown-menu-title-content"
               >
                 <div
-                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyS"
+                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyS"
                   role="paragraph"
                 >
                   Text 3
@@ -859,7 +859,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 2`] = `
                 class="mia-platform-dropdown-menu-title-content"
               >
                 <div
-                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyS"
+                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyS"
                   role="paragraph"
                 >
                   Text 4
@@ -876,7 +876,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 2`] = `
                 class="mia-platform-dropdown-menu-title-content"
               >
                 <div
-                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyS"
+                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyS"
                   role="paragraph"
                 >
                   Text 5
@@ -913,7 +913,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 2`] = `
                 class="mia-platform-dropdown-menu-title-content"
               >
                 <div
-                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyS"
+                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyS"
                   role="paragraph"
                 >
                   Item 1
@@ -930,7 +930,7 @@ exports[`Breadcrumb Component renders a breadcrumb with collapsed items 2`] = `
                 class="mia-platform-dropdown-menu-title-content"
               >
                 <div
-                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyS"
+                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyS"
                   role="paragraph"
                 >
                   Text 7
@@ -980,7 +980,7 @@ exports[`Breadcrumb Component renders a breadcrumb with different button types 1
               class="breadcrumbItemLabelText"
             >
               <div
-                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
                 role="paragraph"
               >
                 Text
@@ -1002,7 +1002,7 @@ exports[`Breadcrumb Component renders a breadcrumb with different button types 1
               class="breadcrumbItemLabelText"
             >
               <div
-                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
                 role="paragraph"
               >
                 Very long text that should be ellipsed at some point
@@ -1068,7 +1068,7 @@ exports[`Breadcrumb Component renders a breadcrumb with different button types 1
               class="breadcrumbItemLabelText"
             >
               <div
-                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
                 role="paragraph"
               >
                 Text
@@ -1103,7 +1103,7 @@ exports[`Breadcrumb Component renders a breadcrumb with different button types 1
             class="breadcrumbItemLabelText"
           >
             <div
-              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
               role="paragraph"
             >
               Text
@@ -1141,7 +1141,7 @@ exports[`Breadcrumb Component renders a breadcrumb with different button types 1
             class="breadcrumbItemLabelText"
           >
             <div
-              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
               role="paragraph"
             >
               Text
@@ -1182,7 +1182,7 @@ exports[`Breadcrumb Component renders a breadcrumb with different button types 1
               class="breadcrumbItemLabelText"
             >
               <div
-                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
                 role="paragraph"
               >
                 Text
@@ -1253,7 +1253,7 @@ exports[`Breadcrumb Component renders controlled item menu correctly 1`] = `
             class="breadcrumbItemLabelText"
           >
             <div
-              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
               role="paragraph"
             >
               Text
@@ -1295,7 +1295,7 @@ exports[`Breadcrumb Component renders controlled item menu correctly 1`] = `
             class="breadcrumbItemLabelText"
           >
             <div
-              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
               role="paragraph"
             >
               Text
@@ -1369,7 +1369,7 @@ exports[`Breadcrumb Component renders controlled item menu correctly 1`] = `
                 class="mia-platform-dropdown-menu-title-content"
               >
                 <div
-                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyS"
+                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyS"
                   role="paragraph"
                 >
                   Item 1
@@ -1402,7 +1402,7 @@ exports[`Breadcrumb Component renders controlled item menu correctly 1`] = `
                 class="mia-platform-dropdown-menu-title-content"
               >
                 <div
-                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyS"
+                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyS"
                   role="paragraph"
                 >
                   Item 2
@@ -1458,7 +1458,7 @@ exports[`Breadcrumb Component renders item menu correctly 1`] = `
               class="breadcrumbItemLabelText"
             >
               <div
-                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
                 role="paragraph"
               >
                 Text
@@ -1522,7 +1522,7 @@ exports[`Breadcrumb Component renders item menu correctly 1`] = `
             class="breadcrumbItemLabelText"
           >
             <div
-              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
               role="paragraph"
             >
               Sub item
@@ -1567,7 +1567,7 @@ exports[`Breadcrumb Component renders item menu correctly 1`] = `
               class="breadcrumbItemLabelText"
             >
               <div
-                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
                 role="paragraph"
               >
                 Text
@@ -1610,7 +1610,7 @@ exports[`Breadcrumb Component renders item menu correctly 1`] = `
             class="breadcrumbItemLabelText"
           >
             <div
-              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
               role="paragraph"
             >
               Sub item
@@ -1664,7 +1664,7 @@ exports[`Breadcrumb Component renders item menu correctly 2`] = `
               class="breadcrumbItemLabelText"
             >
               <div
-                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
                 role="paragraph"
               >
                 Text
@@ -1728,7 +1728,7 @@ exports[`Breadcrumb Component renders item menu correctly 2`] = `
             class="breadcrumbItemLabelText"
           >
             <div
-              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
               role="paragraph"
             >
               Sub item
@@ -1773,7 +1773,7 @@ exports[`Breadcrumb Component renders item menu correctly 2`] = `
               class="breadcrumbItemLabelText"
             >
               <div
-                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
                 role="paragraph"
               >
                 Text
@@ -1816,7 +1816,7 @@ exports[`Breadcrumb Component renders item menu correctly 2`] = `
             class="breadcrumbItemLabelText"
           >
             <div
-              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
               role="paragraph"
             >
               Sub item
@@ -1890,7 +1890,7 @@ exports[`Breadcrumb Component renders item menu correctly 2`] = `
                 class="mia-platform-dropdown-menu-title-content"
               >
                 <div
-                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyS"
+                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyS"
                   role="paragraph"
                 >
                   Item 1
@@ -1923,7 +1923,7 @@ exports[`Breadcrumb Component renders item menu correctly 2`] = `
                 class="mia-platform-dropdown-menu-title-content"
               >
                 <div
-                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyS"
+                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyS"
                   role="paragraph"
                 >
                   Item 2
@@ -1979,7 +1979,7 @@ exports[`Breadcrumb Component renders item menu correctly 3`] = `
               class="breadcrumbItemLabelText"
             >
               <div
-                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
                 role="paragraph"
               >
                 Text
@@ -2043,7 +2043,7 @@ exports[`Breadcrumb Component renders item menu correctly 3`] = `
             class="breadcrumbItemLabelText"
           >
             <div
-              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
               role="paragraph"
             >
               Sub item
@@ -2088,7 +2088,7 @@ exports[`Breadcrumb Component renders item menu correctly 3`] = `
               class="breadcrumbItemLabelText"
             >
               <div
-                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+                class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
                 role="paragraph"
               >
                 Text
@@ -2131,7 +2131,7 @@ exports[`Breadcrumb Component renders item menu correctly 3`] = `
             class="breadcrumbItemLabelText"
           >
             <div
-              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyL"
+              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyL"
               role="paragraph"
             >
               Sub item
@@ -2205,7 +2205,7 @@ exports[`Breadcrumb Component renders item menu correctly 3`] = `
                 class="mia-platform-dropdown-menu-title-content"
               >
                 <div
-                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyS"
+                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyS"
                   role="paragraph"
                 >
                   Item 1
@@ -2262,7 +2262,7 @@ exports[`Breadcrumb Component renders item menu correctly 3`] = `
                 class="mia-platform-dropdown-menu-title-content"
               >
                 <div
-                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line bodyS"
+                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyS"
                   role="paragraph"
                 >
                   Sub item

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button Component renders block button correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-block button buttonMd"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid mia-platform-btn-block button buttonMd"
     type="button"
   >
     <div
@@ -18,7 +18,7 @@ exports[`Button Component renders block button correctly 1`] = `
 exports[`Button Component renders button with href correctly 1`] = `
 <DocumentFragment>
   <a
-    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid button buttonMd"
     href="https://mia-platform.eu"
     rel="noopener noreferrer"
     tabindex="0"
@@ -35,7 +35,7 @@ exports[`Button Component renders button with href correctly 1`] = `
 exports[`Button Component renders button with icon left correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid button buttonMd"
     type="button"
   >
     <span
@@ -70,16 +70,11 @@ exports[`Button Component renders button with icon left correctly 1`] = `
 exports[`Button Component renders button with icon right correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid mia-platform-btn-icon-end button buttonMd"
     type="button"
   >
-    <div
-      class="buttonText"
-    >
-      Button
-    </div>
     <span
-      class="mia-platform-btn-icon mia-platform-btn-icon-end"
+      class="mia-platform-btn-icon"
     >
       <svg
         color="white"
@@ -98,6 +93,11 @@ exports[`Button Component renders button with icon right correctly 1`] = `
         />
       </svg>
     </span>
+    <div
+      class="buttonText"
+    >
+      Button
+    </div>
   </button>
 </DocumentFragment>
 `;
@@ -105,7 +105,7 @@ exports[`Button Component renders button with icon right correctly 1`] = `
 exports[`Button Component renders circle button correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only button buttonMdIconOnly"
+    class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-solid mia-platform-btn-icon-only button buttonMdIconOnly"
     type="button"
   >
     <span
@@ -135,7 +135,7 @@ exports[`Button Component renders circle button correctly 1`] = `
 exports[`Button Component renders danger filled button correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-dangerous button buttonMd"
+    class="mia-platform-btn mia-platform-btn-dangerous mia-platform-btn-solid button buttonMd"
     type="button"
   >
     <div
@@ -150,7 +150,7 @@ exports[`Button Component renders danger filled button correctly 1`] = `
 exports[`Button Component renders danger ghost button correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-background-ghost mia-platform-btn-dangerous button buttonMd buttonGhost"
+    class="mia-platform-btn mia-platform-btn-dangerous mia-platform-btn-solid mia-platform-btn-background-ghost button buttonMd buttonGhost"
     type="button"
   >
     <div
@@ -165,7 +165,7 @@ exports[`Button Component renders danger ghost button correctly 1`] = `
 exports[`Button Component renders danger link button correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-background-ghost mia-platform-btn-dangerous button buttonGhost buttonLink"
+    class="mia-platform-btn mia-platform-btn-dangerous mia-platform-btn-solid mia-platform-btn-background-ghost button buttonGhost buttonLink"
     type="button"
   >
     <div>
@@ -178,7 +178,7 @@ exports[`Button Component renders danger link button correctly 1`] = `
 exports[`Button Component renders danger outline button correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-background-ghost mia-platform-btn-dangerous button buttonMd"
+    class="mia-platform-btn mia-platform-btn-dangerous mia-platform-btn-solid mia-platform-btn-background-ghost button buttonMd"
     type="button"
   >
     <div
@@ -193,7 +193,7 @@ exports[`Button Component renders danger outline button correctly 1`] = `
 exports[`Button Component renders disabled button correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid button buttonMd"
     disabled=""
     type="button"
   >
@@ -209,7 +209,7 @@ exports[`Button Component renders disabled button correctly 1`] = `
 exports[`Button Component renders large button correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-lg button buttonLg"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid mia-platform-btn-lg button buttonLg"
     type="button"
   >
     <div
@@ -224,7 +224,7 @@ exports[`Button Component renders large button correctly 1`] = `
 exports[`Button Component renders loading button correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-loading button buttonMd"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid mia-platform-btn-loading button buttonMd"
     type="button"
   >
     <span
@@ -262,7 +262,7 @@ exports[`Button Component renders loading button correctly 1`] = `
 exports[`Button Component renders middle button correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid button buttonMd"
     type="button"
   >
     <div
@@ -277,7 +277,7 @@ exports[`Button Component renders middle button correctly 1`] = `
 exports[`Button Component renders neutral ghost button correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-default button buttonMd buttonGhost"
+    class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined button buttonMd buttonGhost"
     type="button"
   >
     <div
@@ -292,7 +292,7 @@ exports[`Button Component renders neutral ghost button correctly 1`] = `
 exports[`Button Component renders neutral link button correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-default button buttonGhost buttonLink"
+    class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined button buttonGhost buttonLink"
     type="button"
   >
     <div>
@@ -305,7 +305,7 @@ exports[`Button Component renders neutral link button correctly 1`] = `
 exports[`Button Component renders neutral outline button correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-default button buttonMd"
+    class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined button buttonMd"
     type="button"
   >
     <div
@@ -320,7 +320,7 @@ exports[`Button Component renders neutral outline button correctly 1`] = `
 exports[`Button Component renders primary filled button correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid button buttonMd"
     type="button"
   >
     <div
@@ -335,7 +335,7 @@ exports[`Button Component renders primary filled button correctly 1`] = `
 exports[`Button Component renders primary filled button correctly with form ref and htmlType 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid button buttonMd"
     form="some-form"
     type="submit"
   >
@@ -351,7 +351,7 @@ exports[`Button Component renders primary filled button correctly with form ref 
 exports[`Button Component renders primary ghost button correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-background-ghost button buttonMd buttonGhost"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid mia-platform-btn-background-ghost button buttonMd buttonGhost"
     type="button"
   >
     <div
@@ -366,7 +366,7 @@ exports[`Button Component renders primary ghost button correctly 1`] = `
 exports[`Button Component renders primary link button correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-background-ghost button buttonGhost buttonLink"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid mia-platform-btn-background-ghost button buttonGhost buttonLink"
     type="button"
   >
     <div>
@@ -379,7 +379,7 @@ exports[`Button Component renders primary link button correctly 1`] = `
 exports[`Button Component renders primary outline button correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-background-ghost button buttonMd"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid mia-platform-btn-background-ghost button buttonMd"
     type="button"
   >
     <div
@@ -394,7 +394,7 @@ exports[`Button Component renders primary outline button correctly 1`] = `
 exports[`Button Component renders primary outline button correctly with form ref and no htmlType 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-background-ghost button buttonMd"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid mia-platform-btn-background-ghost button buttonMd"
     form="some-form"
     type="submit"
   >
@@ -410,7 +410,7 @@ exports[`Button Component renders primary outline button correctly with form ref
 exports[`Button Component renders primary outline button correctly with form ref and reset htmlType 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-background-ghost button buttonMd"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid mia-platform-btn-background-ghost button buttonMd"
     form="some-form"
     type="reset"
   >
@@ -426,7 +426,7 @@ exports[`Button Component renders primary outline button correctly with form ref
 exports[`Button Component renders small button correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-sm button buttonSm"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid mia-platform-btn-sm button buttonSm"
     type="button"
   >
     <div
@@ -441,7 +441,7 @@ exports[`Button Component renders small button correctly 1`] = `
 exports[`Button Component renders small button icon only correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-sm mia-platform-btn-icon-only button buttonSmIconOnly"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid mia-platform-btn-sm mia-platform-btn-icon-only button buttonSmIconOnly"
     type="button"
   >
     <span
@@ -471,7 +471,7 @@ exports[`Button Component renders small button icon only correctly 1`] = `
 exports[`Button Component renders square button correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-icon-only button buttonMdIconOnly"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid mia-platform-btn-icon-only button buttonMdIconOnly"
     type="button"
   >
     <span

--- a/src/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/components/Card/__snapshots__/Card.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Card Component renders card correctly 1`] = `
         >
           <h3
             aria-label="Card Title"
-            class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h3"
+            class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line h3"
             role="h3"
           >
             Card Title
@@ -25,7 +25,7 @@ exports[`Card Component renders card correctly 1`] = `
             class="docLink"
           >
             <button
-              class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+              class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-solid mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
               type="button"
             >
               <span
@@ -60,7 +60,7 @@ exports[`Card Component renders card correctly 1`] = `
         </div>
       </div>
       <button
-        class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+        class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid button buttonMd"
         type="button"
       >
         <div
@@ -109,7 +109,7 @@ exports[`Card Component renders header only 1`] = `
         >
           <h3
             aria-label="Card Title"
-            class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h3"
+            class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line h3"
             role="h3"
           >
             Card Title
@@ -118,7 +118,7 @@ exports[`Card Component renders header only 1`] = `
             class="docLink"
           >
             <button
-              class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+              class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-solid mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
               type="button"
             >
               <span
@@ -153,7 +153,7 @@ exports[`Card Component renders header only 1`] = `
         </div>
       </div>
       <button
-        class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+        class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid button buttonMd"
         type="button"
       >
         <div

--- a/src/components/Drawer/__snapshots__/Drawer.test.tsx.snap
+++ b/src/components/Drawer/__snapshots__/Drawer.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`Drawer renders drawer with provided title and footer 1`] = `
               >
                 <h4
                   aria-label=""
-                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
+                  class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line h4"
                   role="h4"
                 >
                   <span>
@@ -99,7 +99,7 @@ exports[`Drawer renders drawer with provided title and footer 1`] = `
                 class="footerButtons"
               >
                 <button
-                  class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+                  class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid button buttonMd"
                   type="button"
                 >
                   <div

--- a/src/components/FeedbackMessage/__snapshots__/FeedbackMessage.test.tsx.snap
+++ b/src/components/FeedbackMessage/__snapshots__/FeedbackMessage.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`FeedbackMessage Component renders message with extra content 1`] = `
   >
     Feedback Message
     <button
-      class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+      class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid button buttonMd"
       type="button"
     >
       <div

--- a/src/components/Menu/Menu.mocks.tsx
+++ b/src/components/Menu/Menu.mocks.tsx
@@ -16,7 +16,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { PiAlien, PiAtom, PiCloud, PiGlobeHemisphereEast, PiGlobeHemisphereWest, PiMoon, PiPlanet, PiShield, PiSkull, PiSnowflake, PiStar, PiSun, PiSword, PiVirus, PiWind } from 'react-icons/pi'
+import {
+  PiAlien,
+  PiAnchor,
+  PiArrowSquareOut,
+  PiAtom,
+  PiCloud,
+  PiGlobeHemisphereEast,
+  PiGlobeHemisphereWest,
+  PiMoon,
+  PiPlanet,
+  PiShield,
+  PiSkull,
+  PiSnowflake,
+  PiStar,
+  PiSun,
+  PiSword,
+  PiVirus,
+  PiWind,
+} from 'react-icons/pi'
 
 import { Icon } from '../Icon'
 import { ItemType } from './Menu.types'
@@ -32,6 +50,26 @@ export const item = {
       aria-label="PiStar"
       color="currentColor"
       component={PiStar}
+      size={16}
+    />
+  ),
+}
+
+export const itemWithExtra = {
+  key: 'item-with-extra',
+  label: 'Item with Extra',
+  title: 'Item with Extra',
+  icon: (
+    <Icon
+      aria-label="PiAnchor"
+      component={PiAnchor}
+      size={16}
+    />
+  ),
+  extra: (
+    <Icon
+      aria-label="PiArrowSquareOut"
+      component={PiArrowSquareOut}
       size={16}
     />
   ),

--- a/src/components/Menu/Menu.module.css
+++ b/src/components/Menu/Menu.module.css
@@ -44,7 +44,7 @@
   }
   &:global(.mia-platform-menu-inline) > li[role*=presentation] > div[role*=presentation] {
     padding: var(--menu-pad) var(--menu-pad) var(--menu-pad-sm) var(--menu-pad-xs) !important;
-  } 
+  }
   &:global(.mia-platform-menu-inline.primary) div[role*=presentation] {
     padding-left: 0 !important;
   }
@@ -59,7 +59,17 @@
   &:global(.mia-platform-menu-vertical) div[role*=presentation] {
     padding: var(--menu-pad) var(--menu-pad) var(--menu-pad-sm) !important;
   }
-  
+
+  :global(.mia-platform-menu-title-content){
+    display: flex;
+    width: 100%;
+
+    :global(.mia-platform-menu-item-extra) {
+      display: flex;
+      color: unset;
+    }
+  }
+
   /*
     The popover is generated on the left when the parent node has a width less than the popover content.
     In the case of the left sidebar attached to the left side of the window causes the node to exit outside the screen.

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -19,7 +19,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
-import { category, divider, group, item, nestedGroup } from './Menu.mocks'
+import { category, divider, group, item, itemWithExtra, nestedGroup } from './Menu.mocks'
 import { Menu } from './'
 import { defaults } from './Menu'
 
@@ -29,6 +29,7 @@ const meta = {
     ...defaults,
     items: [
       item,
+      itemWithExtra,
       divider,
       category,
       divider,

--- a/src/components/Menu/Menu.types.ts
+++ b/src/components/Menu/Menu.types.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { MenuItemType } from 'antd/es/menu/hooks/useItems'
+import { Key, ReactNode } from 'react'
 
 export enum ItemType {
   Category = 'category',
@@ -34,12 +34,23 @@ export enum Mode {
   Vertical = 'vertical',
 }
 
+// Remapped from: https://github.com/ant-design/ant-design/blob/master/components/menu/interface.ts#L8
+export type AntdMenuItemType = {
+  danger?: boolean;
+  disabled?: boolean;
+  icon?: ReactNode;
+  label?: ReactNode;
+  key: Key;
+  title?: string;
+  children?: AntdMenuItemType[]
+}
+
 /**
  * Represents a menu item, extending the base type {@link MenuItemType}.
  *
  * @see {@link https://ant.design/components/menu#menuitemtype}
  */
-export type Item = MenuItemType & {
+export type Item = AntdMenuItemType & {
 
   /**
    * The type of the menu item.
@@ -50,4 +61,9 @@ export type Item = MenuItemType & {
    * An array of child items for nested menus.
    */
   children?: Item[];
+
+  /**
+   * optional extra to be appended to the menu item
+   */
+  extra?: ReactNode
 }

--- a/src/components/Menu/Menu.utils.tsx
+++ b/src/components/Menu/Menu.utils.tsx
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ItemType as AntItemType } from 'antd/es/menu/hooks/useItems'
+// import { ItemType as AntItemType } from 'antd/es/menu/hooks/useItems'
 
-import { Hierarchy, Item, ItemType } from './Menu.types'
+import { AntdMenuItemType, Hierarchy, Item, ItemType } from './Menu.types'
 
 const { Primary } = Hierarchy
 const { Category, Divider, Group } = ItemType
@@ -38,7 +38,7 @@ function formatLabels(
   selectedItem?: string,
   isCollapsed?: boolean,
   hierarchy?: Hierarchy
-): AntItemType[] {
+): AntdMenuItemType[] {
   return items.map(({ title, label, type, key, children, icon, ...item }) => {
     if (type === Category && isCollapsed) {
       return formatLabels(children, selectedItem, isCollapsed, hierarchy)

--- a/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -27,13 +27,8 @@ exports[`Modal Component renders fullscreen modal correctly (with empty header) 
         style="width: 520px;"
       >
         <div
-          aria-hidden="true"
-          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-          tabindex="0"
-        />
-        <div
           style="outline: none;"
-          tabindex="-1"
+          tabindex="0"
         >
           <div
             class="mia-platform-modal-content"
@@ -103,7 +98,7 @@ exports[`Modal Component renders fullscreen modal correctly (with empty header) 
                   class="footerButtons"
                 >
                   <button
-                    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+                    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid button buttonMd"
                     type="button"
                   >
                     <div
@@ -113,7 +108,7 @@ exports[`Modal Component renders fullscreen modal correctly (with empty header) 
                     </div>
                   </button>
                   <button
-                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                    class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined button buttonMd"
                     type="button"
                   >
                     <div
@@ -128,7 +123,6 @@ exports[`Modal Component renders fullscreen modal correctly (with empty header) 
           </div>
         </div>
         <div
-          aria-hidden="true"
           style="width: 0px; height: 0px; overflow: hidden; outline: none;"
           tabindex="0"
         />
@@ -159,13 +153,8 @@ exports[`Modal Component renders large modal correctly (with empty footer) 1`] =
         style="width: 520px;"
       >
         <div
-          aria-hidden="true"
-          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-          tabindex="0"
-        />
-        <div
           style="outline: none;"
-          tabindex="-1"
+          tabindex="0"
         >
           <div
             class="mia-platform-modal-content"
@@ -212,7 +201,7 @@ exports[`Modal Component renders large modal correctly (with empty footer) 1`] =
                 >
                   <h4
                     aria-label="Modal Title"
-                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
+                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line h4"
                     role="h4"
                   >
                     Modal Title
@@ -221,7 +210,7 @@ exports[`Modal Component renders large modal correctly (with empty footer) 1`] =
                     class="docLink"
                   >
                     <button
-                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-solid mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
                       type="button"
                     >
                       <span
@@ -273,7 +262,6 @@ exports[`Modal Component renders large modal correctly (with empty footer) 1`] =
           </div>
         </div>
         <div
-          aria-hidden="true"
           style="width: 0px; height: 0px; overflow: hidden; outline: none;"
           tabindex="0"
         />
@@ -304,13 +292,8 @@ exports[`Modal Component renders modal with aside fixed 1`] = `
         style="width: 520px;"
       >
         <div
-          aria-hidden="true"
-          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-          tabindex="0"
-        />
-        <div
           style="outline: none;"
-          tabindex="-1"
+          tabindex="0"
         >
           <div
             class="mia-platform-modal-content"
@@ -357,7 +340,7 @@ exports[`Modal Component renders modal with aside fixed 1`] = `
                 >
                   <h4
                     aria-label="Modal Title"
-                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
+                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line h4"
                     role="h4"
                   >
                     Modal Title
@@ -366,7 +349,7 @@ exports[`Modal Component renders modal with aside fixed 1`] = `
                     class="docLink"
                   >
                     <button
-                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-solid mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
                       type="button"
                     >
                       <span
@@ -435,7 +418,7 @@ exports[`Modal Component renders modal with aside fixed 1`] = `
                   class="footerButtons"
                 >
                   <button
-                    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+                    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid button buttonMd"
                     type="button"
                   >
                     <div
@@ -445,7 +428,7 @@ exports[`Modal Component renders modal with aside fixed 1`] = `
                     </div>
                   </button>
                   <button
-                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                    class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined button buttonMd"
                     type="button"
                   >
                     <div
@@ -460,7 +443,6 @@ exports[`Modal Component renders modal with aside fixed 1`] = `
           </div>
         </div>
         <div
-          aria-hidden="true"
           style="width: 0px; height: 0px; overflow: hidden; outline: none;"
           tabindex="0"
         />
@@ -491,13 +473,8 @@ exports[`Modal Component renders modal with aside openable 1`] = `
         style="width: 520px;"
       >
         <div
-          aria-hidden="true"
-          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-          tabindex="0"
-        />
-        <div
           style="outline: none;"
-          tabindex="-1"
+          tabindex="0"
         >
           <div
             class="mia-platform-modal-content"
@@ -544,7 +521,7 @@ exports[`Modal Component renders modal with aside openable 1`] = `
                 >
                   <h4
                     aria-label="Modal Title"
-                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
+                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line h4"
                     role="h4"
                   >
                     Modal Title
@@ -553,7 +530,7 @@ exports[`Modal Component renders modal with aside openable 1`] = `
                     class="docLink"
                   >
                     <button
-                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-solid mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
                       type="button"
                     >
                       <span
@@ -652,7 +629,7 @@ exports[`Modal Component renders modal with aside openable 1`] = `
                   class="footerButtons"
                 >
                   <button
-                    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+                    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid button buttonMd"
                     type="button"
                   >
                     <div
@@ -662,7 +639,7 @@ exports[`Modal Component renders modal with aside openable 1`] = `
                     </div>
                   </button>
                   <button
-                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                    class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined button buttonMd"
                     type="button"
                   >
                     <div
@@ -677,7 +654,6 @@ exports[`Modal Component renders modal with aside openable 1`] = `
           </div>
         </div>
         <div
-          aria-hidden="true"
           style="width: 0px; height: 0px; overflow: hidden; outline: none;"
           tabindex="0"
         />
@@ -708,13 +684,8 @@ exports[`Modal Component renders modal with aside openable 2`] = `
         style="width: 520px;"
       >
         <div
-          aria-hidden="true"
-          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-          tabindex="0"
-        />
-        <div
           style="outline: none;"
-          tabindex="-1"
+          tabindex="0"
         >
           <div
             class="mia-platform-modal-content"
@@ -761,7 +732,7 @@ exports[`Modal Component renders modal with aside openable 2`] = `
                 >
                   <h4
                     aria-label="Modal Title"
-                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
+                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line h4"
                     role="h4"
                   >
                     Modal Title
@@ -770,7 +741,7 @@ exports[`Modal Component renders modal with aside openable 2`] = `
                     class="docLink"
                   >
                     <button
-                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-solid mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
                       type="button"
                     >
                       <span
@@ -869,7 +840,7 @@ exports[`Modal Component renders modal with aside openable 2`] = `
                   class="footerButtons"
                 >
                   <button
-                    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+                    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid button buttonMd"
                     type="button"
                   >
                     <div
@@ -879,7 +850,7 @@ exports[`Modal Component renders modal with aside openable 2`] = `
                     </div>
                   </button>
                   <button
-                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                    class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined button buttonMd"
                     type="button"
                   >
                     <div
@@ -894,7 +865,6 @@ exports[`Modal Component renders modal with aside openable 2`] = `
           </div>
         </div>
         <div
-          aria-hidden="true"
           style="width: 0px; height: 0px; overflow: hidden; outline: none;"
           tabindex="0"
         />
@@ -925,13 +895,8 @@ exports[`Modal Component renders modal with body full width 1`] = `
         style="width: 520px;"
       >
         <div
-          aria-hidden="true"
-          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-          tabindex="0"
-        />
-        <div
           style="outline: none;"
-          tabindex="-1"
+          tabindex="0"
         >
           <div
             class="mia-platform-modal-content"
@@ -999,7 +964,6 @@ exports[`Modal Component renders modal with body full width 1`] = `
           </div>
         </div>
         <div
-          aria-hidden="true"
           style="width: 0px; height: 0px; overflow: hidden; outline: none;"
           tabindex="0"
         />
@@ -1030,13 +994,8 @@ exports[`Modal Component renders modal with custom footer 1`] = `
         style="width: 520px;"
       >
         <div
-          aria-hidden="true"
-          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-          tabindex="0"
-        />
-        <div
           style="outline: none;"
-          tabindex="-1"
+          tabindex="0"
         >
           <div
             class="mia-platform-modal-content"
@@ -1083,7 +1042,7 @@ exports[`Modal Component renders modal with custom footer 1`] = `
                 >
                   <h4
                     aria-label="Modal Title"
-                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
+                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line h4"
                     role="h4"
                   >
                     Modal Title
@@ -1092,7 +1051,7 @@ exports[`Modal Component renders modal with custom footer 1`] = `
                     class="docLink"
                   >
                     <button
-                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-solid mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
                       type="button"
                     >
                       <span
@@ -1144,7 +1103,7 @@ exports[`Modal Component renders modal with custom footer 1`] = `
                   class="footerButtons"
                 >
                   <button
-                    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+                    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid button buttonMd"
                     type="button"
                   >
                     <div
@@ -1154,7 +1113,7 @@ exports[`Modal Component renders modal with custom footer 1`] = `
                     </div>
                   </button>
                   <button
-                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                    class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined button buttonMd"
                     type="button"
                   >
                     <div
@@ -1164,7 +1123,7 @@ exports[`Modal Component renders modal with custom footer 1`] = `
                     </div>
                   </button>
                   <button
-                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                    class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined button buttonMd"
                     type="button"
                   >
                     <div
@@ -1174,7 +1133,7 @@ exports[`Modal Component renders modal with custom footer 1`] = `
                     </div>
                   </button>
                   <button
-                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                    class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined button buttonMd"
                     type="button"
                   >
                     <div
@@ -1190,7 +1149,6 @@ exports[`Modal Component renders modal with custom footer 1`] = `
           </div>
         </div>
         <div
-          aria-hidden="true"
           style="width: 0px; height: 0px; overflow: hidden; outline: none;"
           tabindex="0"
         />
@@ -1221,13 +1179,8 @@ exports[`Modal Component renders not closable modal 1`] = `
         style="width: 520px;"
       >
         <div
-          aria-hidden="true"
-          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-          tabindex="0"
-        />
-        <div
           style="outline: none;"
-          tabindex="-1"
+          tabindex="0"
         >
           <div
             class="mia-platform-modal-content"
@@ -1265,7 +1218,6 @@ exports[`Modal Component renders not closable modal 1`] = `
           </div>
         </div>
         <div
-          aria-hidden="true"
           style="width: 0px; height: 0px; overflow: hidden; outline: none;"
           tabindex="0"
         />
@@ -1296,13 +1248,8 @@ exports[`Modal Component renders small modal correctly (with children, docLink, 
         style="width: 520px;"
       >
         <div
-          aria-hidden="true"
-          style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-          tabindex="0"
-        />
-        <div
           style="outline: none;"
-          tabindex="-1"
+          tabindex="0"
         >
           <div
             class="mia-platform-modal-content"
@@ -1349,7 +1296,7 @@ exports[`Modal Component renders small modal correctly (with children, docLink, 
                 >
                   <h4
                     aria-label="Modal Title"
-                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-single-line mia-platform-typography-ellipsis-single-line h4"
+                    class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line h4"
                     role="h4"
                   >
                     Modal Title
@@ -1358,7 +1305,7 @@ exports[`Modal Component renders small modal correctly (with children, docLink, 
                     class="docLink"
                   >
                     <button
-                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
+                      class="mia-platform-btn mia-platform-btn-circle mia-platform-btn-primary mia-platform-btn-solid mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
                       type="button"
                     >
                       <span
@@ -1410,7 +1357,7 @@ exports[`Modal Component renders small modal correctly (with children, docLink, 
                   class="footerButtons"
                 >
                   <button
-                    class="mia-platform-btn mia-platform-btn-primary button buttonMd"
+                    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-solid button buttonMd"
                     type="button"
                   >
                     <div
@@ -1420,7 +1367,7 @@ exports[`Modal Component renders small modal correctly (with children, docLink, 
                     </div>
                   </button>
                   <button
-                    class="mia-platform-btn mia-platform-btn-default button buttonMd"
+                    class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined button buttonMd"
                     type="button"
                   >
                     <div
@@ -1435,7 +1382,6 @@ exports[`Modal Component renders small modal correctly (with children, docLink, 
           </div>
         </div>
         <div
-          aria-hidden="true"
           style="width: 0px; height: 0px; overflow: hidden; outline: none;"
           tabindex="0"
         />

--- a/src/components/Table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/Table/__snapshots__/Table.test.tsx.snap
@@ -211,7 +211,7 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
                           <span
@@ -246,7 +246,7 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
                           <span
@@ -281,7 +281,7 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
                           <span
@@ -316,7 +316,7 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost mia-platform-btn-dangerous button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-dangerous mia-platform-btn-solid mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
                           <span
@@ -376,7 +376,7 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
                           <span
@@ -411,7 +411,7 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
                           <span
@@ -446,7 +446,7 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
                           <span
@@ -481,7 +481,7 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost mia-platform-btn-dangerous button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-dangerous mia-platform-btn-solid mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
                           <span
@@ -541,7 +541,7 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
                           <span
@@ -576,7 +576,7 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
                           <span
@@ -611,7 +611,7 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           disabled=""
                           type="button"
                         >
@@ -647,7 +647,7 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost mia-platform-btn-dangerous button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-dangerous mia-platform-btn-solid mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
                           <span
@@ -707,7 +707,7 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
                           <span
@@ -742,7 +742,7 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
                           <span
@@ -777,7 +777,7 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined mia-platform-btn-icon-only button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
                           <span
@@ -812,7 +812,7 @@ exports[`Table Component renders actions correctly 1`] = `
                         class="action"
                       >
                         <button
-                          class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-icon-only mia-platform-btn-background-ghost mia-platform-btn-dangerous button buttonMdIconOnly buttonGhost"
+                          class="mia-platform-btn mia-platform-btn-dangerous mia-platform-btn-solid mia-platform-btn-icon-only mia-platform-btn-background-ghost button buttonMdIconOnly buttonGhost"
                           type="button"
                         >
                           <span
@@ -2256,7 +2256,7 @@ exports[`Table Component renders external filters and sorters correctly 1`] = `
           class="mia-platform-space-item"
         >
           <button
-            class="mia-platform-btn mia-platform-btn-default button buttonMd"
+            class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined button buttonMd"
             type="button"
           >
             <div
@@ -2270,7 +2270,7 @@ exports[`Table Component renders external filters and sorters correctly 1`] = `
           class="mia-platform-space-item"
         >
           <button
-            class="mia-platform-btn mia-platform-btn-default button buttonMd"
+            class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined button buttonMd"
             type="button"
           >
             <div
@@ -2284,7 +2284,7 @@ exports[`Table Component renders external filters and sorters correctly 1`] = `
           class="mia-platform-space-item"
         >
           <button
-            class="mia-platform-btn mia-platform-btn-default button buttonMd"
+            class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined button buttonMd"
             type="button"
           >
             <div
@@ -2298,7 +2298,7 @@ exports[`Table Component renders external filters and sorters correctly 1`] = `
           class="mia-platform-space-item"
         >
           <button
-            class="mia-platform-btn mia-platform-btn-default button buttonMd"
+            class="mia-platform-btn mia-platform-btn-default mia-platform-btn-outlined button buttonMd"
             type="button"
           >
             <div

--- a/src/components/Typography/BodyX/__snapshots__/BodyX.test.tsx.snap
+++ b/src/components/Typography/BodyX/__snapshots__/BodyX.test.tsx.snap
@@ -91,7 +91,7 @@ Ut in feugiat nunc, in eleifend ex.
       aria-label="Copy"
       class="mia-platform-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -137,7 +137,7 @@ Ut in feugiat nunc, in eleifend ex.
       aria-label="Copy to clipboard!"
       class="mia-platform-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <svg

--- a/src/components/Typography/HX/__snapshots__/HX.test.tsx.snap
+++ b/src/components/Typography/HX/__snapshots__/HX.test.tsx.snap
@@ -76,7 +76,7 @@ Ut in feugiat nunc, in eleifend ex.
       aria-label="Copy"
       class="mia-platform-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -131,7 +131,7 @@ Ut in feugiat nunc, in eleifend ex.
       aria-label="Copy to clipboard!"
       class="mia-platform-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <svg

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,7 +29,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ant-design/colors@npm:^7.0.0, @ant-design/colors@npm:^7.0.2":
+"@ant-design/colors@npm:^7.0.0, @ant-design/colors@npm:^7.1.0":
   version: 7.1.0
   resolution: "@ant-design/colors@npm:7.1.0"
   dependencies:
@@ -38,7 +38,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ant-design/cssinjs@npm:^1.19.1":
+"@ant-design/cssinjs-utils@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@ant-design/cssinjs-utils@npm:1.1.0"
+  dependencies:
+    "@ant-design/cssinjs": "npm:^1.21.0"
+    "@babel/runtime": "npm:^7.23.2"
+    rc-util: "npm:^5.38.0"
+  peerDependencies:
+    react: ">=16.9.0"
+    react-dom: ">=16.9.0"
+  checksum: 10/fad946fc9cd21514d9af21cd548acacf85cf214603e437901ff3d297176da1c66c13dcb04b6c879fa0901d5944a15029f02c383d97e29c8b380b35a02b962e7e
+  languageName: node
+  linkType: hard
+
+"@ant-design/cssinjs@npm:^1.21.0, @ant-design/cssinjs@npm:^1.21.1":
   version: 1.21.1
   resolution: "@ant-design/cssinjs@npm:1.21.1"
   dependencies:
@@ -56,6 +70,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ant-design/fast-color@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@ant-design/fast-color@npm:2.0.6"
+  dependencies:
+    "@babel/runtime": "npm:^7.24.7"
+  checksum: 10/94167d70e10d4c267875b97bbe282fe32e6a60aabbfb70dd9f3c5500c559e4c91c4881a364168629ec1c150441e37f0da3fa97d34cb3d24373535a792d91e627
+  languageName: node
+  linkType: hard
+
 "@ant-design/icons-svg@npm:^4.4.0":
   version: 4.4.2
   resolution: "@ant-design/icons-svg@npm:4.4.2"
@@ -63,9 +86,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ant-design/icons@npm:^5.3.6":
-  version: 5.4.0
-  resolution: "@ant-design/icons@npm:5.4.0"
+"@ant-design/icons@npm:^5.5.1":
+  version: 5.5.1
+  resolution: "@ant-design/icons@npm:5.5.1"
   dependencies:
     "@ant-design/colors": "npm:^7.0.0"
     "@ant-design/icons-svg": "npm:^4.4.0"
@@ -75,7 +98,7 @@ __metadata:
   peerDependencies:
     react: ">=16.0.0"
     react-dom: ">=16.0.0"
-  checksum: 10/63471e5c23762c733148246150452f75af0ccbe320a19d9044355cd9f1b36663afbe84faa3fd21a3a2f8eaf908c68f9e42466da560d6ddfd973ad9763d29c06f
+  checksum: 10/8e5c75df40285af0b87fbb88adaa0c2f566c7fda3282233e802981034a99e968f03f39705ecc7870824d4b4b3ee5dc1b8e733a3073717441dc5c691e07c28536
   languageName: node
   linkType: hard
 
@@ -1507,12 +1530,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.10.4, @babel/runtime@npm:^7.11.1, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.0, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.22.5, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.6, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.24.4, @babel/runtime@npm:^7.24.5, @babel/runtime@npm:^7.24.8, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.10.4, @babel/runtime@npm:^7.11.1, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.0, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.22.5, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.6, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.24.4, @babel/runtime@npm:^7.24.8, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
   version: 7.25.4
   resolution: "@babel/runtime@npm:7.25.4"
   dependencies:
     regenerator-runtime: "npm:^0.14.0"
   checksum: 10/70d2a420c24a3289ea6c4addaf3a1c4186bc3d001c92445faa3cd7601d7d2fbdb32c63b3a26b9771e20ff2f511fa76b726bf256f823cdb95bc37b8eadbd02f70
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.24.7, @babel/runtime@npm:^7.25.6":
+  version: 7.25.6
+  resolution: "@babel/runtime@npm:7.25.6"
+  dependencies:
+    regenerator-runtime: "npm:^0.14.0"
+  checksum: 10/0c4134734deb20e1005ffb9165bf342e1074576621b246d8e5e41cc7cb315a885b7d98950fbf5c63619a2990a56ae82f444d35fe8c4691a0b70c2fe5673667dc
   languageName: node
   linkType: hard
 
@@ -2531,7 +2563,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^7.17.0"
     "@typescript-eslint/parser": "npm:^7.15.0"
     "@vitejs/plugin-react-swc": "npm:^3.6.0"
-    antd: "npm:5.17.0"
+    antd: "npm:5.21.0"
     camelcase: "npm:^8.0.0"
     cheerio: "npm:^1.0.0"
     classnames: "npm:^2.5.1"
@@ -3287,18 +3319,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rc-component/color-picker@npm:~1.5.3":
-  version: 1.5.3
-  resolution: "@rc-component/color-picker@npm:1.5.3"
+"@rc-component/color-picker@npm:~2.0.1":
+  version: 2.0.1
+  resolution: "@rc-component/color-picker@npm:2.0.1"
   dependencies:
+    "@ant-design/fast-color": "npm:^2.0.6"
     "@babel/runtime": "npm:^7.23.6"
-    "@ctrl/tinycolor": "npm:^3.6.1"
     classnames: "npm:^2.2.6"
     rc-util: "npm:^5.38.1"
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/b0e54b69e583f62978aafa44e23a8f30a441352e37dc4b69772d2f19ce201b1e79b6ea1edda9fa1e71312205b5633f0709a215d976029e53cd133ff7f594dccb
+  checksum: 10/7c4268063a476184a8cf68fadc6f353ae303832f0e458478c5d6ad12ed4a4ffa77ae3d46aebc8823ebfa9e7efb44207e0478099a3ba0ea323cc338f1aebff6ef
   languageName: node
   linkType: hard
 
@@ -3352,9 +3384,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rc-component/tour@npm:~1.14.2":
-  version: 1.14.2
-  resolution: "@rc-component/tour@npm:1.14.2"
+"@rc-component/qrcode@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "@rc-component/qrcode@npm:1.0.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.24.7"
+    classnames: "npm:^2.3.2"
+    rc-util: "npm:^5.38.0"
+  peerDependencies:
+    react: ">=16.9.0"
+    react-dom: ">=16.9.0"
+  checksum: 10/946393e8c5522b5a1431ac433919f0d2c5654dd213d0e5aee1ffc2f9ab3508bd99be152261ccee2d8d6253d3ec25b19094ada54ab46e7373466aa9a20523cade
+  languageName: node
+  linkType: hard
+
+"@rc-component/tour@npm:~1.15.1":
+  version: 1.15.1
+  resolution: "@rc-component/tour@npm:1.15.1"
   dependencies:
     "@babel/runtime": "npm:^7.18.0"
     "@rc-component/portal": "npm:^1.0.0-9"
@@ -3364,7 +3410,7 @@ __metadata:
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/2409e511eb2d5c55031af07b2c53650cfa15af744a524ae05d6f034a789f182979219a6316e62a323d6f041f3a2d198809333867334954a55917a55abc3ac6b8
+  checksum: 10/6dfbb662c19456d78ac653e4ecdc359cea6590cbf52da5f8a06ddb229d367a567630c8aa493c479d631a11cd9fab12c744757a180324ce1c07861983e7444f43
   languageName: node
   linkType: hard
 
@@ -3382,6 +3428,23 @@ __metadata:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
   checksum: 10/d7835a7219c8f19adf913f219f1f7281a37b837fd9c793d68e62347eb07cb04740e1dfde0049ff2fee9d21e9c6aef5ea97210c810f0fb81ebf55f321ecddab3c
+  languageName: node
+  linkType: hard
+
+"@rc-component/trigger@npm:^2.2.3":
+  version: 2.2.3
+  resolution: "@rc-component/trigger@npm:2.2.3"
+  dependencies:
+    "@babel/runtime": "npm:^7.23.2"
+    "@rc-component/portal": "npm:^1.1.0"
+    classnames: "npm:^2.3.2"
+    rc-motion: "npm:^2.0.0"
+    rc-resize-observer: "npm:^1.3.1"
+    rc-util: "npm:^5.38.0"
+  peerDependencies:
+    react: ">=16.9.0"
+    react-dom: ">=16.9.0"
+  checksum: 10/1747ae80f8dd46f3d288b989ae5b799eaf1b37dbc23166fcbcae6bd5c45c6b3413b7e43724e9d8c363d4f8cd2ed6e91d94f3f26f32006cc65808842f246b2417
   languageName: node
   linkType: hard
 
@@ -5913,62 +5976,60 @@ __metadata:
   languageName: node
   linkType: hard
 
-"antd@npm:5.17.0":
-  version: 5.17.0
-  resolution: "antd@npm:5.17.0"
+"antd@npm:5.21.0":
+  version: 5.21.0
+  resolution: "antd@npm:5.21.0"
   dependencies:
-    "@ant-design/colors": "npm:^7.0.2"
-    "@ant-design/cssinjs": "npm:^1.19.1"
-    "@ant-design/icons": "npm:^5.3.6"
+    "@ant-design/colors": "npm:^7.1.0"
+    "@ant-design/cssinjs": "npm:^1.21.1"
+    "@ant-design/cssinjs-utils": "npm:^1.1.0"
+    "@ant-design/icons": "npm:^5.5.1"
     "@ant-design/react-slick": "npm:~1.1.2"
-    "@babel/runtime": "npm:^7.24.5"
+    "@babel/runtime": "npm:^7.25.6"
     "@ctrl/tinycolor": "npm:^3.6.1"
-    "@rc-component/color-picker": "npm:~1.5.3"
+    "@rc-component/color-picker": "npm:~2.0.1"
     "@rc-component/mutate-observer": "npm:^1.1.0"
-    "@rc-component/tour": "npm:~1.14.2"
-    "@rc-component/trigger": "npm:^2.1.1"
+    "@rc-component/qrcode": "npm:~1.0.0"
+    "@rc-component/tour": "npm:~1.15.1"
+    "@rc-component/trigger": "npm:^2.2.3"
     classnames: "npm:^2.5.1"
     copy-to-clipboard: "npm:^3.3.3"
-    dayjs: "npm:^1.11.10"
-    qrcode.react: "npm:^3.1.0"
-    rc-cascader: "npm:~3.25.0"
-    rc-checkbox: "npm:~3.2.0"
-    rc-collapse: "npm:~3.7.3"
-    rc-dialog: "npm:~9.4.0"
-    rc-drawer: "npm:~7.1.0"
+    dayjs: "npm:^1.11.11"
+    rc-cascader: "npm:~3.28.1"
+    rc-checkbox: "npm:~3.3.0"
+    rc-collapse: "npm:~3.8.0"
+    rc-dialog: "npm:~9.6.0"
+    rc-drawer: "npm:~7.2.0"
     rc-dropdown: "npm:~4.2.0"
-    rc-field-form: "npm:~2.0.0"
-    rc-image: "npm:~7.6.0"
-    rc-input: "npm:~1.4.5"
-    rc-input-number: "npm:~9.0.0"
-    rc-mentions: "npm:~2.11.1"
-    rc-menu: "npm:~9.13.0"
-    rc-motion: "npm:^2.9.0"
-    rc-notification: "npm:~5.4.0"
-    rc-pagination: "npm:~4.0.4"
-    rc-picker: "npm:~4.5.0"
+    rc-field-form: "npm:~2.4.0"
+    rc-image: "npm:~7.11.0"
+    rc-input: "npm:~1.6.3"
+    rc-input-number: "npm:~9.2.0"
+    rc-mentions: "npm:~2.16.1"
+    rc-menu: "npm:~9.15.1"
+    rc-motion: "npm:^2.9.3"
+    rc-notification: "npm:~5.6.1"
+    rc-pagination: "npm:~4.3.0"
+    rc-picker: "npm:~4.6.14"
     rc-progress: "npm:~4.0.0"
-    rc-rate: "npm:~2.12.0"
+    rc-rate: "npm:~2.13.0"
     rc-resize-observer: "npm:^1.4.0"
-    rc-segmented: "npm:~2.3.0"
-    rc-select: "npm:~14.13.1"
-    rc-slider: "npm:~10.6.2"
+    rc-segmented: "npm:~2.5.0"
+    rc-select: "npm:~14.15.2"
+    rc-slider: "npm:~11.1.6"
     rc-steps: "npm:~6.0.1"
     rc-switch: "npm:~4.1.0"
-    rc-table: "npm:~7.45.5"
-    rc-tabs: "npm:~15.0.0 "
-    rc-textarea: "npm:~1.6.3"
-    rc-tooltip: "npm:~6.2.0"
-    rc-tree: "npm:~5.8.5"
-    rc-tree-select: "npm:~5.20.0"
-    rc-upload: "npm:~4.5.2"
-    rc-util: "npm:^5.39.1"
+    rc-table: "npm:~7.47.5"
+    rc-tabs: "npm:~15.2.0"
+    rc-textarea: "npm:~1.8.2"
+    rc-tooltip: "npm:~6.2.1"
+    rc-tree: "npm:~5.9.0"
+    rc-tree-select: "npm:~5.23.0"
+    rc-upload: "npm:~4.8.1"
+    rc-util: "npm:^5.43.0"
     scroll-into-view-if-needed: "npm:^3.1.0"
-    throttle-debounce: "npm:^5.0.0"
-  peerDependencies:
-    react: ">=16.9.0"
-    react-dom: ">=16.9.0"
-  checksum: 10/1afa1fe63826f77e1c20babf6b15ec2a721f7173f2e71dc31a662982763d55f4583f5ce558dc2b8409aa3663917fa25a48b5747793d9e8641516157ff1c63de5
+    throttle-debounce: "npm:^5.0.2"
+  checksum: 10/8916c1c0a6c64bd788ae99743ad53dba32e0b1891d89882e352d8953c41dd6930cc55244b4f8441d189f1eaf7955fc32ace4e1601604148edee590e8ba0a6522
   languageName: node
   linkType: hard
 
@@ -7313,10 +7374,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dayjs@npm:^1.11.10":
-  version: 1.11.11
-  resolution: "dayjs@npm:1.11.11"
-  checksum: 10/f03948b172fbeed229837965988d1d5bac99c72a31c28731a457303259439f2f36289186489ae140adbeb10f591a926908c8de5d81eb449a2edbf5cbd6e9e30c
+"dayjs@npm:^1.11.11":
+  version: 1.11.13
+  resolution: "dayjs@npm:1.11.13"
+  checksum: 10/7374d63ab179b8d909a95e74790def25c8986e329ae989840bacb8b1888be116d20e1c4eee75a69ea0dfbae13172efc50ef85619d304ee7ca3c01d5878b704f5
   languageName: node
   linkType: hard
 
@@ -13084,15 +13145,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qrcode.react@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "qrcode.react@npm:3.1.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 10/71953241f151ca5ad4013c034cb13033e1ebad56a1db77297a7ddd7fd4d5f137f37f3be51133aeef0b54dc52d6c76630429d2269bd72e6858c3209fe42310498
-  languageName: node
-  linkType: hard
-
 "qs@npm:6.13.0":
   version: 6.13.0
   resolution: "qs@npm:6.13.0"
@@ -13151,26 +13203,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-cascader@npm:~3.25.0":
-  version: 3.25.0
-  resolution: "rc-cascader@npm:3.25.0"
+"rc-cascader@npm:~3.28.1":
+  version: 3.28.1
+  resolution: "rc-cascader@npm:3.28.1"
   dependencies:
     "@babel/runtime": "npm:^7.12.5"
     array-tree-filter: "npm:^2.1.0"
     classnames: "npm:^2.3.1"
-    rc-select: "npm:~14.13.0"
-    rc-tree: "npm:~5.8.1"
+    rc-select: "npm:~14.15.0"
+    rc-tree: "npm:~5.9.0"
     rc-util: "npm:^5.37.0"
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/029250563c6b246568b47a81a168701aa64520e8a5e9a33999af86cc284a9eef8c1381c42ed98d56079c760f7d3ca230de4d5d80f99798dd61e7dce829a75a17
+  checksum: 10/bb2feb79c0db19f459b265e9a0afb87611f4ba06c4776a5ea8ddcb0bfc81403292ada3a1c29cd7511872f8d2bfda7c29eab6dbc32052a60baf49576a50866d77
   languageName: node
   linkType: hard
 
-"rc-checkbox@npm:~3.2.0":
-  version: 3.2.0
-  resolution: "rc-checkbox@npm:3.2.0"
+"rc-checkbox@npm:~3.3.0":
+  version: 3.3.0
+  resolution: "rc-checkbox@npm:3.3.0"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
     classnames: "npm:^2.3.2"
@@ -13178,13 +13230,13 @@ __metadata:
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/58e3ec5094ad9be8d0855bfc3446af0cb3b36e201bc5d6da606e75c48890a588cc6851af618884028a0c594ade41c39cf60d35d942eac0a233e0460e8981051b
+  checksum: 10/95d48a1012339163e98bea6e158e5c650e45759550c50f1615f610a19ce31b0af384df899dfded147e1b16d2016e90f16a949792bb79f5b7f6709cf95a9eb1a5
   languageName: node
   linkType: hard
 
-"rc-collapse@npm:~3.7.3":
-  version: 3.7.3
-  resolution: "rc-collapse@npm:3.7.3"
+"rc-collapse@npm:~3.8.0":
+  version: 3.8.0
+  resolution: "rc-collapse@npm:3.8.0"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
     classnames: "npm:2.x"
@@ -13193,13 +13245,13 @@ __metadata:
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/33bc54c0ebabad1e079001911c0f37409314834c274c29da7e4a58cc35fb333bcf71ab3e6c611fe927f5c34fcff0d43046e15cc352def5cafc3d4e2c82e5fe8d
+  checksum: 10/b9d44fb1bd406be23803938a9945d73acdbe0412d2f81ea17ef6ea5620a1cbc3404adbbafe9d114f5f9267c9bfc0bb159a522014effb367d9e066fb43b48ea43
   languageName: node
   linkType: hard
 
-"rc-dialog@npm:~9.4.0":
-  version: 9.4.0
-  resolution: "rc-dialog@npm:9.4.0"
+"rc-dialog@npm:~9.6.0":
+  version: 9.6.0
+  resolution: "rc-dialog@npm:9.6.0"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
     "@rc-component/portal": "npm:^1.0.0-8"
@@ -13209,13 +13261,13 @@ __metadata:
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/ecff15ae26df104e42581482f32fa06a718cf5c01440b6d1556b080dd4cfc80a96fcd648b626f34b6b549a9968503f193f309a9e9004e669ead9a70e27e4a4f4
+  checksum: 10/f6dcdb066f26f7b59fef458e18ba3c257a73b7036774d12022d548c7e343e8a51db2d1f3bae45928bcefb978fb29c4f2d6954c56fd006b0360fcc47c095c01c8
   languageName: node
   linkType: hard
 
-"rc-drawer@npm:~7.1.0":
-  version: 7.1.0
-  resolution: "rc-drawer@npm:7.1.0"
+"rc-drawer@npm:~7.2.0":
+  version: 7.2.0
+  resolution: "rc-drawer@npm:7.2.0"
   dependencies:
     "@babel/runtime": "npm:^7.23.9"
     "@rc-component/portal": "npm:^1.1.1"
@@ -13225,7 +13277,7 @@ __metadata:
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/6d37b35e3a9abd0e105f91f388c818dcd7d6e9a5805a9bb0909b01e96e47437af2010e29c05648d15ece37e0768ff752e15f498ced69a476c20b9ea06c5e636f
+  checksum: 10/1c9c7e5a00bd341a996684e5e288e273fee5083c8daf37e61a5ef5db5204df8aeaf48bcb67d89d01cab4d3c484bcf4d73af257a2d8de2dd71a757fa9cabaed3c
   languageName: node
   linkType: hard
 
@@ -13244,9 +13296,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-field-form@npm:~2.0.0":
-  version: 2.0.1
-  resolution: "rc-field-form@npm:2.0.1"
+"rc-field-form@npm:~2.4.0":
+  version: 2.4.0
+  resolution: "rc-field-form@npm:2.4.0"
   dependencies:
     "@babel/runtime": "npm:^7.18.0"
     "@rc-component/async-validator": "npm:^5.0.3"
@@ -13254,46 +13306,46 @@ __metadata:
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/d38a7363e57a6f5b173e47d58d1ee1a98254db7c2e14a4f59c11436b79d162360c63bbf7e7bc62b8fa53abd4c70cbd57c0e9bc7dcc81ad7f28d17ae86d77b294
+  checksum: 10/dcf6928749bd750e55a525e67cc012613d9660eae52401caf48760dac20ca665b4d302bed9c498386a7076c20fae767c1f1e235192685a4397b2207d371c8a1a
   languageName: node
   linkType: hard
 
-"rc-image@npm:~7.6.0":
-  version: 7.6.0
-  resolution: "rc-image@npm:7.6.0"
+"rc-image@npm:~7.11.0":
+  version: 7.11.0
+  resolution: "rc-image@npm:7.11.0"
   dependencies:
     "@babel/runtime": "npm:^7.11.2"
     "@rc-component/portal": "npm:^1.0.2"
     classnames: "npm:^2.2.6"
-    rc-dialog: "npm:~9.4.0"
+    rc-dialog: "npm:~9.6.0"
     rc-motion: "npm:^2.6.2"
     rc-util: "npm:^5.34.1"
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/7452ac4d946edd806cbd81bd19db427639438dcc7f73c61de8929d2c604dc69c8960ed589685095ec9d183b009872aa53146ae7a63e2d5c1f8fdf2c1d1390f67
+  checksum: 10/e66cee768853cf2acde3c8e01a019352ec378afc11ab5093ff30477f7fe746eaefcba064a6410b0bcb232d2936bae47d3079ea5c4f6c3dc0e95adc5fbaae788b
   languageName: node
   linkType: hard
 
-"rc-input-number@npm:~9.0.0":
-  version: 9.0.0
-  resolution: "rc-input-number@npm:9.0.0"
+"rc-input-number@npm:~9.2.0":
+  version: 9.2.0
+  resolution: "rc-input-number@npm:9.2.0"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
     "@rc-component/mini-decimal": "npm:^1.0.1"
     classnames: "npm:^2.2.5"
-    rc-input: "npm:~1.4.0"
-    rc-util: "npm:^5.28.0"
+    rc-input: "npm:~1.6.0"
+    rc-util: "npm:^5.40.1"
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/5b02990b351dc214f75b68c74e815b26e44c134932fcf264c635ff7a2fb9f2fd8636300a5285b8a1dc042c96a3f2e64ea59ba8aa0bf10e81abcf0ae1f7c9f167
+  checksum: 10/6e7b4778d911bdd16c0ad39b6519ec3145a88b222ce04ffe06daae0a751710be8db4233375ae9ccc703cc9ee738ab0e0eeb7019cd72755adb4ae3eb78dcce4e0
   languageName: node
   linkType: hard
 
-"rc-input@npm:~1.4.0, rc-input@npm:~1.4.5":
-  version: 1.4.5
-  resolution: "rc-input@npm:1.4.5"
+"rc-input@npm:~1.6.0, rc-input@npm:~1.6.3":
+  version: 1.6.3
+  resolution: "rc-input@npm:1.6.3"
   dependencies:
     "@babel/runtime": "npm:^7.11.1"
     classnames: "npm:^2.2.1"
@@ -13301,31 +13353,31 @@ __metadata:
   peerDependencies:
     react: ">=16.0.0"
     react-dom: ">=16.0.0"
-  checksum: 10/52c5716940295ddcb8ed302a073277dd1242fed25121d1ae2422be392103e7c5f75525bd7aa4bd76c56994e191ba008b57509072168c559f08e81f50c900f5cd
+  checksum: 10/e163a4105a5a7b18b88fc3c9cfa65fa36bf397c526843b30c0484eaab788feb0173b1f5af2fec26e6e31db4ec11b58a3619e35878bc4ea410e16e98f514ac664
   languageName: node
   linkType: hard
 
-"rc-mentions@npm:~2.11.1":
-  version: 2.11.1
-  resolution: "rc-mentions@npm:2.11.1"
+"rc-mentions@npm:~2.16.1":
+  version: 2.16.1
+  resolution: "rc-mentions@npm:2.16.1"
   dependencies:
     "@babel/runtime": "npm:^7.22.5"
     "@rc-component/trigger": "npm:^2.0.0"
     classnames: "npm:^2.2.6"
-    rc-input: "npm:~1.4.0"
-    rc-menu: "npm:~9.13.0"
-    rc-textarea: "npm:~1.6.1"
+    rc-input: "npm:~1.6.0"
+    rc-menu: "npm:~9.15.1"
+    rc-textarea: "npm:~1.8.0"
     rc-util: "npm:^5.34.1"
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/5bf5a69008467cbb613c5d327824318fe8181466c6f352c71bd9bc9076d772c098940b7322373c7b9326dacc8dc5dd14e6feca8a5d0be506cbd061bb1f05b061
+  checksum: 10/eedea461e0d8e6dff9aacc6fa0bf0617653e3f3cd020e7a0274c588a013f691c4475768372f9d680375de28c46c84a64a199d6a4c5ce8b5b09c57a4f3d8ff553
   languageName: node
   linkType: hard
 
-"rc-menu@npm:~9.13.0":
-  version: 9.13.0
-  resolution: "rc-menu@npm:9.13.0"
+"rc-menu@npm:~9.15.1":
+  version: 9.15.1
+  resolution: "rc-menu@npm:9.15.1"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
     "@rc-component/trigger": "npm:^2.0.0"
@@ -13336,7 +13388,7 @@ __metadata:
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/afabaadadf662b67461bd7a6bfce982fdc0d6093e3e3d86049cd070e0acd7cd7c68fe76aaa59c7accda6fae657d7eec500728c717c82ea843f7eb58d60b8b30e
+  checksum: 10/9bcb2cfd9e59d371394ce7b5c1bf37f7dc3e46ee2b87580b500bd91c35cb53e0f156034e3937b2edf01bd8a5a3cfabd04ba567c66e4ab6042ee6bc744d70faa1
   languageName: node
   linkType: hard
 
@@ -13354,9 +13406,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-notification@npm:~5.4.0":
-  version: 5.4.0
-  resolution: "rc-notification@npm:5.4.0"
+"rc-motion@npm:^2.9.3":
+  version: 2.9.3
+  resolution: "rc-motion@npm:2.9.3"
+  dependencies:
+    "@babel/runtime": "npm:^7.11.1"
+    classnames: "npm:^2.2.1"
+    rc-util: "npm:^5.43.0"
+  peerDependencies:
+    react: ">=16.9.0"
+    react-dom: ">=16.9.0"
+  checksum: 10/7468588fdcd49d707a5c4ad071fe2bbea82c704a48e639af7437655a523f35d80ee34cc290d8c7daf4c211fa6d2a27826d6d30eaede1accf8e384b4e61582ff6
+  languageName: node
+  linkType: hard
+
+"rc-notification@npm:~5.6.1":
+  version: 5.6.1
+  resolution: "rc-notification@npm:5.6.1"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
     classnames: "npm:2.x"
@@ -13365,7 +13431,7 @@ __metadata:
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/ab31506b55df40b03638abffcad434ffd6684253b117543d2254a785e57db284d0be074fca8ab36172813e776a591f2f0e373a6b6058ae9732a626d5237b2e15
+  checksum: 10/84d75e12bcbf5f23317a474b9ed8e10911a80e854b133a75b0067f046dfeca7d3bf207dbb6c69da61aa8ff5332087edd2406b0120139c8e3670be67d2734cb46
   languageName: node
   linkType: hard
 
@@ -13384,9 +13450,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-pagination@npm:~4.0.4":
-  version: 4.0.4
-  resolution: "rc-pagination@npm:4.0.4"
+"rc-pagination@npm:~4.3.0":
+  version: 4.3.0
+  resolution: "rc-pagination@npm:4.3.0"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
     classnames: "npm:^2.3.2"
@@ -13394,20 +13460,20 @@ __metadata:
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/343c3f0d07a59e2c4f2d4e87b4e89400d5323871b7ea038f7417312eb4fea2b3b2e43306a41efdbc36bebe2b554800e2a35842689e81cd2e3a5549da5e619323
+  checksum: 10/5ffdf81ae46eccdf308d62483f5e7509a04f8fb60a5e65a2d52373db4e3f19ccf40d71d108fe8aa4c142a292d8688b1726e81fd62e922b914fcff207995fce05
   languageName: node
   linkType: hard
 
-"rc-picker@npm:~4.5.0":
-  version: 4.5.0
-  resolution: "rc-picker@npm:4.5.0"
+"rc-picker@npm:~4.6.14":
+  version: 4.6.15
+  resolution: "rc-picker@npm:4.6.15"
   dependencies:
-    "@babel/runtime": "npm:^7.10.1"
+    "@babel/runtime": "npm:^7.24.7"
     "@rc-component/trigger": "npm:^2.0.0"
     classnames: "npm:^2.2.1"
     rc-overflow: "npm:^1.3.2"
     rc-resize-observer: "npm:^1.4.0"
-    rc-util: "npm:^5.38.1"
+    rc-util: "npm:^5.43.0"
   peerDependencies:
     date-fns: ">= 2.x"
     dayjs: ">= 1.x"
@@ -13424,7 +13490,7 @@ __metadata:
       optional: true
     moment:
       optional: true
-  checksum: 10/6d4fa172a38ed0dada38a96a34df39ea8d7c3a555f9f26c033222936c8ec7a960a27ca0f8a6ae71cee9b833c4b032762093e6f789f3b6c5235b35f0a14d0679e
+  checksum: 10/62f7fe5473d01bc52bf3f06f789d9b3386a0624f39f45ca6e4aa3f25e8b98a3df3ef94498b4b2af2b364fb03cdd9f3c434342f41be6594a07fa452cd8bcdbac1
   languageName: node
   linkType: hard
 
@@ -13442,9 +13508,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-rate@npm:~2.12.0":
-  version: 2.12.0
-  resolution: "rc-rate@npm:2.12.0"
+"rc-rate@npm:~2.13.0":
+  version: 2.13.0
+  resolution: "rc-rate@npm:2.13.0"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
     classnames: "npm:^2.2.5"
@@ -13452,7 +13518,7 @@ __metadata:
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/bddfa1d3e4d61e88407fe20a98c81d4cae64bbf874a0254d916f92014cad454cc66d4550f44dadf26df8af062f5a7f9f307680a4d4c4e0fd6df545413a2bea5f
+  checksum: 10/ad56526e394245cb610066e44e9ea90e5febb91a45a144a9485d828aa55706ec83df2f5008d692d153ac8be82a9ea265eae8fee0d6a9b0f802e8e4fb5bcb6b6f
   languageName: node
   linkType: hard
 
@@ -13471,9 +13537,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-segmented@npm:~2.3.0":
-  version: 2.3.0
-  resolution: "rc-segmented@npm:2.3.0"
+"rc-segmented@npm:~2.5.0":
+  version: 2.5.0
+  resolution: "rc-segmented@npm:2.5.0"
   dependencies:
     "@babel/runtime": "npm:^7.11.1"
     classnames: "npm:^2.2.1"
@@ -13482,13 +13548,13 @@ __metadata:
   peerDependencies:
     react: ">=16.0.0"
     react-dom: ">=16.0.0"
-  checksum: 10/4cacfc629f547c6d2a159e91808c718f3bcf7dce1d5ebb05419766c72ea34de09b1ac8648e80dfc26fd8f3a8f760296f979723d8841f65dfa6fc20e930203449
+  checksum: 10/f1389a3e0aa0727116ee9adc7861a63dc41c3e0fc8ec9c624cbb51ade433f07784bef328474a375f475a4b218c8551ab915c4152d11160388db93ecb34b4ba95
   languageName: node
   linkType: hard
 
-"rc-select@npm:~14.13.0, rc-select@npm:~14.13.1":
-  version: 14.13.4
-  resolution: "rc-select@npm:14.13.4"
+"rc-select@npm:~14.15.0, rc-select@npm:~14.15.2":
+  version: 14.15.2
+  resolution: "rc-select@npm:14.15.2"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
     "@rc-component/trigger": "npm:^2.1.1"
@@ -13500,13 +13566,13 @@ __metadata:
   peerDependencies:
     react: "*"
     react-dom: "*"
-  checksum: 10/9c7aa2aeb52377a2b313b6a9c502d3a888595546a250f65ddae0b2c9c5480f2a354b887a665e1b8111ef59ed78b0ec0356d1f55ae16db56d70f32b30cde4c03e
+  checksum: 10/707d9de38aaf83063ede754a925b56d6f02740197a3bed93f886c132ce797321d9e70a2fe32cff0546c54d9a11414d6d2c8fc1f914ac665fa11ad2b30a08bc85
   languageName: node
   linkType: hard
 
-"rc-slider@npm:~10.6.2":
-  version: 10.6.2
-  resolution: "rc-slider@npm:10.6.2"
+"rc-slider@npm:~11.1.6":
+  version: 11.1.6
+  resolution: "rc-slider@npm:11.1.6"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
     classnames: "npm:^2.2.5"
@@ -13514,7 +13580,7 @@ __metadata:
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/ee5ec34fe940487a44cb03e89abf4199cbae990a334756fa9536a158d3a790cb7c1ebf321fc8048050a0cefa86138e097eb11bcc135bdb10db287b0738370790
+  checksum: 10/5f080792bf34cfbe5afdb3f3632dd8330acab723b42c6015c34d09a3c966d8dde9fbbbedc7f3c477bf38f252c039b00ff5a829a475b01bb7cbc72ea0aa6e7e46
   languageName: node
   linkType: hard
 
@@ -13546,60 +13612,60 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-table@npm:~7.45.5":
-  version: 7.45.7
-  resolution: "rc-table@npm:7.45.7"
+"rc-table@npm:~7.47.5":
+  version: 7.47.5
+  resolution: "rc-table@npm:7.47.5"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
     "@rc-component/context": "npm:^1.4.0"
     classnames: "npm:^2.2.5"
     rc-resize-observer: "npm:^1.1.0"
-    rc-util: "npm:^5.37.0"
+    rc-util: "npm:^5.41.0"
     rc-virtual-list: "npm:^3.14.2"
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/5193406895f826bbe66dd0efaffe90eb7b33dac69445fdae2df40a98133207360adeeb43a9f0221ff9bbaf9a1ecdff300ee5f17c3c9245580b5c6a113a685c9e
+  checksum: 10/ba7cb5057dcf2e0be99d8d35566f03905b53f554ef3b0fc2e3ce1ace1939c1f09046cd7e1ed5b953ca8c3c2be95f62085cfdcc572aea0ed5572c3e0de3439919
   languageName: node
   linkType: hard
 
-"rc-tabs@npm:~15.0.0 ":
-  version: 15.0.0
-  resolution: "rc-tabs@npm:15.0.0"
+"rc-tabs@npm:~15.2.0":
+  version: 15.2.0
+  resolution: "rc-tabs@npm:15.2.0"
   dependencies:
     "@babel/runtime": "npm:^7.11.2"
     classnames: "npm:2.x"
     rc-dropdown: "npm:~4.2.0"
-    rc-menu: "npm:~9.13.0"
+    rc-menu: "npm:~9.15.1"
     rc-motion: "npm:^2.6.2"
     rc-resize-observer: "npm:^1.0.0"
     rc-util: "npm:^5.34.1"
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/0db4b6491635c0dbffd9404c702732c3b63c5f3e49ecffbaa9ec2bee22fb52584c133ef3c52c6fa343dcdb2b0bab406450470cae4132965613e055d95c1066f9
+  checksum: 10/c4e024b9dd75a7d4046abd872afa044e3181e4b326860f66e6442fca4e84cd4093a0c2e22d83f65a8f436275c2e6ff18e57dadf22dcedaab93b6959edabaa25b
   languageName: node
   linkType: hard
 
-"rc-textarea@npm:~1.6.1, rc-textarea@npm:~1.6.3":
-  version: 1.6.3
-  resolution: "rc-textarea@npm:1.6.3"
+"rc-textarea@npm:~1.8.0, rc-textarea@npm:~1.8.2":
+  version: 1.8.2
+  resolution: "rc-textarea@npm:1.8.2"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
     classnames: "npm:^2.2.1"
-    rc-input: "npm:~1.4.0"
+    rc-input: "npm:~1.6.0"
     rc-resize-observer: "npm:^1.0.0"
     rc-util: "npm:^5.27.0"
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/e9dee4b726c7e5a573c830f9f745a9768efeadffac4973c0ed602ae4065a911cfd710b0ec33cdf574e4d23eac16de7f1c53f0c4554e388c796b63fb39b319a4e
+  checksum: 10/033145ca79888c4d53a3604829a7b8205610e8ac01e518eadbdf290c981da995a5863e151fa434caeebbf4c0872fbf693fa4a71ebbb098cc0dcda0b44158825b
   languageName: node
   linkType: hard
 
-"rc-tooltip@npm:~6.2.0":
-  version: 6.2.0
-  resolution: "rc-tooltip@npm:6.2.0"
+"rc-tooltip@npm:~6.2.1":
+  version: 6.2.1
+  resolution: "rc-tooltip@npm:6.2.1"
   dependencies:
     "@babel/runtime": "npm:^7.11.2"
     "@rc-component/trigger": "npm:^2.0.0"
@@ -13607,29 +13673,29 @@ __metadata:
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/2be8fd3da8666df1d83485e5532e11eacf4dd3686efed9b4f0bc78caeb647196cac62104e54b9ce5dbc3051a9df70e07e54557f3273b632bb474a73c8bca0a2d
+  checksum: 10/a82064d6d521ba4c03d074505402f6c38f9f50439037235969546b694e38977bab3420b46080bde295aca2436e6725d64b0a330a5ccdd51932deabbb1bf7585b
   languageName: node
   linkType: hard
 
-"rc-tree-select@npm:~5.20.0":
-  version: 5.20.0
-  resolution: "rc-tree-select@npm:5.20.0"
+"rc-tree-select@npm:~5.23.0":
+  version: 5.23.0
+  resolution: "rc-tree-select@npm:5.23.0"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
     classnames: "npm:2.x"
-    rc-select: "npm:~14.13.0"
-    rc-tree: "npm:~5.8.1"
+    rc-select: "npm:~14.15.0"
+    rc-tree: "npm:~5.9.0"
     rc-util: "npm:^5.16.1"
   peerDependencies:
     react: "*"
     react-dom: "*"
-  checksum: 10/ba701485168ee86ccd322a828c2818512bb879a913fb858887bcbbb2635d077d5d725fc3fb270f3ee4933aceab3ca0d31c712583f86f4bac884596e90338ee65
+  checksum: 10/c39c3ce6c1738e39f4ca1e232378002bbcb7faa8b1bd9a132941cc1d9629e7d00207bc67141f1bf048573bf21f3035c5fc3e7daf4e78ccc6552475bea2c405ad
   languageName: node
   linkType: hard
 
-"rc-tree@npm:~5.8.1, rc-tree@npm:~5.8.5":
-  version: 5.8.8
-  resolution: "rc-tree@npm:5.8.8"
+"rc-tree@npm:~5.9.0":
+  version: 5.9.0
+  resolution: "rc-tree@npm:5.9.0"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
     classnames: "npm:2.x"
@@ -13639,13 +13705,13 @@ __metadata:
   peerDependencies:
     react: "*"
     react-dom: "*"
-  checksum: 10/5bcfcf1e82291a930304012655eb59adc348fe8b8d2d4f37660855ca03ba226f1c01bd17c9891757ccc9636e5872253249ec01d459ce690c6c54dff9401df3b6
+  checksum: 10/d7525c4a524c6de8e177ebc90fe9b924046951a02bacee85efd4529fb05a66add936802b43d5ca8d84469f9c63b8d542437365b911480f62a78e03e2c7fbaca0
   languageName: node
   linkType: hard
 
-"rc-upload@npm:~4.5.2":
-  version: 4.5.2
-  resolution: "rc-upload@npm:4.5.2"
+"rc-upload@npm:~4.8.1":
+  version: 4.8.1
+  resolution: "rc-upload@npm:4.8.1"
   dependencies:
     "@babel/runtime": "npm:^7.18.3"
     classnames: "npm:^2.2.5"
@@ -13653,11 +13719,11 @@ __metadata:
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/3b01357ba5a1504461d0ecf6e693ab4494f2b7cb080f1c400f179d1e329a7a7863e22e07b7c3ac2029dd236cfa0a85e87b9cc2d06aa4c9871abf0511f9a9407c
+  checksum: 10/aa8703d2f79a2ed3a0ba751844a6f6b1081af4ef79cf039a3912521bb71b8155ce0531b63adeb75dd94e4df6cc8249b2214207a668ffac1108c51326100e32f3
   languageName: node
   linkType: hard
 
-"rc-util@npm:^5.0.1, rc-util@npm:^5.16.1, rc-util@npm:^5.17.0, rc-util@npm:^5.18.1, rc-util@npm:^5.2.0, rc-util@npm:^5.20.1, rc-util@npm:^5.21.0, rc-util@npm:^5.24.4, rc-util@npm:^5.25.2, rc-util@npm:^5.27.0, rc-util@npm:^5.28.0, rc-util@npm:^5.30.0, rc-util@npm:^5.31.1, rc-util@npm:^5.32.2, rc-util@npm:^5.34.1, rc-util@npm:^5.35.0, rc-util@npm:^5.36.0, rc-util@npm:^5.37.0, rc-util@npm:^5.38.0, rc-util@npm:^5.38.1, rc-util@npm:^5.39.1, rc-util@npm:^5.39.3":
+"rc-util@npm:^5.0.1, rc-util@npm:^5.16.1, rc-util@npm:^5.17.0, rc-util@npm:^5.18.1, rc-util@npm:^5.2.0, rc-util@npm:^5.20.1, rc-util@npm:^5.21.0, rc-util@npm:^5.24.4, rc-util@npm:^5.25.2, rc-util@npm:^5.27.0, rc-util@npm:^5.30.0, rc-util@npm:^5.31.1, rc-util@npm:^5.32.2, rc-util@npm:^5.34.1, rc-util@npm:^5.35.0, rc-util@npm:^5.36.0, rc-util@npm:^5.37.0, rc-util@npm:^5.38.0, rc-util@npm:^5.38.1, rc-util@npm:^5.39.3, rc-util@npm:^5.40.1, rc-util@npm:^5.41.0, rc-util@npm:^5.43.0":
   version: 5.43.0
   resolution: "rc-util@npm:5.43.0"
   dependencies:
@@ -15295,6 +15361,13 @@ __metadata:
   version: 5.0.0
   resolution: "throttle-debounce@npm:5.0.0"
   checksum: 10/bedd5a20cd226c7a6e765719c73fa8ec7a43f0c552bfb658cbe7ed51e16ab5f315dd2baed66904c004a1d16b0bb4e85e10126695a787b13516c37d4907426ec5
+  languageName: node
+  linkType: hard
+
+"throttle-debounce@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "throttle-debounce@npm:5.0.2"
+  checksum: 10/9a5e5ae7f93127d921e913ad741e75e6d2bb946d15e1898ed541037bc646adb9a759c481385400be917ec6d93f078fd8b016980c1a9143e09ea88c99559b0c93
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This PR provides the `extra` prop to allow the display of an additional item on the right of the menu items (generally an `Icon`).

<img width="508" alt="Screenshot 2024-09-25 alle 10 10 43" src="https://github.com/user-attachments/assets/475eeeba-954a-4389-a9b6-8d1b17265989">

<img width="472" alt="Screenshot 2024-09-25 alle 10 08 55" src="https://github.com/user-attachments/assets/7d30aa8d-9437-4c48-8af4-d2fe28f2fe91">

### Menu

 - introduced `extra` menu item prop
 - fixed type remapping to avoid importing types from antd

## [IMPORTANT] PR Checklist

- [X] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [X] PR title follows the `<type>(<scope>): <subject>` structure
- [X] The PR has been labeled according to the type of changes (e.g., enhancement, bug).

### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [ ] Changes are covered by tests 
- [ ] Changes to components are accessible and documented in the Storybook
- [ ] Typings have been updated
- [ ] New components are exported from the `index` file
- [ ] New files include the Apache 2.0 License disclaimer
- [ ] The browser console does not contain errors
