### PR TITLE
feat: readonly form item render

### DIFF
--- a/src/components/Form/FormItem/FormItem.stories.tsx
+++ b/src/components/Form/FormItem/FormItem.stories.tsx
@@ -204,7 +204,7 @@ export const ReadOnlyInput = {
   args: {
     name: 'input',
     isReadOnly: true,
-    children: <InputComponent/>,
+    children: <InputComponent />,
   },
 }
 
@@ -212,7 +212,7 @@ export const ReadOnlySelect = {
   args: {
     name: 'select',
     isReadOnly: true,
-    children: <SelectComponent options={options}/>,
+    children: <SelectComponent options={options} />,
   },
 }
 
@@ -220,6 +220,6 @@ export const ReadOnlyMultiSelect = {
   args: {
     name: 'multiselect',
     isReadOnly: true,
-    children: <SelectComponent isMultiple options={options}/>,
+    children: <SelectComponent isMultiple options={options} />,
   },
 }

--- a/src/components/Form/FormItem/FormItem.stories.tsx
+++ b/src/components/Form/FormItem/FormItem.stories.tsx
@@ -39,12 +39,13 @@ const options = [
   label: `label ${id + 1}`,
 }))
 
-const initalValues = {
+const initialValues = {
   input: 'input',
   textarea: 'textarea',
   number: 1,
   search: options[0].value,
   select: options[0].value,
+  multiselect: [options[0].value, options[1].value],
   checkboxGroup: [options[0].value],
   inputAddon: { before: options[0].value, value: 'text' },
   switch: true,
@@ -58,7 +59,7 @@ const meta = {
   decorators: (story) => {
     const handleFinish = (values: unknown): void => alert(`onFinish:\n${JSON.stringify(values)}`)
     return (
-      <Form initialValues={initalValues} preserve={false} onFinish={handleFinish}>{story()}</Form>
+      <Form initialValues={initialValues} preserve={false} onFinish={handleFinish}>{story()}</Form>
     )
   },
   args: {
@@ -196,5 +197,29 @@ export const Custom: Story = {
         <Button onClick={handleClick}>{`clicked ${value} times`}</Button>
       )
     },
+  },
+}
+
+export const ReadOnlyInput = {
+  args: {
+    name: 'input',
+    isReadOnly: true,
+    children: <InputComponent/>,
+  },
+}
+
+export const ReadOnlySelect = {
+  args: {
+    name: 'select',
+    isReadOnly: true,
+    children: <SelectComponent options={options}/>,
+  },
+}
+
+export const ReadOnlyMultiSelect = {
+  args: {
+    name: 'multiselect',
+    isReadOnly: true,
+    children: <SelectComponent isMultiple options={options}/>,
   },
 }

--- a/src/components/Form/FormItem/FormItem.test.tsx
+++ b/src/components/Form/FormItem/FormItem.test.tsx
@@ -383,12 +383,12 @@ describe('FormItem Component', () => {
         valuePropName: 'test',
       })
 
-      const button = screen.getByRole('button', {name: String(initialValues.custom)})
+      const button = screen.getByRole('button', { name: String(initialValues.custom) })
       expect(within(button).getByText(initialValues.custom)).toBeInTheDocument()
       fireEvent.click(button)
       expect(within(button).getByText(initialValues.custom + 1)).toBeInTheDocument()
       expect(onValuesChange).toHaveBeenCalledWith(
-        {custom: initialValues.custom + 1}, {
+        { custom: initialValues.custom + 1 }, {
           custom: initialValues.custom + 1,
         })
     })
@@ -410,12 +410,12 @@ describe('FormItem Component', () => {
         children: customInput,
       })
 
-      const button = screen.getByRole('button', {name: String(initialValues.custom)})
+      const button = screen.getByRole('button', { name: String(initialValues.custom) })
       expect(within(button).getByText(initialValues.custom)).toBeInTheDocument()
       fireEvent.click(button)
       expect(within(button).getByText(initialValues.custom + 1)).toBeInTheDocument()
       expect(onValuesChange).toHaveBeenCalledWith(
-        {custom: initialValues.custom + 1}, {
+        { custom: initialValues.custom + 1 }, {
           custom: initialValues.custom + 1,
         })
     })
