### PR TITLE
feat(Dropdown): menu max height controllable with `menuItemsMaxHeight` prop

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -141,6 +141,31 @@ export const WithCustomFooter: Story = {
   },
 }
 
+export const WithCustomFooterOverAndCustomMaxHeight: Story = {
+  args: {
+    menuItemsMaxHeight: 128,
+    footer: {
+      top: <Typography.BodyM>{'Top description'}</Typography.BodyM>,
+      bottom: <Typography.BodyM>{'Bottom description'}</Typography.BodyM>,
+      actions: [{
+        icon: <Icon component={PiAcorn} size={16} />,
+        label: 'OK',
+        onClick: action('footer button click'),
+      }, {
+        icon: <Icon component={PiNut} size={16} />,
+        label: 'NOT OK',
+        onClick: action('footer button 2 click'),
+      }],
+    },
+  },
+}
+
+export const WithCustomMaxHeight: Story = {
+  args: {
+    menuItemsMaxHeight: 128,
+  },
+}
+
 export const Disabled: Story = {
   args: {
     isDisabled: true,

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -47,8 +47,9 @@ const antdSourceMap: Record<AntdTriggerSource, OpenChangeInfoSource> = {
 
 export const defaults = {
   itemLayout: ItemLayout.Horizontal,
-  trigger: [DropdownTrigger.Click],
+  triggers: [DropdownTrigger.Click],
   initialSelectedItems: [],
+  menuItemsMaxHeight: 240,
 }
 
 export const Dropdown = ({
@@ -58,8 +59,9 @@ export const Dropdown = ({
   isDisabled,
   itemLayout = defaults.itemLayout,
   items,
+  menuItemsMaxHeight = defaults.menuItemsMaxHeight,
   onClick,
-  triggers = defaults.trigger,
+  triggers = defaults.triggers,
   onOpenChange,
   getPopupContainer,
   initialSelectedItems = defaults.initialSelectedItems,
@@ -115,18 +117,24 @@ export const Dropdown = ({
   const hookedFooter = useFooterWithHookedActions({ footer, hook: footerActionHook })
 
   const dropdownRender = useCallback((menu: ReactNode): ReactNode => {
+    const clonedMenu = React.cloneElement(menu as ReactElement, { style: { boxShadow: 'none' } })
+    const scrollableStyle = { maxHeight: menuItemsMaxHeight, overflow: 'scroll' }
     if (!hookedFooter) {
-      return React.cloneElement(menu as ReactElement)
+      return (
+        <div className={styles.dropdownRenderWrapper} style={scrollableStyle}>
+          {clonedMenu}
+        </div>
+      )
     }
 
     return (
-      <div className={styles.dropdownWithFooterRenderWrapper}>
-        {React.cloneElement(menu as ReactElement, { style: { boxShadow: 'none' } })}
+      <div className={styles.dropdownRenderWrapper}>
+        <div style={scrollableStyle}>{clonedMenu}</div>
         <Divider margin={spacing?.margin?.none} />
         <Footer footer={hookedFooter} />
       </div>
     )
-  }, [hookedFooter, spacing])
+  }, [hookedFooter, menuItemsMaxHeight, spacing])
 
   const menu = useMemo(() => ({
     items: antdItems,

--- a/src/components/Dropdown/dropdown.module.css
+++ b/src/components/Dropdown/dropdown.module.css
@@ -74,16 +74,15 @@
   }
 }
 
-.dropdownWithFooterRenderWrapper {
+.dropdownRenderWrapper {
   background-color: white;
   width: 100%;
   border-radius: var(--shape-border-radius-lg, 8px);
   gap: var(--spacing-gap-xs, 4px);
-  /* FIXME: design tokens should be used instead, however shadows are not yet generated! */
   box-shadow:
     0px 6px 16px 0px rgba(0, 0, 0, 0.08),
     0px 3px 6px -4px rgba(0, 0, 0, 0.12),
-    0px 9px 28px 8px rgba(0, 0, 0, 0.05)
+    0px 9px 28px 8px rgba(0, 0, 0, 0.05);
 }
 
 .itemRowContainer {

--- a/src/components/Dropdown/dropdown.module.css
+++ b/src/components/Dropdown/dropdown.module.css
@@ -84,6 +84,7 @@
   width: 100%;
   border-radius: var(--shape-border-radius-lg, 8px);
   gap: var(--spacing-gap-xs, 4px);
+  /* FIXME: design tokens should be used instead, however shadows are not yet generated! */
   box-shadow:
     0px 6px 16px 0px rgba(0, 0, 0, 0.08),
     0px 3px 6px -4px rgba(0, 0, 0, 0.12),

--- a/src/components/Dropdown/dropdown.module.css
+++ b/src/components/Dropdown/dropdown.module.css
@@ -16,6 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+:global(.mia-platform-dropdown-trigger) {
+  display: flex;
+  width: fit-content;
+}
+
 .primaryLabel {
   color: var(--palette-text-neutral-main, #636363);
 }

--- a/src/components/Dropdown/props.ts
+++ b/src/components/Dropdown/props.ts
@@ -18,6 +18,8 @@
 
 import { KeyboardEvent, MouseEvent, ReactElement, ReactNode } from 'react'
 
+import { Size } from '../../themes/schema/shape'
+
 export enum ItemLayout {
   Horizontal = 'horizontal',
   Vertical = 'vertical'
@@ -184,6 +186,12 @@ export type DropdownProps = {
    * Allows to control the Dropdown label layout (accepts: horizontal, vertical).
    */
   itemLayout?: ItemLayout,
+
+  /**
+   * Sets the max height for the menu item list, this is useful to prevent creating
+   * a dropdown with many items that may be too big.
+   */
+  menuItemsMaxHeight?: Size,
 
   /**
    * control whether to allow multiple highlight selection.

--- a/src/components/Dropdown/props.ts
+++ b/src/components/Dropdown/props.ts
@@ -189,7 +189,7 @@ export type DropdownProps = {
 
   /**
    * Sets the max height for the menu item list, this is useful to prevent creating
-   * a dropdown with many items that may be too big.
+   * a dropdown with many items that may be too big (default: 240px).
    */
   menuItemsMaxHeight?: Size,
 

--- a/src/themes/schema/shape.ts
+++ b/src/themes/schema/shape.ts
@@ -22,7 +22,7 @@
  * @example 2px
  * @example 16
  */
-type Size = string | number
+export type Size = string | number
 
 /**
  * Scale of dimensions from lower to higher.


### PR DESCRIPTION
### Description

The menu is now limited at 240px, height can be customized with `menuItemsMaxHeight` prop

Screenshots taken from the new stories where max height is set to `128px`

<img width="355" alt="Screenshot 2024-10-03 alle 17 27 31" src="https://github.com/user-attachments/assets/58c0f4df-7d4a-408d-8508-57c76093513a">

<img width="348" alt="Screenshot 2024-10-03 alle 17 27 38" src="https://github.com/user-attachments/assets/44ed99c6-9983-45aa-a93f-2cfcf57aafa8">


### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g., enhancement, bug).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [x] Changes are covered by tests 
- [x] Changes to components are accessible and documented in the Storybook
- [x] Typings have been updated
- [ ] New components are exported from the `index` file
- [ ] New files include the Apache 2.0 License disclaimer
- [x] The browser console does not contain errors
