### PR TITLE
fit parent height table

### DIFF
--- a/src/components/Table/Table.module.css
+++ b/src/components/Table/Table.module.css
@@ -17,6 +17,8 @@
  */
 
 .table {
+
+  --table-header-height: 40px;
   --table-border: 1px solid;
   --table-border-color: var(--palette-common-grey-100, #f2f2f2);
   --column-padding: var(--spacing-padding-sm, 8px);
@@ -78,6 +80,26 @@
         background: var(--palette-success-200, #C8F2BF);
       }
     }
+  }
+}
+
+.fitParentHeight {
+  height: 100%;
+  :global(.mia-platform-spin-nested-loading),
+  :global(.mia-platform-table),
+  :global(.mia-platform-spin-container),
+  :global(.mia-platform-table-container) {
+    height: 100% !important;
+  }
+
+  :global(.mia-platform-table-container) {
+    border: none;
+  }
+  :global(.mia-platform-table-body) {
+    height: calc(100% - var(--table-header-height))!important;
+    border: 1px solid var(--table-border-color);
+    border-bottom-left-radius: var(--shape-border-radius-md, 4px);
+    border-bottom-right-radius: var(--shape-border-radius-md, 4px);
   }
 }
 

--- a/src/components/Table/Table.props.ts
+++ b/src/components/Table/Table.props.ts
@@ -293,7 +293,7 @@ export type TableProps<RecordType extends GenericRecord> = {
    * Makes the table fitting the height of his parent. Useful in combination with scroll={{x: true, y: '100%'}} to implement
    * full screen scrollable tables.
    **/
-  fitParentHeight?: boolean
+  hasParentHeight?: boolean
 
   /**
    * Configuration for row state in table.

--- a/src/components/Table/Table.props.ts
+++ b/src/components/Table/Table.props.ts
@@ -290,6 +290,12 @@ export type TableProps<RecordType extends GenericRecord> = {
   scroll?: Scroll,
 
   /**
+   * Makes the table fitting the height of his parent. Useful in combination with scroll={{x: true, y: '100%'}} to implement
+   * full screen scrollable tables.
+   **/
+  fitParentHeight?: boolean
+
+  /**
    * Configuration for row state in table.
    *
    * @param record - The data record for the row.

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -17,6 +17,7 @@
  */
 
 import type { Meta, StoryObj } from '@storybook/react'
+import { ReactElement } from 'react'
 import { action } from '@storybook/addon-actions'
 
 import { Action, RowState as RowStateEnum } from './Table.types'
@@ -44,7 +45,6 @@ import {
 } from './Table.mocks'
 import { Table } from '.'
 import { defaults } from './Table'
-import {ReactElement} from "react";
 
 const meta = {
   component: Table<TableRecord>,

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -169,7 +169,7 @@ export const RowState: Story = {
   },
 }
 
-export const Empty = () : ReactElement => {
+export const FitParentHeight = () : ReactElement => {
   return (
     <div style={{ height: 'calc(100vh - 2em)' }}>
       <Table

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -44,6 +44,7 @@ import {
 } from './Table.mocks'
 import { Table } from '.'
 import { defaults } from './Table'
+import {ReactElement} from "react";
 
 const meta = {
   component: Table<TableRecord>,
@@ -166,4 +167,18 @@ export const RowState: Story = {
     data: dataState,
     rowState: (record: TableRecordState) => (record.state?.toLowerCase() as RowStateEnum),
   },
+}
+
+export const Empty = () : ReactElement => {
+  return (
+    <div style={{ height: 'calc(100vh - 2em)' }}>
+      <Table
+        {...meta.args}
+        data={[...Array(30).keys()].reduce((acc) => [...acc, ...data], data)}
+        fitParentHeight={true}
+        pagination={false}
+        scroll={{ x: true, y: '100%' }}
+      />
+    </div>
+  )
 }

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -175,7 +175,7 @@ export const FitParentHeight = () : ReactElement => {
       <Table
         {...meta.args}
         data={[...Array(30).keys()].reduce((acc) => [...acc, ...data], data)}
-        fitParentHeight={true}
+        hasParentHeight={true}
         pagination={false}
         scroll={{ x: true, y: '100%' }}
       />

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -440,4 +440,9 @@ describe('Table Component', () => {
 
     await waitFor(() => expect(asFragment()).toMatchSnapshot())
   })
+
+  test('renders fitParentHEight correctly', async() => {
+    const { asFragment } = render(<Table fitParentHeight={true} {...props} />)
+    await waitFor(() => expect(asFragment()).toMatchSnapshot())
+  })
 })

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -442,7 +442,7 @@ describe('Table Component', () => {
   })
 
   test('renders fitParentHEight correctly', async() => {
-    const { asFragment } = render(<Table fitParentHeight={true} {...props} />)
+    const { asFragment } = render(<Table hasParentHeight={true} {...props} />)
     await waitFor(() => expect(asFragment()).toMatchSnapshot())
   })
 })

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -88,13 +88,13 @@ export const Table = <RecordType extends GenericRecord>({
   size = defaults.size,
   scroll = defaults.scroll,
   rowState,
-  fitParentHeight: fitParentHeightProp,
+  hasParentHeight,
 }: TableProps<RecordType>): ReactElement => {
   const theme = useTheme()
   const className = useMemo(() => classnames([
     table,
-    fitParentHeightProp && fitParentHeight,
-  ]), [fitParentHeightProp])
+    hasParentHeight && fitParentHeight,
+  ]), [hasParentHeight])
 
   const iconSize = theme?.shape?.size?.md as IconProps['size'] || 16
 

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -19,6 +19,7 @@
 import { Table as AntTable, Skeleton } from 'antd'
 import { PiPencilSimpleLine, PiTrash } from 'react-icons/pi'
 import { ReactElement, useCallback, useMemo } from 'react'
