### PR TITLE
fix(Dropdown): better classname to prevent class leading with 0 char

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -51,8 +51,6 @@ export const defaults = {
   initialSelectedItems: [],
 }
 
-const DROPDOWN_CLASS_NAME = 'mia-platform-dropdown'
-
 export const Dropdown = ({
   autoFocus,
   children,
@@ -70,7 +68,8 @@ export const Dropdown = ({
 }: DropdownProps): ReactElement => {
   const { spacing } = useTheme()
 
-  const uniqueClassName = useMemo(() => `dropdown-${crypto.randomUUID()}`, [])
+  const uniqueOverlayClassName = useMemo(() => `dropdown-overlay-${crypto.randomUUID()}`, [])
+  const uniqueDropdownClassName = useMemo(() => `dropdown-${crypto.randomUUID()}`, [])
 
   const itemFinderMemo = useCallback((id: string) => itemFinder(items, id), [items])
 
@@ -99,14 +98,12 @@ export const Dropdown = ({
     [itemFinderMemo, onClick, updateSelectedItems]
   )
 
-  const randomClass = useMemo(() => crypto.randomUUID(), [])
-
   /**
    * This function is used to forcibly close the dropdown without controlling
    * the `open` state via prop.
    */
   const footerActionHook = useCallback(() => {
-    const el = document.querySelector(`.${randomClass}`)
+    const el = document.querySelector(`.${uniqueDropdownClassName}`)
     // This branch is not testable since the dropdown always exists when the dropdown is visible
     /* istanbul ignore if */
     if (!el) {
@@ -114,7 +111,7 @@ export const Dropdown = ({
     }
     // FIXME: with hover trigger this does not work and the dropdown will not be closed!
     (el as HTMLElement).click()
-  }, [randomClass])
+  }, [uniqueDropdownClassName])
   const hookedFooter = useFooterWithHookedActions({ footer, hook: footerActionHook })
 
   const dropdownRender = useCallback((menu: ReactNode): ReactNode => {
@@ -134,12 +131,12 @@ export const Dropdown = ({
   const menu = useMemo(() => ({
     items: antdItems,
     /* istanbul ignore next */
-    getPopupContainer: (triggerNode: HTMLElement) => (document.querySelector(`.${uniqueClassName}`) || triggerNode) as HTMLElement,
+    getPopupContainer: (triggerNode: HTMLElement) => (document.querySelector(`.${uniqueOverlayClassName}`) || triggerNode) as HTMLElement,
     onClick: onAntdMenuClick,
     selectedKeys: selectedItems,
-  }), [antdItems, onAntdMenuClick, selectedItems, uniqueClassName])
+  }), [antdItems, onAntdMenuClick, selectedItems, uniqueOverlayClassName])
 
-  const classes = useMemo(() => classNames(styles.dropdownWrapper, uniqueClassName), [uniqueClassName])
+  const classes = useMemo(() => classNames(styles.dropdownWrapper, uniqueOverlayClassName), [uniqueOverlayClassName])
 
   const onOpenChangeInternal = useCallback(
     (open: boolean, info: {source: 'trigger'| 'menu'}) => {
@@ -154,7 +151,7 @@ export const Dropdown = ({
   return (
     <AntdDropdown
       autoFocus={autoFocus}
-      className={classNames(randomClass, DROPDOWN_CLASS_NAME)}
+      className={uniqueDropdownClassName}
       disabled={isDisabled}
       dropdownRender={dropdownRender}
       getPopupContainer={getPopupContainer}


### PR DESCRIPTION
### Description

A classname starting with 0 is not a valid selector. Therefore, starting a class with a raw UUID may lead with a zero-lead class name.

The dropdown was already featuring a "unique classname" for the overlay so I've reworked things a little bit to provide more coherence.

### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g., enhancement, bug).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [x] Changes are covered by tests 
- [ ] Changes to components are accessible and documented in the Storybook
- [ ] Typings have been updated
- [ ] New components are exported from the `index` file
- [ ] New files include the Apache 2.0 License disclaimer
- [ ] The browser console does not contain errors
