### PR TITLE
feat(Input): added custom names for input addon

### DIFF
--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -283,8 +283,10 @@ export const WithCustomLogic = (): ReactElement => {
         }}
         isDisabled={inherited}
         value={value}
-        onChange={(_, {value}: any) => {
-            setValue(value)
+        onChange={(_, val: string | Record<string, unknown>) => {
+          if (typeof val === 'object') {
+            setValue(String(val.value))
+          }
         }}
       />
     </div>

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -283,8 +283,8 @@ export const WithCustomLogic = (): ReactElement => {
         }}
         isDisabled={inherited}
         value={value}
-        onChange={(_, { value: val }) => {
-          setValue(val)
+        onChange={(_, {value}) => {
+            setValue(String(value))
         }}
       />
     </div>

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -283,8 +283,8 @@ export const WithCustomLogic = (): ReactElement => {
         }}
         isDisabled={inherited}
         value={value}
-        onChange={(_, {value}) => {
-            setValue(String(value))
+        onChange={(_, {value}: any) => {
+            setValue(value)
         }}
       />
     </div>

--- a/src/components/Input/Input.test.tsx
+++ b/src/components/Input/Input.test.tsx
@@ -264,7 +264,7 @@ describe('Input Component', () => {
   test('if no addon is provided the second argument of onChange should be the string value', async() => {
     const onChange = jest.fn()
 
-    render(<Input onChange={onChange}/>)
+    render(<Input onChange={onChange} />)
 
     const input = screen.getByRole<HTMLInputElement>('textbox')
 
@@ -276,11 +276,13 @@ describe('Input Component', () => {
   test('should accept an object value prop if addons are set', async() => {
     const onChange = jest.fn()
 
-    render(<Input
-      onChange={onChange}
-      defaultValue={{value: exampleText, before: true}}
-      addonBefore={{ type: AddonType.Checkbox, label: checkboxAddonLabel }}
-    />)
+    render(
+      <Input
+        addonBefore={{ type: AddonType.Checkbox, label: checkboxAddonLabel }}
+        defaultValue={{ value: exampleText, before: true }}
+        onChange={onChange}
+      />
+    )
 
     const input = screen.getByRole<HTMLInputElement>('textbox')
     const checkbox = screen.getByRole<HTMLInputElement>('checkbox')
@@ -294,16 +296,14 @@ describe('Input Component', () => {
   test('should work with custom names for input and addons values', async() => {
     const onChange = jest.fn()
 
-    render(<Input
-      onChange={onChange}
-      valuePropName='inputValue'
-      defaultValue={{inputValue: exampleText, addonBeforeValue: true}}
-      addonBefore={{
-        type: AddonType.Checkbox,
-        label: checkboxAddonLabel,
-        name: 'addonBeforeValue'
-    }}
-    />)
+    render(
+      <Input
+        addonBefore={{ type: AddonType.Checkbox, label: checkboxAddonLabel, name: 'addonBeforeValue' }}
+        defaultValue={{ inputValue: exampleText, addonBeforeValue: true }}
+        valuePropName="inputValue"
+        onChange={onChange}
+      />
+    )
 
     const input = screen.getByRole<HTMLInputElement>('textbox')
     const checkbox = screen.getByRole<HTMLInputElement>('checkbox')
@@ -314,15 +314,13 @@ describe('Input Component', () => {
     fireEvent.change(input, { target: { value: 'changedValue' } })
     expect(onChange).toHaveBeenCalledWith({}, {
       inputValue: 'changedValue',
-      addonBeforeValue: true
+      addonBeforeValue: true,
     })
 
     fireEvent.click(checkbox)
     expect(onChange).toHaveBeenCalledWith(undefined, {
       inputValue: 'changedValue',
-      addonBeforeValue: false
+      addonBeforeValue: false,
     })
-
   })
-
 })

--- a/src/components/Input/Input.test.tsx
+++ b/src/components/Input/Input.test.tsx
@@ -260,4 +260,69 @@ describe('Input Component', () => {
     expect(input).not.toBeDisabled()
     expect(checkbox).toBeDisabled()
   })
+
+  test('if no addon is provided the second argument of onChange should be the string value', async() => {
+    const onChange = jest.fn()
+
+    render(<Input onChange={onChange}/>)
+
+    const input = screen.getByRole<HTMLInputElement>('textbox')
+
+    fireEvent.change(input, { target: { value: exampleText } })
+
+    expect(onChange).toHaveBeenCalledWith({}, exampleText)
+  })
+
+  test('should accept an object value prop if addons are set', async() => {
+    const onChange = jest.fn()
+
+    render(<Input
+      onChange={onChange}
+      defaultValue={{value: exampleText, before: true}}
+      addonBefore={{ type: AddonType.Checkbox, label: checkboxAddonLabel }}
+    />)
+
+    const input = screen.getByRole<HTMLInputElement>('textbox')
+    const checkbox = screen.getByRole<HTMLInputElement>('checkbox')
+
+    fireEvent.change(input, { target: { value: exampleText } })
+
+    expect(input.value).toBe(exampleText)
+    expect(checkbox).toBeChecked()
+  })
+
+  test('should work with custom names for input and addons values', async() => {
+    const onChange = jest.fn()
+
+    render(<Input
+      onChange={onChange}
+      valuePropName='inputValue'
+      defaultValue={{inputValue: exampleText, addonBeforeValue: true}}
+      addonBefore={{
+        type: AddonType.Checkbox,
+        label: checkboxAddonLabel,
+        name: 'addonBeforeValue'
+    }}
+    />)
+
+    const input = screen.getByRole<HTMLInputElement>('textbox')
+    const checkbox = screen.getByRole<HTMLInputElement>('checkbox')
+
+    expect(input.value).toBe(exampleText)
+    expect(checkbox).toBeChecked()
+
+    fireEvent.change(input, { target: { value: 'changedValue' } })
+    expect(onChange).toHaveBeenCalledWith({}, {
+      inputValue: 'changedValue',
+      addonBeforeValue: true
+    })
+
+    fireEvent.click(checkbox)
+    expect(onChange).toHaveBeenCalledWith(undefined, {
+      inputValue: 'changedValue',
+      addonBeforeValue: false
+    })
+
+  })
+
 })

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -42,12 +42,11 @@ const DEFAULT_ICON_SIZE = 12 as never
 
 type AddonPosition = 'before' | 'after'
 
-const getAddonDefaultValue = (position: AddonPosition) =>
-  (props?: InputAddonProps) : Record<string, unknown> => {
-    return props && (props.value !== undefined || props.defaultValue !== undefined)
-      ? { [props.name || position]: props.value || props.defaultValue }
-      : {}
-  }
+const getAddonDefaultValue = (position: AddonPosition, props?: InputAddonProps) : Record<string, unknown> => {
+  return props && (props.value !== undefined || props.defaultValue !== undefined)
+    ? { [props.name || position]: props.value || props.defaultValue }
+    : {}
+}
 
 const useInputValue = (
   value: Record<string, unknown> | string | undefined,
@@ -60,8 +59,8 @@ const useInputValue = (
   ] => {
   return useState({
     ...(typeof value === 'object' ? value : { [valuePropName]: value || '' }),
-    ...getAddonDefaultValue('before')(before),
-    ...getAddonDefaultValue('after')(after),
+    ...getAddonDefaultValue('before', before),
+    ...getAddonDefaultValue('after', after),
   })
 }
 

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -35,7 +35,7 @@ import styles from './input.module.css'
 export const defaults = {
   ...baseInputDefaults,
   htmlType: Type.Text,
-  valuePropName: "value",
+  valuePropName: 'value',
 }
 
 const DEFAULT_ICON_SIZE = 12 as never
@@ -106,7 +106,7 @@ export const Input = (
     if (onChange) {
       onChange(event, addonBeforeProp || addonAfterProp ? nextVal : nextValue)
     }
-  }, [addonAfterProp, addonBeforeProp, onChange, setVal, val])
+  }, [addonAfterProp, addonBeforeProp, onChange, valuePropName, setVal, val])
 
   const renderAddon = useCallback((
     position: AddonPosition,
@@ -147,7 +147,7 @@ export const Input = (
 
   const getValue = useCallback((strOrObj?: string | Record<string, unknown>) => {
     return typeof strOrObj === 'object' ? String(strOrObj[valuePropName]) : strOrObj
-  }, [])
+  }, [valuePropName])
 
   const inputValue = useMemo(() => {
     return getValue(value)

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -30,6 +30,7 @@ import { BaseInput, defaults as baseInputDefaults } from '../BaseInput/BaseInput
 import { InputAddon, InputAddonProps } from './InputAddon.tsx'
 import { Icon } from '../Icon'
 import { InputProps } from './props'
+import { isObject } from '../../utils/object.ts'
 import styles from './input.module.css'
 
 export const defaults = {
@@ -58,7 +59,7 @@ const useInputValue = (
     React.Dispatch<React.SetStateAction<Record<string, unknown>>>
   ] => {
   return useState({
-    ...(typeof value === 'object' ? value : { [valuePropName]: value || '' }),
+    ...(isObject(value) ? value : { [valuePropName]: value || '' }),
     ...getAddonDefaultValue('before', before),
     ...getAddonDefaultValue('after', after),
   })
@@ -145,7 +146,7 @@ export const Input = (
   ), [addonAfterProp, renderAddon])
 
   const getValue = useCallback((strOrObj?: string | Record<string, unknown>) => {
-    return typeof strOrObj === 'object' ? String(strOrObj[valuePropName]) : strOrObj
+    return isObject(strOrObj) ? String(strOrObj[valuePropName]) : strOrObj
   }, [valuePropName])
 
   const inputValue = useMemo(() => {

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -106,7 +106,7 @@ export const Input = (
     if (onChange) {
       onChange(event, addonBeforeProp || addonAfterProp ? nextVal : nextValue)
     }
-  }, [addonAfterProp, addonBeforeProp, onChange, valuePropName, setVal, val])
+  }, [addonAfterProp, addonBeforeProp, onChange, valuePropName])
 
   const renderAddon = useCallback((
     position: AddonPosition,

--- a/src/components/Input/InputAddon.tsx
+++ b/src/components/Input/InputAddon.tsx
@@ -34,6 +34,7 @@ type InputAddonConfig<
   Type extends AddonType,
   Config extends object = object
 > = Config & {
+  name?: string
   type: Type
   onChange?: (value: unknown) => void
   value?: unknown;
@@ -50,8 +51,6 @@ type SelectConfig = InputAddonConfig<
 }>
 type CheckboxConfig = InputAddonConfig<
   AddonType.Checkbox, {
-  value?: boolean
-  defaultValue?: boolean
   label?: ReactNode
   onChange?: (value: boolean) => void
 }>
@@ -91,9 +90,9 @@ export const InputAddon = ({
     return (
       <div className={styles.inputAddonCheckbox}>
         <Checkbox
-          isChecked={value}
+          isChecked={Boolean(value)}
           isDisabled={isDisabled}
-          isInitiallyChecked={defaultValue}
+          isInitiallyChecked={Boolean(defaultValue)}
           onChange={(event) => {
             if (onChange) {
               onChange(event.target.checked)

--- a/src/components/Input/props.ts
+++ b/src/components/Input/props.ts
@@ -24,7 +24,7 @@ import { InputAddonProps } from './InputAddon'
 import { Type } from './types'
 
 type InputChangeEventHandler =
-  (event: ChangeEvent<HTMLInputElement> | undefined, values: Record<string, unknown>) => void
+  (event: ChangeEvent<HTMLInputElement> | undefined, values: string | Record<string, unknown>) => void
 
 export type InputProps = BaseInputProps & {
 

--- a/src/components/Input/props.ts
+++ b/src/components/Input/props.ts
@@ -24,7 +24,7 @@ import { InputAddonProps } from './InputAddon'
 import { Type } from './types'
 
 type InputChangeEventHandler =
-  (event: ChangeEvent<HTMLInputElement> | undefined, values: {value: string, after?: unknown, before?: unknown}) => void
+  (event: ChangeEvent<HTMLInputElement> | undefined, values: string | Record<string, unknown>) => void
 
 export type InputProps = BaseInputProps & {
 
@@ -46,12 +46,17 @@ export type InputProps = BaseInputProps & {
   /**
    * The input content value.
    */
-  value?: string
+  value?: string | Record<string, unknown>
 
   /**
    * The input default value
    */
-  defaultValue?: string
+  defaultValue?: string | Record<string, unknown>
+
+  /**
+   * The value prop name of the input value if the value provided is an object. Defaults is 'value'
+   */
+  valuePropName?: string
 
   /**
    * If allow to remove input content with clear icon.

--- a/src/components/Input/props.ts
+++ b/src/components/Input/props.ts
@@ -24,7 +24,7 @@ import { InputAddonProps } from './InputAddon'
 import { Type } from './types'
 
 type InputChangeEventHandler =
-  (event: ChangeEvent<HTMLInputElement> | undefined, values: string | Record<string, unknown>) => void
+  (event: ChangeEvent<HTMLInputElement> | undefined, values: Record<string, unknown>) => void
 
 export type InputProps = BaseInputProps & {
 

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2023 Mia srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Returns true if the value is a plain object.
+ *
+ * @param {unknown} value - The value to test.
+ * @returns {boolean}
+ */
+
+export const isObject = (value: unknown): value is Record<string, unknown> => {
+  return (
+    // equality operator checks undefined and null
+    value !== null
+    && (value?.constructor === Object || (!value?.constructor && typeof value === 'object'))
+  )
+}


### PR DESCRIPTION
### Description

The Input component now supports an object to be passed as a controlled value if the input has addons.
Additionally, you can specify custom prop names for the values in the addons by passing in their options a prop "name".
For the text input component, you can specify the prop valuePropName (defaults to "value") to customize the name of the value prop.

##### Input
    - The input now supports custom names to for the values of the input component and the addons

### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g. enhancement, new component, bug).

    > **NOTE**  
    > Some labels are used to generate release note entries: you can find the complete mapping between PR labels and release note categories [here](https://github.com/mia-platform/design-system/blob/main/.github/release.yml).  
    For a more detailed overview of PR labels, please refer to the [dedicated CONTRIBUTING section](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md#pull-request-labels).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [x] Changes are covered by tests 
- [x] Changes to components are accessible and documented in the Storybook
- [x] Typings have been updated
- [x] New components are exported from the `src/index.ts` file
- [x] New files include the Apache 2.0 License disclaimer
- [x] The browser console does not contain errors
