### PR TITLE
feat(SplitButton): add onOpenChange prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives",
     "lint:fix": "yarn lint --fix",
     "checkonly": "find ./src -name '*.test.tsx' | xargs grep '\\.only'; test $? -eq 123",
-    "unit": "jest src/components/SplitButton/SplitButton.test.tsx",
+    "unit": "jest --watchAll",
     "coverage": "yarn unit --coverage --watchAll=false --reporters=default",
     "test": "yarn lint && yarn checkonly && yarn coverage",
     "storybook": "storybook dev -p 6006",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "Federico Pini <federico.pini@mia-platform.eu>",
     "Giovanna Monti <giovanna.monti@mia-platform.eu>",
     "Giovanni Tommasi <giovanni.tommasi@mia-platform.eu>",
-    "Paola Nicosia <paola.nicosia@mia-platform.eu>",
-    "Riccardo Corona <riccardo.corona@mia-platform.eu>",
+    "Guido Zoli <guido.zoli@mia-platform.eu>",
     "Luca Maltagliati <luca.maltagliati@mia-platform.eu>",
-    "Guido Zoli <guido.zoli@mia-platform.eu>"
+    "Paola Nicosia <paola.nicosia@mia-platform.eu>",
+    "Riccardo Corona <riccardo.corona@mia-platform.eu>"
   ],
   "repository": {
     "type": "git",
@@ -38,7 +38,7 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives",
     "lint:fix": "yarn lint --fix",
     "checkonly": "find ./src -name '*.test.tsx' | xargs grep '\\.only'; test $? -eq 123",
-    "unit": "jest --watchAll",
+    "unit": "jest src/components/SplitButton/SplitButton.test.tsx",
     "coverage": "yarn unit --coverage --watchAll=false --reporters=default",
     "test": "yarn lint && yarn checkonly && yarn coverage",
     "storybook": "storybook dev -p 6006",

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -209,6 +209,33 @@ exports[`Dropdown Component highlights selectedItems multiple mode renders prope
 </li>
 `;
 
+exports[`Dropdown Component highlights selectedItems single mode does not highlight elements if persistSelection is set to false: after click render Label 1 is not selected 1`] = `
+<li
+  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-only-child"
+  data-menu-id="rc-menu-uuid-test-1"
+  role="menuitem"
+  tabindex="-1"
+>
+  <span
+    class="mia-platform-dropdown-menu-title-content"
+  >
+    <div
+      class="itemRowContainer"
+    >
+      <div
+        class="labelsContainer horizontalContainer"
+      >
+        <span
+          class="primaryLabel"
+        >
+          Label 1
+        </span>
+      </div>
+    </div>
+  </span>
+</li>
+`;
+
 exports[`Dropdown Component highlights selectedItems single mode does not highlight elements if persistSelection is set to false: after click render Label 1 is still not selected 1`] = `
 <li
   class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-active mia-platform-dropdown-menu-item-only-child"
@@ -236,7 +263,71 @@ exports[`Dropdown Component highlights selectedItems single mode does not highli
 </li>
 `;
 
+exports[`Dropdown Component highlights selectedItems single mode does not highlight elements if persistSelection is set to false: after click render Label 2 is selected 1`] = `
+<li
+  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-only-child"
+  data-menu-id="rc-menu-uuid-test-2"
+  role="menuitem"
+  tabindex="-1"
+>
+  <span
+    class="mia-platform-dropdown-menu-title-content"
+  >
+    <div
+      class="itemRowContainer"
+    >
+      <div
+        class="labelsContainer horizontalContainer"
+      >
+        <span
+          class="primaryLabel"
+        >
+          Label 2
+        </span>
+        <span
+          class="secondaryLabel"
+        >
+          ·
+        </span>
+        <span
+          class="secondaryLabel"
+        >
+          Additional Info 2
+        </span>
+      </div>
+    </div>
+  </span>
+</li>
+`;
+
 exports[`Dropdown Component highlights selectedItems single mode does not highlight elements if persistSelection is set to false: at first render Label 1 is not selected 1`] = `
+<li
+  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-only-child"
+  data-menu-id="rc-menu-uuid-test-1"
+  role="menuitem"
+  tabindex="-1"
+>
+  <span
+    class="mia-platform-dropdown-menu-title-content"
+  >
+    <div
+      class="itemRowContainer"
+    >
+      <div
+        class="labelsContainer horizontalContainer"
+      >
+        <span
+          class="primaryLabel"
+        >
+          Label 1
+        </span>
+      </div>
+    </div>
+  </span>
+</li>
+`;
+
+exports[`Dropdown Component highlights selectedItems single mode render and ignores "initialSelectedItems" prop if "persistSelection" is false: after click render Label 1 is still not selected 1`] = `
 <li
   class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-only-child"
   data-menu-id="rc-menu-uuid-test-1"
@@ -293,6 +384,33 @@ exports[`Dropdown Component highlights selectedItems single mode render and igno
 exports[`Dropdown Component highlights selectedItems single mode renders proper highlight 1`] = `
 <li
   class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-selected mia-platform-dropdown-menu-item-only-child"
+  data-menu-id="rc-menu-uuid-test-1"
+  role="menuitem"
+  tabindex="-1"
+>
+  <span
+    class="mia-platform-dropdown-menu-title-content"
+  >
+    <div
+      class="itemRowContainer"
+    >
+      <div
+        class="labelsContainer horizontalContainer"
+      >
+        <span
+          class="primaryLabel"
+        >
+          Label 1
+        </span>
+      </div>
+    </div>
+  </span>
+</li>
+`;
+
+exports[`Dropdown Component highlights selectedItems single mode updates highlight 1`] = `
+<li
+  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-active mia-platform-dropdown-menu-item-selected mia-platform-dropdown-menu-item-only-child"
   data-menu-id="rc-menu-uuid-test-1"
   role="menuitem"
   tabindex="-1"
@@ -502,6 +620,33 @@ exports[`Dropdown Component label layouts render labels 3`] = `
           class="secondaryLabel danger"
         >
           Additional Info 2
+        </span>
+      </div>
+    </div>
+  </span>
+</li>
+`;
+
+exports[`Dropdown Component with footer renders footer: after click render Label 1 is still not selected 1`] = `
+<li
+  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-active mia-platform-dropdown-menu-item-only-child"
+  data-menu-id="rc-menu-uuid-test-1"
+  role="menuitem"
+  tabindex="-1"
+>
+  <span
+    class="mia-platform-dropdown-menu-title-content"
+  >
+    <div
+      class="itemRowContainer"
+    >
+      <div
+        class="labelsContainer horizontalContainer"
+      >
+        <span
+          class="primaryLabel"
+        >
+          Label 1
         </span>
       </div>
     </div>

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -209,33 +209,6 @@ exports[`Dropdown Component highlights selectedItems multiple mode renders prope
 </li>
 `;
 
-exports[`Dropdown Component highlights selectedItems single mode does not highlight elements if persistSelection is set to false: after click render Label 1 is not selected 1`] = `
-<li
-  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-only-child"
-  data-menu-id="rc-menu-uuid-test-1"
-  role="menuitem"
-  tabindex="-1"
->
-  <span
-    class="mia-platform-dropdown-menu-title-content"
-  >
-    <div
-      class="itemRowContainer"
-    >
-      <div
-        class="labelsContainer horizontalContainer"
-      >
-        <span
-          class="primaryLabel"
-        >
-          Label 1
-        </span>
-      </div>
-    </div>
-  </span>
-</li>
-`;
-
 exports[`Dropdown Component highlights selectedItems single mode does not highlight elements if persistSelection is set to false: after click render Label 1 is still not selected 1`] = `
 <li
   class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-active mia-platform-dropdown-menu-item-only-child"
@@ -263,71 +236,7 @@ exports[`Dropdown Component highlights selectedItems single mode does not highli
 </li>
 `;
 
-exports[`Dropdown Component highlights selectedItems single mode does not highlight elements if persistSelection is set to false: after click render Label 2 is selected 1`] = `
-<li
-  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-only-child"
-  data-menu-id="rc-menu-uuid-test-2"
-  role="menuitem"
-  tabindex="-1"
->
-  <span
-    class="mia-platform-dropdown-menu-title-content"
-  >
-    <div
-      class="itemRowContainer"
-    >
-      <div
-        class="labelsContainer horizontalContainer"
-      >
-        <span
-          class="primaryLabel"
-        >
-          Label 2
-        </span>
-        <span
-          class="secondaryLabel"
-        >
-          ·
-        </span>
-        <span
-          class="secondaryLabel"
-        >
-          Additional Info 2
-        </span>
-      </div>
-    </div>
-  </span>
-</li>
-`;
-
 exports[`Dropdown Component highlights selectedItems single mode does not highlight elements if persistSelection is set to false: at first render Label 1 is not selected 1`] = `
-<li
-  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-only-child"
-  data-menu-id="rc-menu-uuid-test-1"
-  role="menuitem"
-  tabindex="-1"
->
-  <span
-    class="mia-platform-dropdown-menu-title-content"
-  >
-    <div
-      class="itemRowContainer"
-    >
-      <div
-        class="labelsContainer horizontalContainer"
-      >
-        <span
-          class="primaryLabel"
-        >
-          Label 1
-        </span>
-      </div>
-    </div>
-  </span>
-</li>
-`;
-
-exports[`Dropdown Component highlights selectedItems single mode render and ignores "initialSelectedItems" prop if "persistSelection" is false: after click render Label 1 is still not selected 1`] = `
 <li
   class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-only-child"
   data-menu-id="rc-menu-uuid-test-1"
@@ -384,33 +293,6 @@ exports[`Dropdown Component highlights selectedItems single mode render and igno
 exports[`Dropdown Component highlights selectedItems single mode renders proper highlight 1`] = `
 <li
   class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-selected mia-platform-dropdown-menu-item-only-child"
-  data-menu-id="rc-menu-uuid-test-1"
-  role="menuitem"
-  tabindex="-1"
->
-  <span
-    class="mia-platform-dropdown-menu-title-content"
-  >
-    <div
-      class="itemRowContainer"
-    >
-      <div
-        class="labelsContainer horizontalContainer"
-      >
-        <span
-          class="primaryLabel"
-        >
-          Label 1
-        </span>
-      </div>
-    </div>
-  </span>
-</li>
-`;
-
-exports[`Dropdown Component highlights selectedItems single mode updates highlight 1`] = `
-<li
-  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-active mia-platform-dropdown-menu-item-selected mia-platform-dropdown-menu-item-only-child"
   data-menu-id="rc-menu-uuid-test-1"
   role="menuitem"
   tabindex="-1"
@@ -620,33 +502,6 @@ exports[`Dropdown Component label layouts render labels 3`] = `
           class="secondaryLabel danger"
         >
           Additional Info 2
-        </span>
-      </div>
-    </div>
-  </span>
-</li>
-`;
-
-exports[`Dropdown Component with footer renders footer: after click render Label 1 is still not selected 1`] = `
-<li
-  class="mia-platform-dropdown-menu-item mia-platform-dropdown-menu-item-active mia-platform-dropdown-menu-item-only-child"
-  data-menu-id="rc-menu-uuid-test-1"
-  role="menuitem"
-  tabindex="-1"
->
-  <span
-    class="mia-platform-dropdown-menu-title-content"
-  >
-    <div
-      class="itemRowContainer"
-    >
-      <div
-        class="labelsContainer horizontalContainer"
-      >
-        <span
-          class="primaryLabel"
-        >
-          Label 1
         </span>
       </div>
     </div>

--- a/src/components/SplitButton/SplitButton.test.tsx
+++ b/src/components/SplitButton/SplitButton.test.tsx
@@ -136,6 +136,25 @@ describe('SplitButton Component', () => {
         domEvent: expect.anything(),
       })
     })
+
+    it('calls onOpenChange when dropdown is triggered', async() => {
+      const onOpenChange = jest.fn()
+      render({ props: { ...defaultProps, onOpenChange } })
+
+      const dropdownButton = screen.getByRole('button', { name: /open dropdown/i })
+      expect(dropdownButton).toBeInTheDocument()
+
+      await userEvent.click(dropdownButton)
+      const firstMenuItem = await screen.findByRole('menuitem', { name: 'Label 1' })
+
+      expect(screen.getAllByRole('menuitem')).toHaveLength(2)
+
+      await userEvent.click(firstMenuItem)
+
+      expect(onOpenChange).toHaveBeenCalledTimes(2)
+      expect(onOpenChange).toHaveBeenNthCalledWith(1, true, { source: 'trigger' })
+      expect(onOpenChange).toHaveBeenNthCalledWith(2, false, { source: 'menu' })
+    })
   })
 })
 

