### PR TITLE
feat(Feedback): replaced custom badge with Badge component

### DIFF
--- a/src/components/Feedback/Feedback.module.css
+++ b/src/components/Feedback/Feedback.module.css
@@ -69,39 +69,6 @@
       }
     }
 
-    & .badge {
-      display: flex;
-      gap: var(--spacing-gap-lg, 16px);
-      align-items: center;
-      width: 100%;
-      max-width: inherit;
-      padding: var(--spacing-padding-lg, 16px);
-      background: var(--Grey-200, #F2F2F2);
-      border-radius: var(--shape-border-radius-lg, 8px);
-
-      & .badgeIcon {
-        flex-shrink: 0;
-      }
-
-      & .badgeTitleWrapper {
-        display: flex;
-        flex-direction: column;
-        gap: var(--spacing-gap-xs, 4px);
-        max-width: calc(100% - 48px - var(--spacing-gap-lg, 16px));
-
-        & .badgeTitle {
-          display: flex;
-          align-items: center;
-          gap: var(--spacing-gap-xs, 4px);
-          max-width: 100%;
-        }
-
-        & .badgeSubtitle {
-          max-width: 100%;
-        }
-      }
-    }
-
     & .alert {
       width: 100%;
       max-width: inherit;

--- a/src/components/Feedback/Feedback.props.ts
+++ b/src/components/Feedback/Feedback.props.ts
@@ -33,12 +33,7 @@ export type FeedbackProps = {
 
   /**
    * Props to customize the appearance and content of an optional badge displayed within the feedback.
-   *
-   * `object`:
-   *  - extra: Additional content to be displayed alongside the badge title (e.g., a tag or an icon). <br> `ReactNode`
-   *  - icon: The icon component to render within the badge. <br> `IconComponent`
-   *  - subtitle: Optional subtitle text to display below the badge title. <br> `string`
-   *  - title: The main title text to display within the badge. <br> `string`
+   * Includes optional title, description, icon, and extra content.
    */
   badge?: BadgeProps;
 

--- a/src/components/Feedback/Feedback.props.ts
+++ b/src/components/Feedback/Feedback.props.ts
@@ -19,31 +19,9 @@
 import { ReactNode } from 'react'
 
 import { AlertProps } from '../Alert/props'
+import { BadgeProps } from '../Badge/Badge.props'
 import { IconComponent } from '../Icon/Icon.props'
 import { Type } from './Feedback.types'
-
-type FeedbackBadgeProps = {
-
-  /**
-   * Additional content to be displayed alongside the badge title (e.g., a tag or an icon).
-   */
-  extra?: ReactNode;
-
-  /**
-   * The icon component to render within the badge.
-   */
-  icon: IconComponent;
-
-  /**
-   * Optional subtitle text to display below the badge title.
-   */
-  subtitle?: string;
-
-  /**
-   * The main title text to display within the badge.
-   */
-  title: string;
-};
 
 export type FeedbackProps = {
 
@@ -62,7 +40,7 @@ export type FeedbackProps = {
    *  - subtitle: Optional subtitle text to display below the badge title. <br> `string`
    *  - title: The main title text to display within the badge. <br> `string`
    */
-  badge?: FeedbackBadgeProps;
+  badge?: BadgeProps;
 
   /**
    * Child elements to render within the feedback component.

--- a/src/components/Feedback/Feedback.stories.tsx
+++ b/src/components/Feedback/Feedback.stories.tsx
@@ -100,10 +100,10 @@ export const Badge: Story = {
   args: {
     ...defaults,
     badge: {
+      description: loremIpsum,
       extra: <Tag>Tag</Tag>,
       icon: PiAddressBook,
       title: 'Badge title',
-      subtitle: loremIpsum,
     },
     type: Feedback.Type.Delete,
   },

--- a/src/components/Feedback/Feedback.test.tsx
+++ b/src/components/Feedback/Feedback.test.tsx
@@ -63,9 +63,9 @@ describe('Feedback Component', () => {
     const { asFragment } = render(
       <Feedback
         badge={{
+          description: 'Badge subtitle',
           extra: <Tag>Tag</Tag>,
           icon: PiAddressBook,
-          subtitle: 'Badge subtitle',
           title: 'Badge title',
         }}
         title="Title"

--- a/src/components/Feedback/Feedback.tsx
+++ b/src/components/Feedback/Feedback.tsx
@@ -24,7 +24,7 @@ import {
   PiWarningDiamondFill,
   PiXSquareFill,
 } from 'react-icons/pi'
-import { ReactElement, ReactNode, useMemo } from 'react'
+import { ReactElement, ReactNode } from 'react'
 import { Spin, TooltipProps } from 'antd'
 import { LoadingOutlined } from '@ant-design/icons'
 
@@ -125,23 +125,19 @@ export const Feedback = ({
 }: FeedbackProps): ReactElement => {
   const { palette } = useTheme()
 
-  const icon: ReactNode = useMemo(() => {
-    if (type === Type.Loading) {
-      return (
-        <div className={styles.spinner}>
-          <Spin indicator={<LoadingOutlined className={styles.loading} />} size="large" />
-        </div>
-      )
-    }
-
-    return (
+  const icon: ReactNode = (type === Type.Loading)
+    ? (
+      <div className={styles.spinner}>
+        <Spin indicator={<LoadingOutlined className={styles.loading} />} size="large" />
+      </div>
+    )
+    : (
       <div className={styles.icon} data-testid="custom-icon">
         <Icon color={getColor(type, palette)} component={customIcon || getIcon(type)} size={64} />
       </div>
     )
-  }, [customIcon, palette, type])
 
-  const title = useMemo(() => (
+  const title = (
     <div className={styles.titleWrapper}>
       <div className={styles.title}>
         <Typography.H2
@@ -159,35 +155,25 @@ export const Feedback = ({
         </div>
       )}
     </div>
-  ), [description, palette, customTitle, type])
+  )
 
-  const badge = useMemo(() => {
-    if (!customBadge) { return }
+  const badge = customBadge ? <Badge {...customBadge} /> : null
 
-    return (
-      <Badge {...customBadge} />
-    )
-  }, [customBadge])
-
-  const alert = useMemo(() => {
-    if (!customAlert) { return }
-
-    return (
+  const alert = customAlert
+    ? (
       <div className={styles.alert}>
         <Alert {...customAlert} isCompressed />
       </div>
     )
-  }, [customAlert])
+    : null
 
-  const children = useMemo(() => {
-    if (!customChildren) { return }
-
-    return (
+  const children = customChildren
+    ? (
       <div className={styles.children}>
         {customChildren}
       </div>
     )
-  }, [customChildren])
+    : null
 
   return (
     <div className={styles.feedback}>

--- a/src/components/Feedback/Feedback.tsx
+++ b/src/components/Feedback/Feedback.tsx
@@ -29,6 +29,7 @@ import { Spin, TooltipProps } from 'antd'
 import { LoadingOutlined } from '@ant-design/icons'
 
 import { Alert } from '../Alert'
+import { Badge } from '../Badge'
 import { FeedbackProps } from './Feedback.props'
 import { Icon } from '../Icon'
 import { IconComponent } from '../Icon/Icon.props'
@@ -164,28 +165,9 @@ export const Feedback = ({
     if (!customBadge) { return }
 
     return (
-      <div className={styles.badge}>
-        <div className={styles.badgeIcon} data-testid="badge-icon">
-          <Icon color={palette.text.neutral.subtle} component={customBadge.icon} size={48} />
-        </div>
-        <div className={styles.badgeTitleWrapper}>
-          <div className={styles.badgeTitle}>
-            <Typography.H3 ellipsis={{ rows: 2, tooltip: { ...tooltipProps, title: customBadge.title } }}>
-              {customBadge.title}
-            </Typography.H3>
-            {customBadge.extra}
-          </div>
-          {customBadge.subtitle && (
-            <div className={styles.badgeSubtitle}>
-              <Typography.BodyS ellipsis={{ rows: 1, tooltip: { ...tooltipProps, title: customBadge.subtitle } }}>
-                {customBadge.subtitle}
-              </Typography.BodyS>
-            </div>
-          )}
-        </div>
-      </div>
+      <Badge {...customBadge} />
     )
-  }, [customBadge, palette.text.neutral.subtle])
+  }, [customBadge])
 
   const alert = useMemo(() => {
     if (!customAlert) { return }

--- a/src/components/Feedback/__snapshots__/Feedback.test.tsx.snap
+++ b/src/components/Feedback/__snapshots__/Feedback.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`Feedback Component renders a feedback with a badge 1`] = `
         class="badge"
       >
         <div
-          class="badgeIcon"
+          class="icon"
           data-testid="badge-icon"
         >
           <svg
@@ -74,34 +74,34 @@ exports[`Feedback Component renders a feedback with a badge 1`] = `
           </svg>
         </div>
         <div
-          class="badgeTitleWrapper"
+          class="content"
         >
           <div
-            class="badgeTitle"
+            class="title"
           >
             <h3
               aria-label="Badge title"
-              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-multiple-line h3"
+              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line h3"
               role="h3"
             >
               Badge title
             </h3>
-            <span
-              class="mia-platform-tag tag"
-            >
-              Tag
-            </span>
           </div>
           <div
-            class="badgeSubtitle"
+            class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyS"
+            role="paragraph"
           >
-            <div
-              class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line bodyS"
-              role="paragraph"
-            >
-              Badge subtitle
-            </div>
+            Badge subtitle
           </div>
+        </div>
+        <div
+          class="extra"
+        >
+          <span
+            class="mia-platform-tag tag"
+          >
+            Tag
+          </span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Description

This PR has the goal of using the newly created `Badge` component instead of a custom badge inside the `Feedback` component. Props, style, stories and tests have been updated accordingly.

IMPORTANT: these changes replace the `subtitle` prop of the custom badge with the `description` prop of the `Badge` component.

##### Feedback
    - updated props to include `BadgeProps`
    - removed custom badge and replaced with `Badge` component
    - removed useless style

### [IMPORTANT] PR Checklist

- [X] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [X] PR title follows the `<type>(<scope>): <subject>` structure
- [X] The PR has been labeled according to the type of changes (e.g. enhancement, new component, bug).

    > **NOTE**  
    > Some labels are used to generate release note entries: you can find the complete mapping between PR labels and release note categories [here](https://github.com/mia-platform/design-system/blob/main/.github/release.yml).  
    For a more detailed overview of PR labels, please refer to the [dedicated CONTRIBUTING section](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md#pull-request-labels).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [X] Changes are covered by tests 
- [X] Changes to components are accessible and documented in the Storybook
- [X] Typings have been updated
- [ ] New components are exported from the `src/index.ts` file
- [ ] New files include the Apache 2.0 License disclaimer
- [X] The browser console does not contain errors
