### PR TITLE
fix(Feedback): fixed icon size

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives",
     "lint:fix": "yarn lint --fix",
     "checkonly": "find ./src -name '*.test.tsx' | xargs grep '\\.only'; test $? -eq 123",
-    "unit": "jest --watchAll",
+    "unit": "jest --watch",
     "coverage": "yarn unit --coverage --watchAll=false --reporters=default",
     "test": "yarn lint && yarn checkonly && yarn coverage",
     "storybook": "storybook dev -p 6006",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives",
     "lint:fix": "yarn lint --fix",
     "checkonly": "find ./src -name '*.test.tsx' | xargs grep '\\.only'; test $? -eq 123",
-    "unit": "jest --watch",
+    "unit": "jest --watchAll",
     "coverage": "yarn unit --coverage --watchAll=false --reporters=default",
     "test": "yarn lint && yarn checkonly && yarn coverage",
     "storybook": "storybook dev -p 6006",

--- a/src/components/Feedback/Feedback.module.css
+++ b/src/components/Feedback/Feedback.module.css
@@ -51,6 +51,11 @@
       }
     }
 
+    & .icon {
+      width: 64px;
+      height: 64px;
+    }
+
     & .spinner {
       display: flex;
       align-items: center;

--- a/src/components/Feedback/Feedback.tsx
+++ b/src/components/Feedback/Feedback.tsx
@@ -134,7 +134,7 @@ export const Feedback = ({
     }
 
     return (
-      <div data-testid="custom-icon">
+      <div className={styles.icon} data-testid="custom-icon">
         <Icon color={getColor(type, palette)} component={customIcon || getIcon(type)} size={64} />
       </div>
     )

--- a/src/components/Feedback/__snapshots__/Feedback.test.tsx.snap
+++ b/src/components/Feedback/__snapshots__/Feedback.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`Feedback Component renders a feedback with a badge 1`] = `
       class="content"
     >
       <div
+        class="icon"
         data-testid="custom-icon"
       >
         <svg
@@ -117,6 +118,7 @@ exports[`Feedback Component renders a feedback with a custom icon 1`] = `
       class="content"
     >
       <div
+        class="icon"
         data-testid="custom-icon"
       >
         <svg
@@ -164,6 +166,7 @@ exports[`Feedback Component renders a feedback with a description 1`] = `
       class="content"
     >
       <div
+        class="icon"
         data-testid="custom-icon"
       >
         <svg
@@ -281,6 +284,7 @@ exports[`Feedback Component renders a feedback with an alert 1`] = `
       class="content"
     >
       <div
+        class="icon"
         data-testid="custom-icon"
       >
         <svg
@@ -384,6 +388,7 @@ exports[`Feedback Component renders a feedback with children 1`] = `
       class="content"
     >
       <div
+        class="icon"
         data-testid="custom-icon"
       >
         <svg
@@ -473,6 +478,7 @@ exports[`Feedback Component renders a feedback with icon and title 1`] = `
       class="content"
     >
       <div
+        class="icon"
         data-testid="custom-icon"
       >
         <svg


### PR DESCRIPTION
### Description

This PR has the goal of setting the `Feedback` icon to a fixed dimension of 64x64px.

##### Feedback
    - updated icon size

### [IMPORTANT] PR Checklist

- [X] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [X] PR title follows the `<type>(<scope>): <subject>` structure
- [X] The PR has been labeled according to the type of changes (e.g. enhancement, new component, bug).

    > **NOTE**  
    > Some labels are used to generate release note entries: you can find the complete mapping between PR labels and release note categories [here](https://github.com/mia-platform/design-system/blob/main/.github/release.yml).  
    For a more detailed overview of PR labels, please refer to the [dedicated CONTRIBUTING section](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md#pull-request-labels).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [ ] Changes are covered by tests 
- [X] Changes to components are accessible and documented in the Storybook
- [ ] Typings have been updated
- [ ] New components are exported from the `src/index.ts` file
- [ ] New files include the Apache 2.0 License disclaimer
- [X] The browser console does not contain errors
