### PR TITLE
added: Table & Card css fix to inherit parent flex or grid height dinamicaly 

### DIFF
--- a/.storybook/decorators/theme.tsx
+++ b/.storybook/decorators/theme.tsx
@@ -32,6 +32,15 @@ const {lightTheme, darkTheme} = themes
  * @param context - The context object containing contextual information.
  * @returns The decorated Story component with the specified theme.
  */
+
+const styles = {
+  height: 'calc(100vh - 30px)', 
+  background: 'rgb(244, 249, 255)', 
+  padding: 16, 
+  overflow: 'auto', 
+  borderRadius: 'var(--shape-border-radius-lg, 8px)'
+}
+
 const withTheme: Decorator = (Story, {globals}) => {
   const { theme: themeKey } = globals
 
@@ -41,7 +50,9 @@ const withTheme: Decorator = (Story, {globals}) => {
   
   return (
     <ThemeProvider theme={theme}>
-      <Story/>
+      <div style={styles}>
+        <Story/>
+      </div>
     </ThemeProvider>
   )
 }

--- a/.storybook/reset.css
+++ b/.storybook/reset.css
@@ -38,3 +38,7 @@ body {
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
 }
+
+.sb-show-main.sb-show-main {
+  background-color: var(--palette-background-primary-200, #eaf3ff) !important;
+}

--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -23,11 +23,18 @@
   border-radius: var(--shape-border-radius-lg, 8px);
   border-width: var(--shape-border-width-xs, 1px);
   padding: var(--spacing-padding-sm, 8px) var(--spacing-padding-xl, 24px);
+
+  /* used when parent have a display flex or grid */
+  min-height: 0;
+  min-width: 0;
 }
 
 .content {
   padding: var(--spacing-padding-lg, 16px) 0;
   gap: var(--spacing-gap-xl, 24px);
+  
+  /* used to inherit from card class the relative height correctly */
+  min-height: 0;
 }
 
 .docLink {
@@ -57,4 +64,8 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-gap-sm, 8px);
+}
+
+.skeleton {
+  padding: 12px 0;
 }

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Meta, StoryObj } from '@storybook/react'
+import type { Meta, StoryFn, StoryObj } from '@storybook/react'
 
 import { actionButton, children, docLink, extra, subtitle, title } from './Card.mocks'
 import { hugeData, rowKey, scroll, scrollableColumns } from '../Table/Table.mocks'
@@ -78,17 +78,23 @@ export const ActionContent: Story = {
   },
 }
 