+import classnames from 'classnames'
 
 import { Action, ColumnAlignment, ColumnFilterMode, GenericRecord, Layout, RowState, Size, SortOrder } from './Table.types'
 import { Icon } from '../Icon'
@@ -31,7 +32,7 @@ import { useTheme } from '../../hooks/useTheme'
 const { Auto } = Layout
 const { Middle } = Size
 const { Edit, Delete } = Action
-const { table } = styles
+const { table, fitParentHeight } = styles
 
 export const defaults = {
   actions: [],
@@ -87,8 +88,14 @@ export const Table = <RecordType extends GenericRecord>({
   size = defaults.size,
   scroll = defaults.scroll,
   rowState,
+  fitParentHeight: fitParentHeightProp,
 }: TableProps<RecordType>): ReactElement => {
   const theme = useTheme()
+  const className = useMemo(() => classnames([
+    table,
+    fitParentHeightProp && fitParentHeight,
+  ]), [fitParentHeightProp])
+
   const iconSize = theme?.shape?.size?.md as IconProps['size'] || 16
 
   const editAction = useMemo(() => actions?.find(({ dataIndex }) => dataIndex === Edit), [actions])
@@ -147,7 +154,7 @@ export const Table = <RecordType extends GenericRecord>({
     >
       <AntTable<RecordType>
         bordered={isBordered}
-        className={table}
+        className={className}
         columns={tableColumns}
         dataSource={data}
         expandable={expandable}

--- a/src/components/Table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/Table/__snapshots__/Table.test.tsx.snap
@@ -2762,6 +2762,227 @@ exports[`Table Component renders external filters and sorters correctly 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Table Component renders fitParentHEight correctly 1`] = `
+<DocumentFragment>
+  <div
+    class="mia-platform-table-wrapper table fitParentHeight"
+  >
+    <div
+      class="mia-platform-spin-nested-loading"
+    >
+      <div
+        class="mia-platform-spin-container"
+      >
+        <div
+          class="mia-platform-table mia-platform-table-middle mia-platform-table-scroll-horizontal"
+        >
+          <div
+            class="mia-platform-table-container"
+          >
+            <div
+              class="mia-platform-table-header mia-platform-table-sticky-holder"
+              style="overflow: hidden; top: 0px;"
+            >
+              <table
+                style="table-layout: fixed; visibility: hidden;"
+              >
+                <colgroup />
+                <thead
+                  class="mia-platform-table-thead"
+                >
+                  <tr>
+                    <th
+                      class="mia-platform-table-cell"
+                      scope="col"
+                    >
+                      Field 1
+                    </th>
+                    <th
+                      class="mia-platform-table-cell"
+                      scope="col"
+                    >
+                      Field 2
+                    </th>
+                    <th
+                      class="mia-platform-table-cell"
+                      scope="col"
+                    >
+                      Field 3
+                    </th>
+                    <th
+                      class="mia-platform-table-cell"
+                      scope="col"
+                    >
+                      Field 4
+                    </th>
+                  </tr>
+                </thead>
+              </table>
+            </div>
+            <div
+              class="mia-platform-table-body"
+              style="overflow-x: auto; overflow-y: hidden;"
+            >
+              <table
+                style="width: auto; min-width: 100%; table-layout: auto;"
+              >
+                <colgroup />
+                <tbody
+                  class="mia-platform-table-tbody"
+                >
+                  <tr
+                    aria-hidden="true"
+                    class="mia-platform-table-measure-row"
+                    style="height: 0px; font-size: 0px;"
+                  >
+                    <td
+                      style="padding: 0px; border: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden;"
+                      >
+                         
+                      </div>
+                    </td>
+                    <td
+                      style="padding: 0px; border: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden;"
+                      >
+                         
+                      </div>
+                    </td>
+                    <td
+                      style="padding: 0px; border: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden;"
+                      >
+                         
+                      </div>
+                    </td>
+                    <td
+                      style="padding: 0px; border: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden;"
+                      >
+                         
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="mia-platform-table-row mia-platform-table-row-level-0"
+                    data-row-key="Value 1"
+                  >
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 1
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 1
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 1
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 1
+                    </td>
+                  </tr>
+                  <tr
+                    class="mia-platform-table-row mia-platform-table-row-level-0"
+                    data-row-key="Value 2"
+                  >
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 2
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 2
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 2
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 2
+                    </td>
+                  </tr>
+                  <tr
+                    class="mia-platform-table-row mia-platform-table-row-level-0"
+                    data-row-key="Value 3"
+                  >
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 3
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 3
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 3
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 3
+                    </td>
+                  </tr>
+                  <tr
+                    class="mia-platform-table-row mia-platform-table-row-level-0"
+                    data-row-key="Value 4"
+                  >
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 4
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 4
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 4
+                    </td>
+                    <td
+                      class="mia-platform-table-cell"
+                    >
+                      Value 4
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Table Component renders footer correctly 1`] = `
 <DocumentFragment>
   <div


### PR DESCRIPTION
### Feat(Table): Added hasParentHeight prop

![Screenshot 2025-01-09 alle 17 01 46](https://github.com/user-attachments/assets/271870ef-84ed-44ec-a1c6-3c445433cc20)

Added the prop `hasParentHeight` to `Table`: the prop adds the css property to `height:100%`on the table and its wrappers.
The property is useful in combination with the prop `scroll={{x: true, y: '100%'}}` to create unpaginated scrollable tables, without having to specify directly the height of the table as the y value of the object passed in the scroll prop. 

##### Table
    - Added hasParentHeight prop


### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g. enhancement, new component, bug).

    > **NOTE**  
    > Some labels are used to generate release note entries: you can find the complete mapping between PR labels and release note categories [here](https://github.com/mia-platform/design-system/blob/main/.github/release.yml).  
    For a more detailed overview of PR labels, please refer to the [dedicated CONTRIBUTING section](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md#pull-request-labels).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [x] Changes are covered by tests 
- [x] Changes to components are accessible and documented in the Storybook
- [x] Typings have been updated
- [x] New components are exported from the `src/index.ts` file
- [x] New files include the Apache 2.0 License disclaimer
- [x] The browser console does not contain errors