@@ -436,7 +436,7 @@ describe('FormItem Component', () => {
       renderItem({
         name: 'input',
         isReadOnly: true,
-        children: <Input/>,
+        children: <Input />,
       })
       screen.logTestingPlaygroundURL()
       const paragraph = screen.getByRole('paragraph')
@@ -447,7 +447,7 @@ describe('FormItem Component', () => {
       renderItem({
         name: 'input',
         isReadOnly: true,
-        children: <Select options={options}/>,
+        children: <Select options={options} />,
       })
       const paragraph = screen.getByRole('paragraph')
       expect(paragraph.innerHTML).toEqual(initialValues.select)
@@ -457,7 +457,7 @@ describe('FormItem Component', () => {
       renderItem({
         name: 'multiselect',
         isReadOnly: true,
-        children: <Select isMultiple={true} options={options}/>,
+        children: <Select isMultiple={true} options={options} />,
       })
       const paragraph = screen.getByRole('paragraph')
       expect(paragraph.innerHTML).toEqual([options[0].label, options[1].label].join(', '))

--- a/src/components/Form/FormItem/FormItem.test.tsx
+++ b/src/components/Form/FormItem/FormItem.test.tsx
@@ -445,12 +445,12 @@ describe('FormItem Component', () => {
 
     test('read only select should render selected option label', () => {
       renderItem({
-        name: 'input',
+        name: 'select',
         isReadOnly: true,
         children: <Select options={options} />,
       })
       const paragraph = screen.getByRole('paragraph')
-      expect(paragraph.innerHTML).toEqual(initialValues.select)
+      expect(paragraph.innerHTML).toEqual(options[0].label)
     })
 
     test('read only select should render comma separated options labels', () => {

--- a/src/components/Form/FormItem/FormItem.test.tsx
+++ b/src/components/Form/FormItem/FormItem.test.tsx
@@ -45,12 +45,13 @@ const options = [
 
 const exampleText = 'text'
 
-const initalValues = {
+const initialValues = {
   input: 'input',
   textarea: 'textarea',
   number: 1,
   search: options[0].value,
   select: options[0].value,
+  multiselect: [options[0].value, options[1].value],
   checkboxGroup: [options[0].value],
   inputAddon: { before: options[0].value, value: 'text' },
   switch: true,
@@ -63,7 +64,7 @@ const onValuesChange = jest.fn()
 
 const renderItem = ({ children, ...props }: FormItemProps): RenderResult => (
   render(
-    <Form initialValues={initalValues} preserve={false} onValuesChange={onValuesChange}>
+    <Form initialValues={initialValues} preserve={false} onValuesChange={onValuesChange}>
       <FormItem shouldUpdate {...props}>
         {children}
       </FormItem>
@@ -235,7 +236,7 @@ describe('FormItem Component', () => {
       })
 
       const input = screen.getByRole<HTMLInputElement>('textbox', { name: 'input' })
-      expect(input.value).toEqual(initalValues.input)
+      expect(input.value).toEqual(initialValues.input)
       fireEvent.change(input, { target: { value: exampleText } })
       expect(input.value).toEqual(exampleText)
       expect(onValuesChange).toHaveBeenCalledWith({ input: exampleText }, { input: exampleText })
@@ -248,7 +249,7 @@ describe('FormItem Component', () => {
       })
 
       const input = screen.getByRole<HTMLInputElement>('textbox', { name: 'textarea' })
-      expect(input.value).toEqual(initalValues.textarea)
+      expect(input.value).toEqual(initialValues.textarea)
       fireEvent.change(input, { target: { value: exampleText } })
       expect(input.value).toEqual(exampleText)
       expect(onValuesChange).toHaveBeenCalledWith({ textarea: exampleText }, { textarea: exampleText })
@@ -261,7 +262,7 @@ describe('FormItem Component', () => {
       })
 
       const input = screen.getByRole<HTMLInputElement>('spinbutton', { name: 'number' })
-      expect(input.value).toEqual(String(initalValues.number))
+      expect(input.value).toEqual(String(initialValues.number))
       fireEvent.change(input, { target: { value: 123456 } })
       expect(input.value).toEqual(String(123456))
       expect(onValuesChange).toHaveBeenCalledWith({ number: 123456 }, { number: 123456 })
@@ -382,13 +383,14 @@ describe('FormItem Component', () => {
         valuePropName: 'test',
       })
 
-      const button = screen.getByRole('button', { name: String(initalValues.custom) })
-      expect(within(button).getByText(initalValues.custom)).toBeInTheDocument()
+      const button = screen.getByRole('button', {name: String(initialValues.custom)})
+      expect(within(button).getByText(initialValues.custom)).toBeInTheDocument()
       fireEvent.click(button)
-      expect(within(button).getByText(initalValues.custom + 1)).toBeInTheDocument()
+      expect(within(button).getByText(initialValues.custom + 1)).toBeInTheDocument()
       expect(onValuesChange).toHaveBeenCalledWith(
-        { custom: initalValues.custom + 1 }, {
-          custom: initalValues.custom + 1 })
+        {custom: initialValues.custom + 1}, {
+          custom: initialValues.custom + 1,
+        })
     })
 
     test('custom input from render function should work properly', () => {
@@ -408,13 +410,14 @@ describe('FormItem Component', () => {
         children: customInput,
       })
 
-      const button = screen.getByRole('button', { name: String(initalValues.custom) })
-      expect(within(button).getByText(initalValues.custom)).toBeInTheDocument()
+      const button = screen.getByRole('button', {name: String(initialValues.custom)})
+      expect(within(button).getByText(initialValues.custom)).toBeInTheDocument()
       fireEvent.click(button)
-      expect(within(button).getByText(initalValues.custom + 1)).toBeInTheDocument()
+      expect(within(button).getByText(initialValues.custom + 1)).toBeInTheDocument()
       expect(onValuesChange).toHaveBeenCalledWith(
-        { custom: initalValues.custom + 1 }, {
-          custom: initalValues.custom + 1 })
+        {custom: initialValues.custom + 1}, {
+          custom: initialValues.custom + 1,
+        })
     })
 
     test('custom input from render function should work properly if no name is specified', () => {
@@ -425,6 +428,39 @@ describe('FormItem Component', () => {
         children: customInput,
       })
       expect(screen.getByText(exampleText)).toBeInTheDocument()
+    })
+  })
+
+  describe('readOnly', () => {
+    test('read only input should render value as text', () => {
+      renderItem({
+        name: 'input',
+        isReadOnly: true,
+        children: <Input/>,
+      })
+      screen.logTestingPlaygroundURL()
+      const paragraph = screen.getByRole('paragraph')
+      expect(paragraph.innerHTML).toEqual(initialValues.input)
+    })
+
+    test('read only select should render selected option label', () => {
+      renderItem({
+        name: 'input',
+        isReadOnly: true,
+        children: <Select options={options}/>,
+      })
+      const paragraph = screen.getByRole('paragraph')
+      expect(paragraph.innerHTML).toEqual(initialValues.select)
+    })
+
+    test('read only select should render comma separated options labels', () => {
+      renderItem({
+        name: 'multiselect',
+        isReadOnly: true,
+        children: <Select isMultiple={true} options={options}/>,
+      })
+      const paragraph = screen.getByRole('paragraph')
+      expect(paragraph.innerHTML).toEqual([options[0].label, options[1].label].join(', '))
     })
   })
 })

--- a/src/components/Form/FormItem/FormItem.tsx
+++ b/src/components/Form/FormItem/FormItem.tsx
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {ReactElement, ReactNode, isValidElement, useCallback, useMemo} from 'react'
+import { ReactElement, ReactNode, isValidElement, useCallback, useMemo } from 'react'
 import { Form as AntForm } from 'antd'
 import { PiBookOpen } from 'react-icons/pi'
 
@@ -26,14 +26,14 @@ import { FormItemProps } from '../props.ts'
 import ICircleFilled from '../../../assets/icons/ICircleFilled.svg'
 import { Icon } from '../../Icon'
 import { Input } from '../../Input'
-import {InputNumber} from '../../InputNumber'
+import { InputNumber } from '../../InputNumber'
 import { RadioGroup } from '../../RadioGroup'
-import {Select} from '../../Select'
-import {SelectProps} from '../../Select/props.ts'
+import { Select } from '../../Select'
+import { SelectProps } from '../../Select/props.ts'
 import { Switch } from '../../Switch'
-import {TextArea} from '../../TextArea'
+import { TextArea } from '../../TextArea'
 import { Tooltip } from '../../Tooltip'
-import {Typography} from '../../Typography/index.ts'
+import { Typography } from '../../Typography/index.ts'
 import log from '../../../utils/log.ts'
 import styles from './FormItem.module.css'
 const defaults = {
@@ -42,34 +42,34 @@ const defaults = {
 }
 
 const getDefaultReadOnlyElement = (element: ReactElement, value: unknown): ReactNode => {
-  const {type, props} = element
+  const { type, props } = element
   switch (type) {
-    case Input:
-    case InputNumber:
-    case TextArea: {
-      return (
-        <Typography.BodyS>
-          {value ? String(value) : '-'}
-        </Typography.BodyS>
-      )
-    }
-    case Select: {
-      const {options} = props as SelectProps
-      const selectedOptions = options.filter(({value: val}) => {
-        return Array.isArray(value) ? value.includes(val) : value === val
-      }) || []
-      const text = selectedOptions
-        .map(({label}) => String(label))
-        .join(', ') || '-'
-      return (
-        <Typography.BodyS>
-          {text}
-        </Typography.BodyS>
-      )
-    }
-    default:
-      log.error(`read-only ${type} is unimplemented: provide your own custom render`)
-      return undefined
+  case Input:
+  case InputNumber:
+  case TextArea: {
+    return (
+      <Typography.BodyS>
+        {value ? String(value) : '-'}
+      </Typography.BodyS>
+    )
+  }
+  case Select: {
+    const { options } = props as SelectProps
+    const selectedOptions = options.filter(({ value: val }) => {
+      return Array.isArray(value) ? value.includes(val) : value === val
+    }) || []
+    const text = selectedOptions
+      .map(({ label }) => String(label))
+      .join(', ') || '-'
+    return (
+      <Typography.BodyS>
+        {text}
+      </Typography.BodyS>
+    )
+  }
+  default:
+    log.error(`read-only ${type} is unimplemented: provide your own custom render`)
+    return undefined
   }
 }
 

--- a/src/components/Form/props.ts
+++ b/src/components/Form/props.ts
@@ -179,5 +179,10 @@ export type FormItemProps = {
    * Whether the field is required, showing an asterisk and applying validation.
    */
   isRequired?: boolean;
+
+  /**
+   * Whether the field is readonly. For text based input, a default implementation is provided.
+   */
+  isReadOnly?: boolean;
 };
 


### PR DESCRIPTION
### Feat(FormItem): added isReadOnly prop to FormItem

If the FormItem is read-only, we added some default rendering for certain types of inputs.
Text inputs will render the input value; select and multiselect will render the labels associated with the input values separated by a comma.

<img width="1415" alt="Screenshot 2025-01-24 alle 09 30 51" src="https://github.com/user-attachments/assets/33eccda7-bddb-4b9c-86f9-484ec001d6e9" />

<img width="1419" alt="Screenshot 2025-01-24 alle 09 29 53" src="https://github.com/user-attachments/assets/7e917aab-fd99-42c3-80b8-9a3e91b18138" />

##### FormItem
    -  added isReadOnly prop

### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g. enhancement, new component, bug).

    > **NOTE**  
    > Some labels are used to generate release note entries: you can find the complete mapping between PR labels and release note categories [here](https://github.com/mia-platform/design-system/blob/main/.github/release.yml).  
    For a more detailed overview of PR labels, please refer to the [dedicated CONTRIBUTING section](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md#pull-request-labels).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [x] Changes are covered by tests 
- [x] Changes to components are accessible and documented in the Storybook
- [x] Typings have been updated
- [x] New components are exported from the `src/index.ts` file
- [x] New files include the Apache 2.0 License disclaimer
- [x] The browser console does not contain errors
