### PR TITLE
feat(components): Add onBlur prop to Input and TextArea components

### DIFF
--- a/src/components/Input/Input.test.tsx
+++ b/src/components/Input/Input.test.tsx
@@ -164,6 +164,19 @@ describe('Input Component', () => {
     expect(input.value).toBe(exampleText)
   })
 
+  test('Should call event handler on Blur', async() => {
+    const onBlur = jest.fn()
+
+    render(<Input onBlur={onBlur} />)
+
+    const input = screen.getByRole<HTMLInputElement>('textbox')
+
+    fireEvent.blur(input, { target: { value: exampleText } })
+
+    expect(onBlur).toHaveBeenCalled()
+    expect(input.value).toBe(exampleText)
+  })
+
   test('Allow clear should clear input', () => {
     render(<Input allowClear defaultValue={exampleText} />)
 

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -84,6 +84,7 @@ export const Input = (
     isFullWidth = defaults.isFullWidth,
     isError,
     inputRef,
+    onBlur,
     onChange,
     placeholder,
     iconLeft,
@@ -183,6 +184,7 @@ export const Input = (
       suffix={iconRight && <Icon component={iconRight} size={DEFAULT_ICON_SIZE} />}
       type={type}
       value={inputValue}
+      onBlur={onBlur}
       onChange={handleChange}
     />
   )

--- a/src/components/Input/props.ts
+++ b/src/components/Input/props.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ChangeEvent } from 'react'
+import { ChangeEvent, FocusEventHandler } from 'react'
 
 import { BaseInputProps } from '../BaseInput/props'
 import { IconComponent } from '../Icon/Icon.props'
@@ -79,6 +79,11 @@ export type InputProps = BaseInputProps & {
   maxLength?: number
 
   /**
+   * Callback when input loses focus.
+   */
+  onBlur?: FocusEventHandler
+
+  /**
    * Callback when user input.
    */
   onChange?: InputChangeEventHandler
@@ -86,5 +91,4 @@ export type InputProps = BaseInputProps & {
   addonBefore?: InputAddonProps
 
   addonAfter?: InputAddonProps
-
 }

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -45,6 +45,7 @@ export const TextArea = (
     isError,
     inputRef,
     onChange,
+    onBlur,
     placeholder,
     allowClear,
     minLength,
@@ -70,6 +71,7 @@ export const TextArea = (
       placeholder={placeholder}
       rows={rows}
       value={value}
+      onBlur={onBlur}
       onChange={onChange}
     />
   )

--- a/src/components/TextArea/props.ts
+++ b/src/components/TextArea/props.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ChangeEventHandler } from 'react'
+import { ChangeEventHandler, FocusEventHandler } from 'react'
 
 import { BaseInputProps } from '../BaseInput/props'
 
@@ -60,6 +60,11 @@ export type TextAreaProps = BaseInputProps & {
    * Enables auto size feature.
    */
   autoSize?: boolean | {minRows?: number; maxRows?: number}
+
+  /**
+   * Callback when input loses focus.
+   */
+  onBlur?: FocusEventHandler
 
   /**
    * Callback when user input.


### PR DESCRIPTION
### Description

In this pull request, I'm adding the `onBlur` property to the `TextArea` and the `Input` components.

### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g. enhancement, new component, bug).

    > **NOTE**  
    > Some labels are used to generate release note entries: you can find the complete mapping between PR labels and release note categories [here](https://github.com/mia-platform/design-system/blob/main/.github/release.yml).  
    For a more detailed overview of PR labels, please refer to the [dedicated CONTRIBUTING section](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md#pull-request-labels).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [x] Changes are covered by tests 
- [x] Changes to components are accessible and documented in the Storybook
- [x] Typings have been updated
- [ ] New components are exported from the `src/index.ts` file
- [ ] New files include the Apache 2.0 License disclaimer
- [ ] The browser console does not contain errors
