### PR TITLE
fix(Modal): aside height calculated incorrectly

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -23,6 +23,8 @@ import docs from "./addons/docs"
 import themeSwitcher from "./addons/theme"
 import withTheme from "./decorators/theme"
 
+import './reset.css'
+
 const preview: Preview = {
   parameters: {
     options: {

--- a/.storybook/reset.css
+++ b/.storybook/reset.css
@@ -1,0 +1,19 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body {
+  height: 100%;
+  width: 100%;
+}
+
+body {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}

--- a/.storybook/reset.css
+++ b/.storybook/reset.css
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// NOTE:
-// This file serves as a foundational reset stylesheet that normalizes default browser styles.
-// It applies to all Storybook stories and provides a clean, consistent starting point for component development and documentation.
+/* NOTE: This file serves as a foundational reset stylesheet that normalizes default browser styles.
+It applies to all Storybook stories and provides a clean, consistent starting point for component development and documentation. */
 
 *,
 *::before,

--- a/.storybook/reset.css
+++ b/.storybook/reset.css
@@ -1,3 +1,25 @@
+/**
+ * Copyright 2024 Mia srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// NOTE:
+// This file serves as a foundational reset stylesheet that normalizes default browser styles.
+// It applies to all Storybook stories and provides a clean, consistent starting point for component development and documentation.
+
 *,
 *::before,
 *::after {

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -123,7 +123,8 @@
       flex-direction: column;
       background-color: var(--palette-background-neutral-300, #f9f9f9);
       border-radius: var(--shape-border-radius-md, 4px);
-      height: calc(100% - 2 * var(--spacing-padding-lg, 16px));
+      box-sizing: border-box;
+      height: 100%;
       gap: var(--spacing-gap-sm, 8px);
       overflow-y: auto;
       padding: var(--spacing-padding-lg, 16px)

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -28,6 +28,14 @@ import { useModal } from '../../hooks/useModal'
 
 const meta = {
   component: Modal,
+  parameters: {
+    docs: {
+      story: {
+        inline: false,
+        iframeHeight: 700,
+      },
+    },
+  },
   args: {
     ...defaults,
     children,


### PR DESCRIPTION
### Description

This PR introduces a fix on the Modal component regarding the height of the `aside` element.

The Storybook setup did not contain any CSS reset file; this means that the `box-sizing` property was implicitly set to `content-box` for certain elements. The `aside` element is an example of this: setting its height to 100% would result in it taking its container's height _plus_ its own vertical padding.

##### Modal
  - updated aside element to have `box-sizing: border-box` and height set to 100%; 
  - added CSS reset to storybook preview
  - updated Modal stories to improve the ease of use
 
![image](https://github.com/user-attachments/assets/c0b8f6d3-c813-4274-b101-884dd1fa2b78)

### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g. enhancement, new component, bug).

    > **NOTE**  
    > Some labels are used to generate release note entries: you can find the complete mapping between PR labels and release note categories [here](https://github.com/mia-platform/design-system/blob/main/.github/release.yml).  
    For a more detailed overview of PR labels, please refer to the [dedicated CONTRIBUTING section](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md#pull-request-labels).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [ ] Changes are covered by tests 
- [x] Changes to components are accessible and documented in the Storybook
- [ ] Typings have been updated
- [ ] New components are exported from the `src/index.ts` file
- [ ] New files include the Apache 2.0 License disclaimer
- [ ] The browser console does not contain errors
