### PR TITLE
Feat(Badge): Added hasMultilineDescription prop to badge

### DIFF
--- a/src/components/Badge/Badge.props.ts
+++ b/src/components/Badge/Badge.props.ts
@@ -45,7 +45,7 @@ export type BadgeProps = {
   /**
    * Whether the badge description should be multiline or clipped with ellipsis at the first line.
    * */
-  multiline?: boolean;
+  hasMultilineDescription?: boolean;
 
   /**
    * Additional content to be displayed alongside the badge title (e.g., a tag or an icon).

--- a/src/components/Badge/Badge.props.ts
+++ b/src/components/Badge/Badge.props.ts
@@ -43,6 +43,11 @@ export type BadgeProps = {
   title: string | ReactNode;
 
   /**
+   * Whether the badge description should be multiline or clipped with ellipsis at the first line.
+   * */
+  multiline?: boolean;
+
+  /**
    * Additional content to be displayed alongside the badge title (e.g., a tag or an icon).
    */
   titleExtra?: ReactNode;

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -95,7 +95,7 @@ export const CustomSubtitle: Story = {
 export const Multiline: Story = {
   args: {
     ...defaults,
-    multiline: true,
+    hasMultilineDescription: true,
     description: 'Maximus tellus congue blandit cras curabitur non. Tempor euismod finibus rhoncus platea blandit enim ipsum dolor sem. Vel tortor cubilia sodales lacus montes enim fames tortor. Non sociosqu primis adipiscing scelerisque inceptos porttitor eu odio penatibus. Laoreet volutpat eros eu mi per rhoncus. Habitasse ac laoreet urna non maecenas. Vulputate cubilia viverra vehicula sollicitudin dictum luctus fames. Efficitur ex suscipit dis sed aliquet, arcu et. Rhoncus turpis ultricies hac habitant bibendum, morbi parturient natoque mattis.',
   },
   decorators: [

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -92,6 +92,22 @@ export const CustomSubtitle: Story = {
   ],
 }
 
+export const Multiline: Story = {
+  args: {
+    ...defaults,
+    multiline: true,
+    description: 'Maximus tellus congue blandit cras curabitur non. Tempor euismod finibus rhoncus platea blandit enim ipsum dolor sem. Vel tortor cubilia sodales lacus montes enim fames tortor. Non sociosqu primis adipiscing scelerisque inceptos porttitor eu odio penatibus. Laoreet volutpat eros eu mi per rhoncus. Habitasse ac laoreet urna non maecenas. Vulputate cubilia viverra vehicula sollicitudin dictum luctus fames. Efficitur ex suscipit dis sed aliquet, arcu et. Rhoncus turpis ultricies hac habitant bibendum, morbi parturient natoque mattis.',
+  },
+  decorators: [
+    (_, { args }) => {
+      return (
+        <Badge {...args} />
+      )
+    },
+  ],
+}
+
+
 export const Extra: Story = {
   args: {
     ...defaults,

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -107,7 +107,6 @@ export const Multiline: Story = {
   ],
 }
 
-
 export const Extra: Story = {
   args: {
     ...defaults,

--- a/src/components/Badge/Badge.test.tsx
+++ b/src/components/Badge/Badge.test.tsx
@@ -47,6 +47,20 @@ describe('Badge Component', () => {
     expect(asFragment()).toMatchSnapshot()
   })
 
+  test('renders multiline correctly', () => {
+    const { asFragment } = render(
+      <Badge
+        description="Description"
+        icon={PiCircleHalfTilt}
+        multiline
+        title="Title"
+      />
+    )
+
+    expect(screen.getByRole('paragraph')).toBeInTheDocument()
+    expect(asFragment()).toMatchSnapshot()
+  })
+
   test('renders a badge with an extra', () => {
     const { asFragment } = render(
       <Badge

--- a/src/components/Badge/Badge.test.tsx
+++ b/src/components/Badge/Badge.test.tsx
@@ -51,8 +51,8 @@ describe('Badge Component', () => {
     const { asFragment } = render(
       <Badge
         description="Description"
+        hasMultilineDescription
         icon={PiCircleHalfTilt}
-        multiline
         title="Title"
       />
     )

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -34,7 +34,7 @@ export const Badge = ({
   icon: customIcon,
   title: customTitle,
   titleExtra,
-  multiline,
+  hasMultilineDescription,
 }: BadgeProps): ReactElement => {
   const { palette } = useTheme()
 
@@ -55,15 +55,13 @@ export const Badge = ({
 
   const description = useMemo(() => {
     if (!customDescription) { return }
-    if (multiline) {
-      return <Typography.BodyS>{customDescription}</Typography.BodyS>
-    }
+    const defaultEllipsis = { rows: 1, tooltip: { title: customDescription } }
     return (
-      <Typography.BodyS ellipsis={{ rows: 1, tooltip: { title: customDescription } }}>
+      <Typography.BodyS {...!hasMultilineDescription && { ellipsis: defaultEllipsis }}>
         {customDescription}
       </Typography.BodyS>
     )
-  }, [customDescription, multiline])
+  }, [customDescription, hasMultilineDescription])
 
   const extra = useMemo(() => {
     if (!customExtra) { return }

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -34,6 +34,7 @@ export const Badge = ({
   icon: customIcon,
   title: customTitle,
   titleExtra,
+  multiline,
 }: BadgeProps): ReactElement => {
   const { palette } = useTheme()
 
@@ -54,13 +55,15 @@ export const Badge = ({
 
   const description = useMemo(() => {
     if (!customDescription) { return }
-
+    if (multiline) {
+      return <Typography.BodyS>{customDescription}</Typography.BodyS>
+    }
     return (
       <Typography.BodyS ellipsis={{ rows: 1, tooltip: { title: customDescription } }}>
         {customDescription}
       </Typography.BodyS>
     )
-  }, [customDescription])
+  }, [customDescription, multiline])
 
   const extra = useMemo(() => {
     if (!customExtra) { return }

--- a/src/components/Badge/__snapshots__/Badge.test.tsx.snap
+++ b/src/components/Badge/__snapshots__/Badge.test.tsx.snap
@@ -160,3 +160,54 @@ exports[`Badge Component renders a badge with icon and title 1`] = `
   </div>
 </DocumentFragment>
 `;
+
+exports[`Badge Component renders multiline correctly 1`] = `
+<DocumentFragment>
+  <div
+    class="badge"
+  >
+    <div
+      class="icon"
+      data-testid="badge-icon"
+    >
+      <svg
+        color="#898989"
+        fill="currentColor"
+        height="48"
+        role="img"
+        stroke="currentColor"
+        stroke-width="0"
+        style="color: rgb(137, 137, 137);"
+        viewBox="0 0 256 256"
+        width="48"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M201.54,54.46A104,104,0,0,0,54.46,201.54,104,104,0,0,0,201.54,54.46ZM184,195.87a87.16,87.16,0,0,1-16,10.5V99.31l16-16Zm-80-32.56,16-16v68.28a88.37,88.37,0,0,1-16-3ZM88,206.37a87,87,0,0,1-16.3-10.76L88,179.31Zm48-75.06,16-16v97.32a88.37,88.37,0,0,1-16,3ZM40,128A88,88,0,0,1,184.3,60.39L60.38,184.31A87.34,87.34,0,0,1,40,128Zm160,50.59V77.41a88,88,0,0,1,0,101.18Z"
+        />
+      </svg>
+    </div>
+    <div
+      class="content"
+    >
+      <div
+        class="title"
+      >
+        <h3
+          aria-label="Title"
+          class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line h3"
+          role="h3"
+        >
+          Title
+        </h3>
+      </div>
+      <div
+        class="mia-platform-typography bodyS"
+        role="paragraph"
+      >
+        Description
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
### Added prop hasMultilineDescription to Badge
Added the prop hasMultilineDescription to Badge: by default the description is clipped and ellipsis is shown, but in some cases is desirable to have text falling back to the next line.

 
<img width="854" alt="Screenshot 2025-01-31 alle 11 32 36" src="https://github.com/user-attachments/assets/17371f08-6124-42a6-9a48-444e405c643a" />


##### Badge
    - Added prop hasMultilineDescription to Badge
    
### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g. enhancement, new component, bug).

    > **NOTE**  
    > Some labels are used to generate release note entries: you can find the complete mapping between PR labels and release note categories [here](https://github.com/mia-platform/design-system/blob/main/.github/release.yml).  
    For a more detailed overview of PR labels, please refer to the [dedicated CONTRIBUTING section](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md#pull-request-labels).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [x] Changes are covered by tests 
- [x] Changes to components are accessible and documented in the Storybook
- [x] Typings have been updated
- [x] New components are exported from the `src/index.ts` file
- [x] New files include the Apache 2.0 License disclaimer
- [x] The browser console does not contain errors
