### PR TITLE
fix(Tag): remove tag margin right

### DIFF
--- a/src/components/Tag/Tag.module.css
+++ b/src/components/Tag/Tag.module.css
@@ -1,0 +1,3 @@
+.tag {
+  margin-inline-end: 0px;
+}

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -20,6 +20,9 @@ import { Tag as AntTag } from 'antd'
 import { ReactElement } from 'react'
 
 import { TagProps } from './Tag.props'
+import styles from './Tag.module.css'
+
+const { tag } = styles
 
 export const defaults = {
   isBordered: true,
@@ -37,6 +40,7 @@ export const Tag = (
   return (
     <AntTag
       bordered={isBordered}
+      className={tag}
       closeIcon={closeIcon}
       color={color}
       onClose={onClose}

--- a/src/components/Tag/__snapshots__/Tag.test.tsx.snap
+++ b/src/components/Tag/__snapshots__/Tag.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Tag renders correctly 1`] = `
 <DocumentFragment>
   <span
-    class="mia-platform-tag mia-platform-tag-has-color"
+    class="mia-platform-tag mia-platform-tag-has-color tag"
     style="background-color: rgb(255, 0, 0);"
   >
     Tag text


### PR DESCRIPTION
### Description

This PR removes the inline margin added by antd on the tag component.

### Addressed issue

### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g., enhancement, bug).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [x] Changes are covered by tests 
- [x] Changes to components are accessible and documented in the Storybook
- [ ] Typings have been updated
- [ ] New components are exported from the `index` file
- [ ] New files include the Apache 2.0 License disclaimer
- [x] The browser console does not contain errors
