### PR TITLE
fix(Card): fixed overflow on header

### DIFF
--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -46,7 +46,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--spacing-gap-sm, 8px);
-  overflow-x: hidden;
+  overflow: hidden;
 
  :global(*) {
     margin: 0 !important;


### PR DESCRIPTION
### Description

This PR has the goal of fixing a bug in the Card component header, where a scrollbar was wrongly displayed in case of overflowing text or when a subtitle was added.  

Before:

![Screenshot from 2024-12-17 17-16-56](https://github.com/user-attachments/assets/76c35844-4813-45c7-b6d2-b0d5219e4911)

After:

![Screenshot from 2024-12-17 17-16-20](https://github.com/user-attachments/assets/409d9ac3-46fd-41fe-8f65-01aed24d5ecd)

##### Card
    - updated style

### [IMPORTANT] PR Checklist

- [X] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [X] PR title follows the `<type>(<scope>): <subject>` structure
- [X] The PR has been labeled according to the type of changes (e.g. enhancement, new component, bug).

    > **NOTE**  
    > Some labels are used to generate release note entries: you can find the complete mapping between PR labels and release note categories [here](https://github.com/mia-platform/design-system/blob/main/.github/release.yml).  
    For a more detailed overview of PR labels, please refer to the [dedicated CONTRIBUTING section](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md#pull-request-labels).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [ ] Changes are covered by tests 
- [X] Changes to components are accessible and documented in the Storybook
- [ ] Typings have been updated
- [ ] New components are exported from the `src/index.ts` file
- [ ] New files include the Apache 2.0 License disclaimer
- [X] The browser console does not contain errors
