### PR TITLE
fix(Dropdown): `width: fit-content` attached to the menu instead of the dropdown

### DIFF
--- a/src/components/Dropdown/dropdown.module.css
+++ b/src/components/Dropdown/dropdown.module.css
@@ -18,7 +18,6 @@
 
 :global(.mia-platform-dropdown-trigger) {
   display: flex;
-  width: fit-content;
 }
 
 .primaryLabel {

--- a/src/components/Dropdown/dropdown.module.css
+++ b/src/components/Dropdown/dropdown.module.css
@@ -76,7 +76,7 @@
 
 .dropdownRenderWrapper {
   background-color: white;
-  width: 100%;
+  width: fit-content;
   border-radius: var(--shape-border-radius-lg, 8px);
   gap: var(--spacing-gap-xs, 4px);
   /* FIXME: design tokens should be used instead, however shadows are not yet generated! */


### PR DESCRIPTION
### Description

<!-- Please provide a brief description of your changes. Summarize the rationale and impact on the codebase. E.g.

##### <Changed component name>
    - change 1
    - change 2
    - ...
-->

##### Dropdown

Removed instruction `width: fit-content` from class `mia-platform-dropdown-trigger` since it caused children to not be able to fill the parent width (CSS instruction has been removed altogether, `width` will be set to its default `auto`).

This instruction has been moved to the `dropdownRenderWrapper` CSS class to ensure that only the menu (when opened) will show items with the width of its content.

Here a quick video to show the result.

[Screencast from 21-10-2024 14:34:40.webm](https://github.com/user-attachments/assets/f5b902db-f5af-478a-b114-68e62ab0861d)

Unsure whether to create a new prop to handle this case. For now I'd stick with this behavior
<!-- Link to the issue, if present. E.g. 
    Closes #XYZ
-->

### [IMPORTANT] PR Checklist

- [X] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [X] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g., enhancement, bug).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [ ] Changes are covered by tests 
- [X] Changes to components are accessible and documented in the Storybook
- [ ] Typings have been updated
- [ ] New components are exported from the `index` file
- [ ] New files include the Apache 2.0 License disclaimer
- [X] The browser console does not contain errors
