### PR TITLE
fix(Button): Danger and Primary Outlined should have white background

### DIFF
--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -81,3 +81,11 @@
 .buttonText {
   padding: 0 var(--spacing-padding-xs, 4px);
 }
+
+.primaryOutlined {
+  background-color: var(--palette-action-secondary-main, #ffffff) !important;
+}
+
+.dangerOutlined {
+  background-color: var(--palette-action-secondary-main, #ffffff) !important;
+}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -34,13 +34,15 @@ const {
   buttonGhost,
   buttonLink,
   buttonText,
+  primaryOutlined,
+  dangerOutlined,
 } = styles
 
 const { Primary, Neutral, Danger } = Hierarchy
 const { Left } = IconPosition
 const { Square } = Shape
 const { Small, Middle, Large } = Size
-const { Filled, Ghost, Link } = Type
+const { Filled, Ghost, Link, Outlined } = Type
 
 enum AntdIconPosition {
   Start = 'start',
@@ -94,9 +96,11 @@ export const Button = ({
       !children && size === Middle && type !== Link && buttonMdIconOnly,
       size === Large && type !== Link && buttonLg,
       (type === Ghost || type === Link) && buttonGhost,
+      (hierarchy === Primary && type === Outlined) && primaryOutlined,
+      (hierarchy === Danger && type === Outlined) && dangerOutlined,
       type === Link && buttonLink,
     ]
-  ), [children, size, type])
+  ), [children, hierarchy, size, type])
 
   const antdIconPosition = useMemo(() => getAntdPosition(iconPosition), [iconPosition])
   return (

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -178,7 +178,7 @@ exports[`Button Component renders danger link button correctly 1`] = `
 exports[`Button Component renders danger outline button correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-dangerous mia-platform-btn-color-dangerous mia-platform-btn-variant-solid mia-platform-btn-background-ghost button buttonMd"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-dangerous mia-platform-btn-color-dangerous mia-platform-btn-variant-solid mia-platform-btn-background-ghost button buttonMd dangerOutlined"
     type="button"
   >
     <div
@@ -379,7 +379,7 @@ exports[`Button Component renders primary link button correctly 1`] = `
 exports[`Button Component renders primary outline button correctly 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-color-primary mia-platform-btn-variant-solid mia-platform-btn-background-ghost button buttonMd"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-color-primary mia-platform-btn-variant-solid mia-platform-btn-background-ghost button buttonMd primaryOutlined"
     type="button"
   >
     <div
@@ -394,7 +394,7 @@ exports[`Button Component renders primary outline button correctly 1`] = `
 exports[`Button Component renders primary outline button correctly with form ref and no htmlType 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-color-primary mia-platform-btn-variant-solid mia-platform-btn-background-ghost button buttonMd"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-color-primary mia-platform-btn-variant-solid mia-platform-btn-background-ghost button buttonMd primaryOutlined"
     form="some-form"
     type="submit"
   >
@@ -410,7 +410,7 @@ exports[`Button Component renders primary outline button correctly with form ref
 exports[`Button Component renders primary outline button correctly with form ref and reset htmlType 1`] = `
 <DocumentFragment>
   <button
-    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-color-primary mia-platform-btn-variant-solid mia-platform-btn-background-ghost button buttonMd"
+    class="mia-platform-btn mia-platform-btn-primary mia-platform-btn-color-primary mia-platform-btn-variant-solid mia-platform-btn-background-ghost button buttonMd primaryOutlined"
     form="some-form"
     type="reset"
   >


### PR DESCRIPTION
### Description

The Button when has hierarchy Danger or Primary, and type Outlined, should have a white background, and not transparent, as inherited from antd.

##### <Changed component name>
    - Button

### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g. enhancement, new component, bug).

    > **NOTE**  
    > Some labels are used to generate release note entries: you can find the complete mapping between PR labels and release note categories [here](https://github.com/mia-platform/design-system/blob/main/.github/release.yml).  
    For a more detailed overview of PR labels, please refer to the [dedicated CONTRIBUTING section](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md#pull-request-labels).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [x] Changes are covered by tests 
- [x] Changes to components are accessible and documented in the Storybook
- [ ] Typings have been updated
- [ ] New components are exported from the `src/index.ts` file
- [ ] New files include the Apache 2.0 License disclaimer
- [x] The browser console does not contain errors