--- a/src/components/SplitButton/SplitButton.tsx
+++ b/src/components/SplitButton/SplitButton.tsx
@@ -23,6 +23,7 @@ import classNames from 'classnames'
 import { Button } from '../Button/Button'
 import { Dropdown } from '../Dropdown/Dropdown'
 import { Icon } from '../Icon'
+import { OpenChangeInfo } from '../Dropdown/props'
 import { SplitButtonProps } from './props'
 import styles from './SplitButton.module.css'
 
@@ -52,12 +53,16 @@ export const SplitButton = ({
   itemLayout,
   onClick,
   onItemClick,
+  onOpenChange,
   target,
   title,
   type,
 }: SplitButtonProps): ReactElement => {
   const [opened, setOpened] = useState(false)
-  const onOpenChange = useCallback(() => setOpened((prev) => !prev), [])
+  const onDropdownOpenChange = useCallback((open: boolean, info: OpenChangeInfo) => {
+    onOpenChange?.(open, info)
+    setOpened((prev) => !prev)
+  }, [onOpenChange])
 
   return (
     <div className={splitButton}>
@@ -84,7 +89,7 @@ export const SplitButton = ({
         persistSelection={false}
         placement={Dropdown.Placement.BottomRight}
         onClick={onItemClick}
-        onOpenChange={onOpenChange}
+        onOpenChange={onDropdownOpenChange}
       >
         <Button
           className={classNames(

--- a/src/components/SplitButton/props.ts
+++ b/src/components/SplitButton/props.ts
@@ -18,7 +18,7 @@
 
 import { MouseEvent, ReactNode } from 'react'
 
-import { DropdownClickEvent, ItemLayout } from '../Dropdown/props'
+import { DropdownClickEvent, ItemLayout, OpenChangeInfo } from '../Dropdown/props'
 import { HTMLType, Hierarchy, Type } from '../Button/Button.types'
 import { SplitButtonItem } from './types'
 
@@ -81,15 +81,20 @@ export type SplitButtonProps = {
   items: SplitButtonItem[]
 
   /**
-   * callback used to notify a click on the main button.
+   * Callback used to notify a click on the main button.
    */
   onClick: (event: MouseEvent) => void,
 
   /**
-   * callback used to notify a click on a dropdown item, see
+   * Callback used to notify a click on a dropdown item, see
    * Dropdown#onClick specification for further details.
    */
   onItemClick: (event: DropdownClickEvent) => void
+
+  /**
+   * Callback used to notify when the open state is changed.
+   */
+  onOpenChange?: (open: boolean, info: OpenChangeInfo) => void
 
   /**
    * Specifies where the linked document will open when the link is clicked.


### PR DESCRIPTION
### Description

Exposed onOpenChange prop for the Split Button component without changing the internal logic

### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g. enhancement, new component, bug).

    > **NOTE**  
    > Some labels are used to generate release note entries: you can find the complete mapping between PR labels and release note categories [here](https://github.com/mia-platform/design-system/blob/main/.github/release.yml).  
    For a more detailed overview of PR labels, please refer to the [dedicated CONTRIBUTING section](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md#pull-request-labels).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [x] Changes are covered by tests 
- [x] Changes to components are accessible and documented in the Storybook
- [x] Typings have been updated
- [ ] New components are exported from the `src/index.ts` file
- [ ] New files include the Apache 2.0 License disclaimer
- [x] The browser console does not contain errors