-export const TableContent: Story = {
-  args: {
-    children: (
-      <Table
-        columns={scrollableColumns}
-        data={hugeData}
-        rowKey={rowKey}
-        scroll={scroll}
-      />
-    ),
-  },
+export const TableContent: StoryFn = () => {
+  return (
+    <div style={{ maxHeight: '100%', display: 'grid', gridTemplateRows: '1fr' }}>
+      <Card
+        subtitle={'Try to resize the viewport height'}
+        title={'Use Table In A Card With Height Resizable'}
+      >
+        <Table
+          columns={scrollableColumns}
+          data={hugeData}
+          hasParentHeight
+          rowKey={rowKey}
+          scroll={scroll}
+        />
+      </Card>
+    </div>
+  )
 }
 
 export const Loading: Story = {

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -28,7 +28,7 @@ import { Icon } from '../Icon'
 import styles from './Card.module.css'
 import { useTheme } from '../../hooks/useTheme'
 
-const { card, content, header, heading } = styles
+const { card, content, header, heading, skeleton } = styles
 
 export const defaults = {
   isLoading: false,
@@ -66,6 +66,7 @@ export const Card = ({
         active
         loading={isLoading}
         paragraph={Card.skeletonParagraph}
+        rootClassName={skeleton}
       >
         {(title || subtitle) && <div className={header}>
           <div className={heading}>

--- a/src/components/Table/Table.mocks.tsx
+++ b/src/components/Table/Table.mocks.tsx
@@ -186,7 +186,7 @@ export const spannedColumns: ColumnType<TableRecord>[] = [
 
 export const scroll = {
   x: 1800,
-  y: 200,
+  y: '100%',
   scrollToFirstRowOnChange: true,
 }
 

--- a/src/components/Table/Table.module.css
+++ b/src/components/Table/Table.module.css
@@ -23,6 +23,9 @@
   --table-border-color: var(--palette-common-grey-100, #f2f2f2);
   --column-padding: var(--spacing-padding-sm, 8px);
 
+  /* used when parent have a display flex or grid to handle correctly the scroll */
+  min-height: 0;
+
   :global(.mia-platform-table-container) {
     border-left: var(--table-border);
     border-right: var(--table-border);
@@ -91,6 +94,7 @@
   :global(.mia-platform-table-container) {
     height: 100% !important;
   }
+
   :global(.mia-platform-table-container) {
     border: none;
     margin: 0 -1px;
@@ -102,12 +106,29 @@
   :global(.mia-platform-table) {
     background: none;
   }
+  /* Remove double border bottom */
+  :global(.mia-platform-table-tbody > tr:last-child > td) {
+    border-bottom: none;
+  }
   :global(.mia-platform-table-body) {
     overflow: auto!important;
     border: 1px solid  var(--table-border-color);
     border-bottom-left-radius: var(--shape-border-radius-md, 4px);
     border-bottom-right-radius: var(--shape-border-radius-md, 4px);
     background: white;
+
+    /* Atnd use a double bottom border. removing this border in "mia-platform-table-tbody >tr:last-child >td" rule 
+     * creates a scrolling problem even when scrolling is not necessary
+     */
+    --table-last-tr-border: -1px;
+    height: calc(100% - var(--table-last-tr-border) - var(--table-header-height));
+  }
+}
+
+.hasPagination {
+  --table-pagination-height: 55px;
+  :global(.mia-platform-table) {
+    height: calc(100% - var(--table-pagination-height)) !important;
   }
 }
 

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -44,6 +44,7 @@ import {
   sizedColumns,
   spannedColumns,
 } from './Table.mocks'
+import { Card } from '../Card'
 import { Table } from '.'
 import { defaults } from './Table'
 
@@ -204,10 +205,47 @@ export const FitParentHeightHalfEmpty: StoryFn = () => {
     <div style={{ height: 'calc(100vh - 2em - 40px)' }}>
       <Table
         {...meta.args}
-        hasParentHeight={true}
+        hasParentHeight
         pagination={false}
         scroll={{ x: true, y: '100%' }}
       />
+    </div>
+  )
+}
+
+export const UseTableInACardWithHeightResizable: StoryFn = () => {
+  return (
+    <div style={{ maxHeight: '100%', display: 'grid', gridTemplateRows: '1fr' }}>
+      <Card
+        subtitle={'Try to resize the viewport height'}
+        title={'Use Table In A Card With Height Resizable'}
+      >
+        <Table
+          {...meta.args}
+          hasParentHeight
+          pagination={false}
+          scroll={{ x: true, y: '100%' }}
+        />
+      </Card>
+    </div>
+  )
+}
+
+export const UseMultipleCardsWithTables: StoryFn = () => {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <Card title={'Use Table In multiple cards'}>
+        <Table
+          {...meta.args}
+          pagination={false}
+        />
+      </Card>
+      <Card title={'Use Table In multiple cards'}>
+        <Table
+          {...meta.args}
+          pagination={false}
+        />
+      </Card>
     </div>
   )
 }

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -32,7 +32,7 @@ import { useTheme } from '../../hooks/useTheme'
 const { Auto } = Layout
 const { Middle } = Size
 const { Edit, Delete } = Action
-const { table, fitParentHeight } = styles
+const { table, fitParentHeight, hasPagination } = styles
 
 export const defaults = {
   actions: [],
@@ -94,7 +94,8 @@ export const Table = <RecordType extends GenericRecord>({
   const className = useMemo(() => classnames([
     table,
     hasParentHeight && fitParentHeight,
-  ]), [hasParentHeight])
+    pagination && hasPagination,
+  ]), [hasParentHeight, pagination])
 
   const iconSize = theme?.shape?.size?.md as IconProps['size'] || 16
 
@@ -105,7 +106,7 @@ export const Table = <RecordType extends GenericRecord>({
   )), [actions])
 
   const tableColumns = useMemo(() => [
-    ...columns,
+    ...columns.map((column) => ({ ellipsis: true, ...column })),
     ...customActions?.map(getAction) || [],
     ...editAction?.onClick || onEditRow ? [getAction({
       dataIndex: Edit,
@@ -148,10 +149,7 @@ export const Table = <RecordType extends GenericRecord>({
   }, [rowState])
 
   return (
-    <Skeleton
-      active
-      loading={isLoading}
-    >
+    <Skeleton active loading={isLoading}>
       <AntTable<RecordType>
         bordered={isBordered}
         className={className}
@@ -169,7 +167,7 @@ export const Table = <RecordType extends GenericRecord>({
         showHeader
         showSorterTooltip={false}
         size={size}
-        sticky={true}
+        sticky={false}
         tableLayout={layout}
         virtual={false}
         onChange={onChange}


### PR DESCRIPTION
### Description

* Styles have been added to storybooks to simulate the Console design
* Changed Card skeleton padding
* BREAKING: Cards now have "min-width" and "min-height" to fit a flex or grid container should it be wrapped in a way that properly handles the behavior dynamically
* Should the header content of a cell be longer than the space calculated dynamically by Antd or greater than the width passed statically to the column, the ellipsis is now handled by default to true. This is necessary to calculate the height in the case of hasParentContent. If the header had multiple heights it would be impossible to know the possible height.
* BREAKING: The table's prop Sticky is passed statically to false because the console will not use any instances of this design case.

####

| Changes | Photo |
| --------- | ------ |
| Added example for auto size tables | ![Registrazione schermo 2025-01-14 alle 15 41 00](https://github.com/user-attachments/assets/36298984-788b-415b-9f4d-df97c2c9c37d) |
| Added example inside the table storybook | <img width="400" alt="Screenshot 2025-01-14 alle 16 34 37" src="https://github.com/user-attachments/assets/b3e6de86-7b57-4078-ad15-8c93e282b738" /> | 
| Bug fix when hasParentHeight is enabled with a pagination | <img width="400" alt="Screenshot 2025-01-14 alle 16 33 20" src="https://github.com/user-attachments/assets/38d079ac-e2f5-4b20-b54a-6ac295997ebe" /> |

### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g. enhancement, new component, bug).

    > **NOTE**  
    > Some labels are used to generate release note entries: you can find the complete mapping between PR labels and release note categories [here](https://github.com/mia-platform/design-system/blob/main/.github/release.yml).  
    For a more detailed overview of PR labels, please refer to the [dedicated CONTRIBUTING section](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md#pull-request-labels).

#### Additional code checks

Some of these checks may not apply based on your changes. Please make sure to check the relevant items in the list.

- [ ] Changes are covered by tests 
- [x] Changes to components are accessible and documented in the Storybook
- [ ] Typings have been updated
- [ ] New components are exported from the `src/index.ts` file
- [ ] New files include the Apache 2.0 License disclaimer
- [ ] The browser console does not contain errors
