### PR TITLE
fix(Button): removed outline and box shadow for ghost and link

### DIFF
--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -68,6 +68,10 @@
 .buttonGhost {
   border-color: transparent !important;
   background-color: transparent;
+  div:first-child {
+    outline: none;
+    box-shadow: none;
+  }
 }
 
 .buttonLink {
@@ -76,6 +80,10 @@
   height: auto;
   width: fit-content;
   text-decoration: none;
+  div:first-child {
+    outline: none;
+    box-shadow: none;
+  }
 }
 
 .buttonText {


### PR DESCRIPTION
### Description

Removed outline animation in the button if the type is `ghost` or `link`

Before fix
<img width="495" alt="image" src="https://github.com/user-attachments/assets/b4595036-58b2-422d-8d2b-384742f4208b">

After fix
<img width="463" alt="image" src="https://github.com/user-attachments/assets/b8b92d41-14f2-41dd-a591-84c12c61068c">



##### <Button>
removed via css outline and box-shadow to the first div contained in the button that is added at button click
  

### Addressed issue

### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g. enhancement, new component, bug).

    > **NOTE**  
    > Some labels are used to generate release note entries: you can find the complete mapping between PR labels and release note categories [here](https://github.com/mia-platform/design-system/blob/main/.github/release.yml).  
    For a more detailed overview of PR labels, please refer to the [dedicated CONTRIBUTING section](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md#pull-request-labels).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [x] Changes are covered by tests 
- [x] Changes to components are accessible and documented in the Storybook
- [x] Typings have been updated
- [x] New components are exported from the `src/index.ts` file
- [x] New files include the Apache 2.0 License disclaimer
- [x] The browser console does not contain errors
