### PR TITLE
fix(dropdown): reset box-shadow when footer is appended

### DIFF
--- a/src/components/Dropdown/dropdown.module.css
+++ b/src/components/Dropdown/dropdown.module.css
@@ -78,7 +78,12 @@
   background-color: white;
   width: 100%;
   border-radius: var(--shape-border-radius-lg, 8px);
-  gap: var(--spacing-gap-xs, 4px)
+  gap: var(--spacing-gap-xs, 4px);
+  /* FIXME: design tokens should be used instead, however shadows are not yet generated! */
+  box-shadow:
+    0px 6px 16px 0px rgba(0, 0, 0, 0.08),
+    0px 3px 6px -4px rgba(0, 0, 0, 0.12),
+    0px 9px 28px 8px rgba(0, 0, 0, 0.05)
 }
 
 .itemRowContainer {


### PR DESCRIPTION
### Description

recreate box-shadow for dropdown wrapper when the footer is appended

### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g., enhancement, bug).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [ ] Changes are covered by tests 
- [ ] Changes to components are accessible and documented in the Storybook
- [ ] Typings have been updated
- [ ] New components are exported from the `index` file
- [ ] New files include the Apache 2.0 License disclaimer
- [x] The browser console does not contain errors
