### PR TITLE
Fix(Alert): Using phosphor icons in both default and compressed variants

### DIFF
--- a/src/components/Alert/Alert.module.css
+++ b/src/components/Alert/Alert.module.css
@@ -40,7 +40,13 @@
   }
 
   & :global(.mia-platform-alert-close-icon) {
+    width: 32px;
+    height: 32px;
     color: var(--palette-action-secondary-contrastText, #636363);
+    cursor: pointer;
+    &:hover {
+      color: var(--palette-action-primary-hover, #1890ff);
+    }
   }
 
   & .titleContainer svg {

--- a/src/components/Alert/Alert.module.css
+++ b/src/components/Alert/Alert.module.css
@@ -67,7 +67,7 @@
   padding: var(--spacing-padding-md, 12px);
 
   &:global(.mia-platform-alert-with-description) :global(.mia-platform-alert-message) {
-    padding-bottom: var(--spacing-padding-sm, 8px);
+    margin-bottom: var(--spacing-padding-sm, 8px) !important;
   }
 
   & .title {
@@ -100,6 +100,9 @@
 .info {
   background-color:  var(--palette-parimary-100, #E5F0FC);
   border-color: var(--palette-primary-500, #1890FF);
+  & .titleContainer > svg {
+    color: var(--palette-primary-500, #1890FF) !important;
+  }
   & > svg {
     color: var(--palette-parimary-100, #E5F0FC) !important;
   }
@@ -108,6 +111,9 @@
 .success {
   background-color:  var(--palette-success-100, #DEF8D8);
   border-color: var(--palette-success-500, #4CB61B);
+  & .titleContainer > svg {
+    color: var(--palette-success-500, #4CB61B) !important;
+  }
   & > svg {
     color: var(--palette-success-100, #DEF8D8) !important;
   }
@@ -116,6 +122,9 @@
 .warning {
   background-color:  var(--palette-warning-50, #FFF8D4);
   border-color: var(--palette-warning-400, #F68F1F);
+  & .titleContainer > svg {
+    color: var(--palette-warning-400, #F68F1F) !important;
+  }
   & > svg {
     color: var(--palette-warning-50, #FFF8D4) !important;
   }
@@ -124,6 +133,9 @@
 .error {
   background-color:  var(--palette-error-100, #FFEBEB);
   border-color: var(--palette-error-500, #FF5453);
+  & .titleContainer > svg {
+    color: var(--palette-error-500, #FF5453) !important;
+  }
   & > svg {
     color:  var(--palette-error-100, #FFEBEB) !important;
   }

--- a/src/components/Alert/Alert.module.css
+++ b/src/components/Alert/Alert.module.css
@@ -40,8 +40,8 @@
   }
 
   & :global(.mia-platform-alert-close-icon) {
-    width: 32px;
-    height: 32px;
+    width: var(--shape-size-xl, 32px);
+    height: var(--shape-size-xl, 32px);
     color: var(--palette-action-secondary-contrastText, #636363);
     cursor: pointer;
     &:hover {
@@ -57,7 +57,7 @@
 
 .compressed {
   border-left-width: 0;
-  padding: 0 16px;
+  padding: 0 var(--spacing-padding-lg, 16px);
 }
 
 .titleContainer {

--- a/src/components/Alert/Alert.test.tsx
+++ b/src/components/Alert/Alert.test.tsx
@@ -143,7 +143,8 @@ describe('Alert Snapshot Tests', () => {
       />
     )
 
-    const closeButton = screen.getByRole('button')
+    screen.logTestingPlaygroundURL()
+    const closeButton = screen.getByRole('img')
     fireEvent.click(closeButton)
 
     await waitFor(() => {

--- a/src/components/Alert/Alert.test.tsx
+++ b/src/components/Alert/Alert.test.tsx
@@ -143,8 +143,7 @@ describe('Alert Snapshot Tests', () => {
       />
     )
 
-    screen.logTestingPlaygroundURL()
-    const closeButton = screen.getByRole('img')
+    const closeButton = screen.getByRole('button')
     fireEvent.click(closeButton)
 
     await waitFor(() => {

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -28,7 +28,6 @@ import { ReactElement, useMemo } from 'react'
 import { Alert as AntAlert } from 'antd'
 import classnames from 'classnames'
 
-import { Button } from '../Button/Button.tsx'
 import { AlertProps } from './props.ts'
 import { Icon } from '../Icon'
 import { IconComponent } from '../Icon/Icon.props.ts'
@@ -98,15 +97,7 @@ export const Alert = ({
   }, [children, description])
 
   const closable = useMemo(() => {
-    return !isCompressed && isClosable && {
-      closeIcon: (
-        <Button
-          hierarchy={Button.Hierarchy.Neutral}
-          icon={<Icon component={PiX} size={16} />}
-          type={Button.Type.Ghost}
-        />
-      ),
-    }
+    return !isCompressed && isClosable && { closeIcon: <Icon component={PiX} size={16} /> }
   }, [isCompressed, isClosable])
 
   return (

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -20,22 +20,19 @@ import {
   PiCheckCircleFill,
   PiCircleHalfTiltFill,
   PiInfoFill,
-  PiWarningFill,
+  PiWarningDiamondFill,
   PiX,
-  PiXCircleFill,
+  PiXSquareFill,
 } from 'react-icons/pi'
 import { ReactElement, useMemo } from 'react'
 import { Alert as AntAlert } from 'antd'
 import classnames from 'classnames'
 
+import { Button } from '../Button/Button.tsx'
 import { AlertProps } from './props.ts'
-import CheckCircle from '../../assets/icons/CheckCircle.svg'
-import ICircle from '../../assets/icons/ICircle.svg'
 import { Icon } from '../Icon'
 import { IconComponent } from '../Icon/Icon.props.ts'
-import MiExclamationCircle from '../../assets/icons/ExclamationCircle.svg'
 import { Type } from './types.ts'
-import XCircle from '../../assets/icons/XCircle.svg'
 import styles from './Alert.module.css'
 
 export const defaults = {
@@ -47,26 +44,11 @@ const getIcon = (type?: Type): IconComponent => {
   case Type.Info:
     return PiInfoFill
   case Type.Warning:
-    return PiWarningFill
+    return PiWarningDiamondFill
   case Type.Error:
-    return PiXCircleFill
+    return PiXSquareFill
   case Type.Success:
     return PiCheckCircleFill
-  default:
-    return PiCircleHalfTiltFill
-  }
-}
-
-const getIconCompressed = (type?: Type): IconComponent => {
-  switch (type) {
-  case Type.Info:
-    return ICircle
-  case Type.Warning:
-    return MiExclamationCircle
-  case Type.Error:
-    return XCircle
-  case Type.Success:
-    return CheckCircle
   default:
     return PiCircleHalfTiltFill
   }
@@ -93,7 +75,7 @@ export const Alert = ({
     return isCompressed
       ? (
         <div className={styles.titleContainer}>
-          <Icon component={icon || getIconCompressed(type)} size={16} />
+          <Icon component={icon || getIcon(type)} size={16} />
           <span className={styles.title}>{titleProp}</span>
         </div>
       )
@@ -116,7 +98,15 @@ export const Alert = ({
   }, [children, description])
 
   const closable = useMemo(() => {
-    return !isCompressed && isClosable && { closeIcon: <Icon component={PiX} size={16} /> }
+    return !isCompressed && isClosable && {
+      closeIcon: (
+        <Button
+          hierarchy={Button.Hierarchy.Neutral}
+          icon={<Icon component={PiX} size={16} />}
+          type={Button.Type.Ghost}
+        />
+      ),
+    }
   }, [isCompressed, isClosable])
 
   return (

--- a/src/components/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/components/Alert/__snapshots__/Alert.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`Alert Snapshot Tests renders Error correctly 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm37.66,130.34a8,8,0,0,1-11.32,11.32L128,139.31l-26.34,26.35a8,8,0,0,1-11.32-11.32L116.69,128,90.34,101.66a8,8,0,0,1,11.32-11.32L128,116.69l26.34-26.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
+        d="M208,32H48A16,16,0,0,0,32,48V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V48A16,16,0,0,0,208,32ZM165.66,154.34a8,8,0,0,1-11.32,11.32L128,139.31l-26.34,26.35a8,8,0,0,1-11.32-11.32L116.69,128,90.34,101.66a8,8,0,0,1,11.32-11.32L128,116.69l26.34-26.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
       />
     </svg>
     <div
@@ -51,23 +51,31 @@ exports[`Alert Snapshot Tests renders Error correctly 1`] = `
       class="ant-alert-close-icon"
       tabindex="0"
       type="button"
+    />
+    <button
+      class="ant-btn css-dev-only-do-not-override-5wsri9 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only button buttonMdIconOnly buttonGhost"
+      type="button"
     >
-      <svg
-        color="currentColor"
-        fill="currentColor"
-        height="16"
-        role="img"
-        stroke="currentColor"
-        stroke-width="0"
-        style="color: currentColor;"
-        viewBox="0 0 256 256"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
+      <span
+        class="ant-btn-icon"
       >
-        <path
-          d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
-        />
-      </svg>
+        <svg
+          color="currentColor"
+          fill="currentColor"
+          height="16"
+          role="img"
+          stroke="currentColor"
+          stroke-width="0"
+          style="color: currentColor;"
+          viewBox="0 0 256 256"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
+          />
+        </svg>
+      </span>
     </button>
   </div>
 </DocumentFragment>
@@ -91,12 +99,20 @@ exports[`Alert Snapshot Tests renders ErrorCompressed correctly 1`] = `
         >
           <svg
             color="currentColor"
-            data-file-name="SvgXCircle"
+            fill="currentColor"
             height="16"
             role="img"
-            size="16"
+            stroke="currentColor"
+            stroke-width="0"
+            style="color: currentColor;"
+            viewBox="0 0 256 256"
             width="16"
-          />
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M208,32H48A16,16,0,0,0,32,48V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V48A16,16,0,0,0,208,32ZM165.66,154.34a8,8,0,0,1-11.32,11.32L128,139.31l-26.34,26.35a8,8,0,0,1-11.32-11.32L116.69,128,90.34,101.66a8,8,0,0,1,11.32-11.32L128,116.69l26.34-26.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
+            />
+          </svg>
           <span
             class="title"
           >
@@ -171,23 +187,31 @@ exports[`Alert Snapshot Tests renders Info correctly 1`] = `
       class="ant-alert-close-icon"
       tabindex="0"
       type="button"
+    />
+    <button
+      class="ant-btn css-dev-only-do-not-override-5wsri9 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only button buttonMdIconOnly buttonGhost"
+      type="button"
     >
-      <svg
-        color="currentColor"
-        fill="currentColor"
-        height="16"
-        role="img"
-        stroke="currentColor"
-        stroke-width="0"
-        style="color: currentColor;"
-        viewBox="0 0 256 256"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
+      <span
+        class="ant-btn-icon"
       >
-        <path
-          d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
-        />
-      </svg>
+        <svg
+          color="currentColor"
+          fill="currentColor"
+          height="16"
+          role="img"
+          stroke="currentColor"
+          stroke-width="0"
+          style="color: currentColor;"
+          viewBox="0 0 256 256"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
+          />
+        </svg>
+      </span>
     </button>
   </div>
 </DocumentFragment>
@@ -211,12 +235,20 @@ exports[`Alert Snapshot Tests renders InfoCompressed correctly 1`] = `
         >
           <svg
             color="currentColor"
-            data-file-name="SvgICircle"
+            fill="currentColor"
             height="16"
             role="img"
-            size="16"
+            stroke="currentColor"
+            stroke-width="0"
+            style="color: currentColor;"
+            viewBox="0 0 256 256"
             width="16"
-          />
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm-4,48a12,12,0,1,1-12,12A12,12,0,0,1,124,72Zm12,112a16,16,0,0,1-16-16V128a8,8,0,0,1,0-16,16,16,0,0,1,16,16v40a8,8,0,0,1,0,16Z"
+            />
+          </svg>
           <span
             class="title"
           >
@@ -291,23 +323,31 @@ exports[`Alert Snapshot Tests renders Special correctly 1`] = `
       class="ant-alert-close-icon"
       tabindex="0"
       type="button"
+    />
+    <button
+      class="ant-btn css-dev-only-do-not-override-5wsri9 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only button buttonMdIconOnly buttonGhost"
+      type="button"
     >
-      <svg
-        color="currentColor"
-        fill="currentColor"
-        height="16"
-        role="img"
-        stroke="currentColor"
-        stroke-width="0"
-        style="color: currentColor;"
-        viewBox="0 0 256 256"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
+      <span
+        class="ant-btn-icon"
       >
-        <path
-          d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
-        />
-      </svg>
+        <svg
+          color="currentColor"
+          fill="currentColor"
+          height="16"
+          role="img"
+          stroke="currentColor"
+          stroke-width="0"
+          style="color: currentColor;"
+          viewBox="0 0 256 256"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
+          />
+        </svg>
+      </span>
     </button>
   </div>
 </DocumentFragment>
@@ -419,23 +459,31 @@ exports[`Alert Snapshot Tests renders Success correctly 1`] = `
       class="ant-alert-close-icon"
       tabindex="0"
       type="button"
+    />
+    <button
+      class="ant-btn css-dev-only-do-not-override-5wsri9 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only button buttonMdIconOnly buttonGhost"
+      type="button"
     >
-      <svg
-        color="currentColor"
-        fill="currentColor"
-        height="16"
-        role="img"
-        stroke="currentColor"
-        stroke-width="0"
-        style="color: currentColor;"
-        viewBox="0 0 256 256"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
+      <span
+        class="ant-btn-icon"
       >
-        <path
-          d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
-        />
-      </svg>
+        <svg
+          color="currentColor"
+          fill="currentColor"
+          height="16"
+          role="img"
+          stroke="currentColor"
+          stroke-width="0"
+          style="color: currentColor;"
+          viewBox="0 0 256 256"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
+          />
+        </svg>
+      </span>
     </button>
   </div>
 </DocumentFragment>
@@ -459,12 +507,20 @@ exports[`Alert Snapshot Tests renders SuccessCompressed correctly 1`] = `
         >
           <svg
             color="currentColor"
-            data-file-name="SvgCheckCircle"
+            fill="currentColor"
             height="16"
             role="img"
-            size="16"
+            stroke="currentColor"
+            stroke-width="0"
+            style="color: currentColor;"
+            viewBox="0 0 256 256"
             width="16"
-          />
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm45.66,85.66-56,56a8,8,0,0,1-11.32,0l-24-24a8,8,0,0,1,11.32-11.32L112,148.69l50.34-50.35a8,8,0,0,1,11.32,11.32Z"
+            />
+          </svg>
           <span
             class="title"
           >
@@ -508,7 +564,7 @@ exports[`Alert Snapshot Tests renders Warning correctly 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M236.8,188.09,149.35,36.22h0a24.76,24.76,0,0,0-42.7,0L19.2,188.09a23.51,23.51,0,0,0,0,23.72A24.35,24.35,0,0,0,40.55,224h174.9a24.35,24.35,0,0,0,21.33-12.19A23.51,23.51,0,0,0,236.8,188.09ZM120,104a8,8,0,0,1,16,0v40a8,8,0,0,1-16,0Zm8,88a12,12,0,1,1,12-12A12,12,0,0,1,128,192Z"
+        d="M235.33,116.72,139.28,20.66a16,16,0,0,0-22.56,0l-96,96.06a16,16,0,0,0,0,22.56l96.05,96.06h0a16,16,0,0,0,22.56,0l96.05-96.06a16,16,0,0,0,0-22.56ZM120,80a8,8,0,0,1,16,0v56a8,8,0,0,1-16,0Zm8,104a12,12,0,1,1,12-12A12,12,0,0,1,128,184Z"
       />
     </svg>
     <div
@@ -539,23 +595,31 @@ exports[`Alert Snapshot Tests renders Warning correctly 1`] = `
       class="ant-alert-close-icon"
       tabindex="0"
       type="button"
+    />
+    <button
+      class="ant-btn css-dev-only-do-not-override-5wsri9 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only button buttonMdIconOnly buttonGhost"
+      type="button"
     >
-      <svg
-        color="currentColor"
-        fill="currentColor"
-        height="16"
-        role="img"
-        stroke="currentColor"
-        stroke-width="0"
-        style="color: currentColor;"
-        viewBox="0 0 256 256"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
+      <span
+        class="ant-btn-icon"
       >
-        <path
-          d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
-        />
-      </svg>
+        <svg
+          color="currentColor"
+          fill="currentColor"
+          height="16"
+          role="img"
+          stroke="currentColor"
+          stroke-width="0"
+          style="color: currentColor;"
+          viewBox="0 0 256 256"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
+          />
+        </svg>
+      </span>
     </button>
   </div>
 </DocumentFragment>
@@ -579,12 +643,20 @@ exports[`Alert Snapshot Tests renders WarningCompressed correctly 1`] = `
         >
           <svg
             color="currentColor"
-            data-file-name="SvgExclamationCircle"
+            fill="currentColor"
             height="16"
             role="img"
-            size="16"
+            stroke="currentColor"
+            stroke-width="0"
+            style="color: currentColor;"
+            viewBox="0 0 256 256"
             width="16"
-          />
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M235.33,116.72,139.28,20.66a16,16,0,0,0-22.56,0l-96,96.06a16,16,0,0,0,0,22.56l96.05,96.06h0a16,16,0,0,0,22.56,0l96.05-96.06a16,16,0,0,0,0-22.56ZM120,80a8,8,0,0,1,16,0v56a8,8,0,0,1-16,0Zm8,104a12,12,0,1,1,12-12A12,12,0,0,1,128,184Z"
+            />
+          </svg>
           <span
             class="title"
           >
@@ -673,23 +745,31 @@ exports[`Alert Snapshot Tests renders WithAction correctly 1`] = `
       class="ant-alert-close-icon"
       tabindex="0"
       type="button"
+    />
+    <button
+      class="ant-btn css-dev-only-do-not-override-5wsri9 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only button buttonMdIconOnly buttonGhost"
+      type="button"
     >
-      <svg
-        color="currentColor"
-        fill="currentColor"
-        height="16"
-        role="img"
-        stroke="currentColor"
-        stroke-width="0"
-        style="color: currentColor;"
-        viewBox="0 0 256 256"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
+      <span
+        class="ant-btn-icon"
       >
-        <path
-          d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
-        />
-      </svg>
+        <svg
+          color="currentColor"
+          fill="currentColor"
+          height="16"
+          role="img"
+          stroke="currentColor"
+          stroke-width="0"
+          style="color: currentColor;"
+          viewBox="0 0 256 256"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
+          />
+        </svg>
+      </span>
     </button>
   </div>
 </DocumentFragment>
@@ -808,23 +888,31 @@ exports[`Alert Snapshot Tests renders WithCustomIcon correctly 1`] = `
       class="ant-alert-close-icon"
       tabindex="0"
       type="button"
+    />
+    <button
+      class="ant-btn css-dev-only-do-not-override-5wsri9 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only button buttonMdIconOnly buttonGhost"
+      type="button"
     >
-      <svg
-        color="currentColor"
-        fill="currentColor"
-        height="16"
-        role="img"
-        stroke="currentColor"
-        stroke-width="0"
-        style="color: currentColor;"
-        viewBox="0 0 256 256"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
+      <span
+        class="ant-btn-icon"
       >
-        <path
-          d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
-        />
-      </svg>
+        <svg
+          color="currentColor"
+          fill="currentColor"
+          height="16"
+          role="img"
+          stroke="currentColor"
+          stroke-width="0"
+          style="color: currentColor;"
+          viewBox="0 0 256 256"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
+          />
+        </svg>
+      </span>
     </button>
   </div>
 </DocumentFragment>

--- a/src/components/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/components/Alert/__snapshots__/Alert.test.tsx.snap
@@ -51,31 +51,23 @@ exports[`Alert Snapshot Tests renders Error correctly 1`] = `
       class="ant-alert-close-icon"
       tabindex="0"
       type="button"
-    />
-    <button
-      class="ant-btn css-dev-only-do-not-override-5wsri9 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only button buttonMdIconOnly buttonGhost"
-      type="button"
     >
-      <span
-        class="ant-btn-icon"
+      <svg
+        color="currentColor"
+        fill="currentColor"
+        height="16"
+        role="img"
+        stroke="currentColor"
+        stroke-width="0"
+        style="color: currentColor;"
+        viewBox="0 0 256 256"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <svg
-          color="currentColor"
-          fill="currentColor"
-          height="16"
-          role="img"
-          stroke="currentColor"
-          stroke-width="0"
-          style="color: currentColor;"
-          viewBox="0 0 256 256"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
+        />
+      </svg>
     </button>
   </div>
 </DocumentFragment>
@@ -187,31 +179,23 @@ exports[`Alert Snapshot Tests renders Info correctly 1`] = `
       class="ant-alert-close-icon"
       tabindex="0"
       type="button"
-    />
-    <button
-      class="ant-btn css-dev-only-do-not-override-5wsri9 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only button buttonMdIconOnly buttonGhost"
-      type="button"
     >
-      <span
-        class="ant-btn-icon"
+      <svg
+        color="currentColor"
+        fill="currentColor"
+        height="16"
+        role="img"
+        stroke="currentColor"
+        stroke-width="0"
+        style="color: currentColor;"
+        viewBox="0 0 256 256"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <svg
-          color="currentColor"
-          fill="currentColor"
-          height="16"
-          role="img"
-          stroke="currentColor"
-          stroke-width="0"
-          style="color: currentColor;"
-          viewBox="0 0 256 256"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
+        />
+      </svg>
     </button>
   </div>
 </DocumentFragment>
@@ -323,31 +307,23 @@ exports[`Alert Snapshot Tests renders Special correctly 1`] = `
       class="ant-alert-close-icon"
       tabindex="0"
       type="button"
-    />
-    <button
-      class="ant-btn css-dev-only-do-not-override-5wsri9 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only button buttonMdIconOnly buttonGhost"
-      type="button"
     >
-      <span
-        class="ant-btn-icon"
+      <svg
+        color="currentColor"
+        fill="currentColor"
+        height="16"
+        role="img"
+        stroke="currentColor"
+        stroke-width="0"
+        style="color: currentColor;"
+        viewBox="0 0 256 256"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <svg
-          color="currentColor"
-          fill="currentColor"
-          height="16"
-          role="img"
-          stroke="currentColor"
-          stroke-width="0"
-          style="color: currentColor;"
-          viewBox="0 0 256 256"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
+        />
+      </svg>
     </button>
   </div>
 </DocumentFragment>
@@ -459,31 +435,23 @@ exports[`Alert Snapshot Tests renders Success correctly 1`] = `
       class="ant-alert-close-icon"
       tabindex="0"
       type="button"
-    />
-    <button
-      class="ant-btn css-dev-only-do-not-override-5wsri9 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only button buttonMdIconOnly buttonGhost"
-      type="button"
     >
-      <span
-        class="ant-btn-icon"
+      <svg
+        color="currentColor"
+        fill="currentColor"
+        height="16"
+        role="img"
+        stroke="currentColor"
+        stroke-width="0"
+        style="color: currentColor;"
+        viewBox="0 0 256 256"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <svg
-          color="currentColor"
-          fill="currentColor"
-          height="16"
-          role="img"
-          stroke="currentColor"
-          stroke-width="0"
-          style="color: currentColor;"
-          viewBox="0 0 256 256"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
+        />
+      </svg>
     </button>
   </div>
 </DocumentFragment>
@@ -595,31 +563,23 @@ exports[`Alert Snapshot Tests renders Warning correctly 1`] = `
       class="ant-alert-close-icon"
       tabindex="0"
       type="button"
-    />
-    <button
-      class="ant-btn css-dev-only-do-not-override-5wsri9 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only button buttonMdIconOnly buttonGhost"
-      type="button"
     >
-      <span
-        class="ant-btn-icon"
+      <svg
+        color="currentColor"
+        fill="currentColor"
+        height="16"
+        role="img"
+        stroke="currentColor"
+        stroke-width="0"
+        style="color: currentColor;"
+        viewBox="0 0 256 256"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <svg
-          color="currentColor"
-          fill="currentColor"
-          height="16"
-          role="img"
-          stroke="currentColor"
-          stroke-width="0"
-          style="color: currentColor;"
-          viewBox="0 0 256 256"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
+        />
+      </svg>
     </button>
   </div>
 </DocumentFragment>
@@ -745,31 +705,23 @@ exports[`Alert Snapshot Tests renders WithAction correctly 1`] = `
       class="ant-alert-close-icon"
       tabindex="0"
       type="button"
-    />
-    <button
-      class="ant-btn css-dev-only-do-not-override-5wsri9 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only button buttonMdIconOnly buttonGhost"
-      type="button"
     >
-      <span
-        class="ant-btn-icon"
+      <svg
+        color="currentColor"
+        fill="currentColor"
+        height="16"
+        role="img"
+        stroke="currentColor"
+        stroke-width="0"
+        style="color: currentColor;"
+        viewBox="0 0 256 256"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <svg
-          color="currentColor"
-          fill="currentColor"
-          height="16"
-          role="img"
-          stroke="currentColor"
-          stroke-width="0"
-          style="color: currentColor;"
-          viewBox="0 0 256 256"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
+        />
+      </svg>
     </button>
   </div>
 </DocumentFragment>
@@ -888,31 +840,23 @@ exports[`Alert Snapshot Tests renders WithCustomIcon correctly 1`] = `
       class="ant-alert-close-icon"
       tabindex="0"
       type="button"
-    />
-    <button
-      class="ant-btn css-dev-only-do-not-override-5wsri9 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only button buttonMdIconOnly buttonGhost"
-      type="button"
     >
-      <span
-        class="ant-btn-icon"
+      <svg
+        color="currentColor"
+        fill="currentColor"
+        height="16"
+        role="img"
+        stroke="currentColor"
+        stroke-width="0"
+        style="color: currentColor;"
+        viewBox="0 0 256 256"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <svg
-          color="currentColor"
-          fill="currentColor"
-          height="16"
-          role="img"
-          stroke="currentColor"
-          stroke-width="0"
-          style="color: currentColor;"
-          viewBox="0 0 256 256"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
+        />
+      </svg>
     </button>
   </div>
 </DocumentFragment>


### PR DESCRIPTION
### Fixed wrong Alert icons
<img width="813" alt="Screenshot 2024-11-28 alle 10 24 00" src="https://github.com/user-attachments/assets/cbb3afdb-bb9e-4462-a5a5-a4239ee9b64f">

### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g. enhancement, new component, bug).

    > **NOTE**  
    > Some labels are used to generate release note entries: you can find the complete mapping between PR labels and release note categories [here](https://github.com/mia-platform/design-system/blob/main/.github/release.yml).  
    For a more detailed overview of PR labels, please refer to the [dedicated CONTRIBUTING section](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md#pull-request-labels).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [x] Changes are covered by tests 
- [x] Changes to components are accessible and documented in the Storybook
- [x] Typings have been updated
- [x] New components are exported from the `src/index.ts` file
- [x] New files include the Apache 2.0 License disclaimer
- [x] The browser console does not contain errors
