### PR TITLE
feat(Table): prevent table remount on load

### DIFF
--- a/src/components/Form/FormItem/FormItem.test.tsx
+++ b/src/components/Form/FormItem/FormItem.test.tsx
@@ -438,7 +438,6 @@ describe('FormItem Component', () => {
         isReadOnly: true,
         children: <Input />,
       })
-      screen.logTestingPlaygroundURL()
       const paragraph = screen.getByRole('paragraph')
       expect(paragraph.innerHTML).toEqual(initialValues.input)
     })

--- a/src/components/Table/Table.props.ts
+++ b/src/components/Table/Table.props.ts
@@ -225,6 +225,11 @@ export type TableProps<RecordType extends GenericRecord> = {
    */
   pagination?: Pagination | false,
 
+  /**
+   * This prop prevents the table to be re-mounted whenever the `isLoading` prop value changes.
+   *
+   * The loading UI won't feature the Skeleton but a spinner instead.
+   */
   preventTableUnmountOnLoading?: boolean,
 
   /**

--- a/src/components/Table/Table.props.ts
+++ b/src/components/Table/Table.props.ts
@@ -128,7 +128,7 @@ export type TableProps<RecordType extends GenericRecord> = {
   isBordered?: boolean,
 
   /**
-   * Indicates whether the table is in a loading state (skeleton).
+   * Indicates whether the table is in a loading state.
    */
   isLoading?: boolean,
 
@@ -224,13 +224,6 @@ export type TableProps<RecordType extends GenericRecord> = {
    * @see {@link https://ant.design/components/pagination#api} for advanced configurations.
    */
   pagination?: Pagination | false,
-
-  /**
-   * This prop prevents the table to be re-mounted whenever the `isLoading` prop value changes.
-   *
-   * The loading UI won't feature the Skeleton but a spinner instead.
-   */
-  preventUnmountOnLoading?: boolean,
 
   /**
    * The key used to identify each row of the table.

--- a/src/components/Table/Table.props.ts
+++ b/src/components/Table/Table.props.ts
@@ -225,6 +225,8 @@ export type TableProps<RecordType extends GenericRecord> = {
    */
   pagination?: Pagination | false,
 
+  preventTableUnmountOnLoading?: boolean,
+
   /**
    * The key used to identify each row of the table.
    *

--- a/src/components/Table/Table.props.ts
+++ b/src/components/Table/Table.props.ts
@@ -230,7 +230,7 @@ export type TableProps<RecordType extends GenericRecord> = {
    *
    * The loading UI won't feature the Skeleton but a spinner instead.
    */
-  preventTableUnmountOnLoading?: boolean,
+  preventUnmountOnLoading?: boolean,
 
   /**
    * The key used to identify each row of the table.

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -79,10 +79,6 @@ export const Loading: Story = {
   args: { ...meta.args, isLoading: true },
 }
 
-export const LoadingWithoutUnmount: Story = {
-  args: { ...meta.args, isLoading: true, preventUnmountOnLoading: true },
-}
-
 export const Bordered: Story = {
   args: { ...meta.args, isBordered: true },
 }

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -79,6 +79,10 @@ export const Loading: Story = {
   args: { ...meta.args, isLoading: true },
 }
 
+export const LoadingWithoutUnmount: Story = {
+  args: { ...meta.args, isLoading: true, preventUnmountOnLoading: true },
+}
+
 export const Bordered: Story = {
   args: { ...meta.args, isBordered: true },
 }

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -89,6 +89,7 @@ export const Table = <RecordType extends GenericRecord>({
   scroll = defaults.scroll,
   rowState,
   hasParentHeight,
+  preventTableUnmountOnLoading,
 }: TableProps<RecordType>): ReactElement => {
   const theme = useTheme()
   const className = useMemo(() => classnames([
@@ -148,32 +149,60 @@ export const Table = <RecordType extends GenericRecord>({
     return isValidState ? styles[`${state}State`] : ''
   }, [rowState])
 
+  const tableComponent = useMemo(() => (
+    <AntTable<RecordType>
+      bordered={isBordered}
+      className={className}
+      columns={tableColumns}
+      dataSource={data}
+      expandable={expandable}
+      footer={footer}
+      loading={isLoading}
+      locale={intlLocale}
+      pagination={tablePagination}
+      rowClassName={rowState ? rowClassName : undefined}
+      rowKey={rowKey}
+      rowSelection={rowSelection}
+      scroll={scroll}
+      showHeader
+      showSorterTooltip={false}
+      size={size}
+      sticky={false}
+      tableLayout={layout}
+      virtual={false}
+      onChange={onChange}
+      onHeaderRow={onHeaderRow}
+      onRow={onRow}
+    />
+  ), [
+    className,
+    data,
+    expandable,
+    footer,
+    intlLocale,
+    isBordered,
+    isLoading,
+    layout,
+    onChange,
+    onHeaderRow,
+    onRow,
+    rowClassName,
+    rowKey,
+    rowSelection,
+    rowState,
+    scroll,
+    size,
+    tableColumns,
+    tablePagination,
+  ])
+
+  if (preventTableUnmountOnLoading) {
+    return tableComponent
+  }
+
   return (
     <Skeleton active loading={isLoading}>
-      <AntTable<RecordType>
-        bordered={isBordered}
-        className={className}
-        columns={tableColumns}
-        dataSource={data}
-        expandable={expandable}
-        footer={footer}
-        loading={false}
-        locale={intlLocale}
-        pagination={tablePagination}
-        rowClassName={rowState ? rowClassName : undefined}
-        rowKey={rowKey}
-        rowSelection={rowSelection}
-        scroll={scroll}
-        showHeader
-        showSorterTooltip={false}
-        size={size}
-        sticky={false}
-        tableLayout={layout}
-        virtual={false}
-        onChange={onChange}
-        onHeaderRow={onHeaderRow}
-        onRow={onRow}
-      />
+      {tableComponent}
     </Skeleton>
   )
 }

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -89,7 +89,7 @@ export const Table = <RecordType extends GenericRecord>({
   scroll = defaults.scroll,
   rowState,
   hasParentHeight,
-  preventTableUnmountOnLoading,
+  preventUnmountOnLoading,
 }: TableProps<RecordType>): ReactElement => {
   const theme = useTheme()
   const className = useMemo(() => classnames([
@@ -196,7 +196,7 @@ export const Table = <RecordType extends GenericRecord>({
     tablePagination,
   ])
 
-  if (preventTableUnmountOnLoading) {
+  if (preventUnmountOnLoading) {
     return tableComponent
   }
 

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Table as AntTable, Skeleton } from 'antd'
 import { PiPencilSimpleLine, PiTrash } from 'react-icons/pi'
 import { ReactElement, useCallback, useMemo } from 'react'
+import { Table as AntTable } from 'antd'
 import classnames from 'classnames'
 
 import { Action, ColumnAlignment, ColumnFilterMode, GenericRecord, Layout, RowState, Size, SortOrder } from './Table.types'
@@ -89,7 +89,6 @@ export const Table = <RecordType extends GenericRecord>({
   scroll = defaults.scroll,
   rowState,
   hasParentHeight,
-  preventUnmountOnLoading,
 }: TableProps<RecordType>): ReactElement => {
   const theme = useTheme()
   const className = useMemo(() => classnames([
@@ -149,7 +148,7 @@ export const Table = <RecordType extends GenericRecord>({
     return isValidState ? styles[`${state}State`] : ''
   }, [rowState])
 
-  const tableComponent = useMemo(() => (
+  return (
     <AntTable<RecordType>
       bordered={isBordered}
       className={className}
@@ -174,36 +173,6 @@ export const Table = <RecordType extends GenericRecord>({
       onHeaderRow={onHeaderRow}
       onRow={onRow}
     />
-  ), [
-    className,
-    data,
-    expandable,
-    footer,
-    intlLocale,
-    isBordered,
-    isLoading,
-    layout,
-    onChange,
-    onHeaderRow,
-    onRow,
-    rowClassName,
-    rowKey,
-    rowSelection,
-    rowState,
-    scroll,
-    size,
-    tableColumns,
-    tablePagination,
-  ])
-
-  if (preventUnmountOnLoading) {
-    return tableComponent
-  }
-
-  return (
-    <Skeleton active loading={isLoading}>
-      {tableComponent}
-    </Skeleton>
   )
 }
 

--- a/src/components/Table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/Table/__snapshots__/Table.test.tsx.snap
@@ -5347,24 +5347,257 @@ exports[`Table Component renders table correctly 1`] = `
 exports[`Table Component renders table correctly while loading 1`] = `
 <DocumentFragment>
   <div
-    class="mia-platform-skeleton mia-platform-skeleton-active"
+    class="mia-platform-table-wrapper table hasPagination"
   >
     <div
-      class="mia-platform-skeleton-content"
+      class="mia-platform-spin-nested-loading"
     >
-      <h3
-        class="mia-platform-skeleton-title"
-        style="width: 38%;"
-      />
-      <ul
-        class="mia-platform-skeleton-paragraph"
+      <div>
+        <div
+          aria-busy="true"
+          aria-live="polite"
+          class="mia-platform-spin mia-platform-spin-spinning"
+        >
+          <span
+            class="mia-platform-spin-dot-holder"
+          >
+            <span
+              class="mia-platform-spin-dot mia-platform-spin-dot-spin"
+            >
+              <i
+                class="mia-platform-spin-dot-item"
+              />
+              <i
+                class="mia-platform-spin-dot-item"
+              />
+              <i
+                class="mia-platform-spin-dot-item"
+              />
+              <i
+                class="mia-platform-spin-dot-item"
+              />
+            </span>
+          </span>
+        </div>
+      </div>
+      <div
+        class="mia-platform-spin-container mia-platform-spin-blur"
       >
-        <li />
-        <li />
-        <li
-          style="width: 61%;"
-        />
-      </ul>
+        <div
+          class="mia-platform-table mia-platform-table-middle mia-platform-table-scroll-horizontal"
+        >
+          <div
+            class="mia-platform-table-container"
+          >
+            <div
+              class="mia-platform-table-content"
+              style="overflow-x: auto; overflow-y: hidden;"
+            >
+              <table
+                style="width: auto; min-width: 100%; table-layout: auto;"
+              >
+                <colgroup />
+                <thead
+                  class="mia-platform-table-thead"
+                >
+                  <tr>
+                    <th
+                      class="mia-platform-table-cell mia-platform-table-cell-ellipsis"
+                      scope="col"
+                      title="Field 1"
+                    >
+                      Field 1
+                    </th>
+                    <th
+                      class="mia-platform-table-cell mia-platform-table-cell-ellipsis"
+                      scope="col"
+                      title="Field 2"
+                    >
+                      Field 2
+                    </th>
+                    <th
+                      class="mia-platform-table-cell mia-platform-table-cell-ellipsis"
+                      scope="col"
+                      title="Field 3"
+                    >
+                      Field 3
+                    </th>
+                    <th
+                      class="mia-platform-table-cell mia-platform-table-cell-ellipsis"
+                      scope="col"
+                      title="Field 4"
+                    >
+                      Field 4
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  class="mia-platform-table-tbody"
+                >
+                  <tr
+                    aria-hidden="true"
+                    class="mia-platform-table-measure-row"
+                    style="height: 0px; font-size: 0px;"
+                  >
+                    <td
+                      style="padding: 0px; border: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden;"
+                      >
+                         
+                      </div>
+                    </td>
+                    <td
+                      style="padding: 0px; border: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden;"
+                      >
+                         
+                      </div>
+                    </td>
+                    <td
+                      style="padding: 0px; border: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden;"
+                      >
+                         
+                      </div>
+                    </td>
+                    <td
+                      style="padding: 0px; border: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden;"
+                      >
+                         
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="mia-platform-table-row mia-platform-table-row-level-0"
+                    data-row-key="Value 1"
+                  >
+                    <td
+                      class="mia-platform-table-cell mia-platform-table-cell-ellipsis"
+                      title="Value 1"
+                    >
+                      Value 1
+                    </td>
+                    <td
+                      class="mia-platform-table-cell mia-platform-table-cell-ellipsis"
+                      title="Value 1"
+                    >
+                      Value 1
+                    </td>
+                    <td
+                      class="mia-platform-table-cell mia-platform-table-cell-ellipsis"
+                      title="Value 1"
+                    >
+                      Value 1
+                    </td>
+                    <td
+                      class="mia-platform-table-cell mia-platform-table-cell-ellipsis"
+                      title="Value 1"
+                    >
+                      Value 1
+                    </td>
+                  </tr>
+                  <tr
+                    class="mia-platform-table-row mia-platform-table-row-level-0"
+                    data-row-key="Value 2"
+                  >
+                    <td
+                      class="mia-platform-table-cell mia-platform-table-cell-ellipsis"
+                      title="Value 2"
+                    >
+                      Value 2
+                    </td>
+                    <td
+                      class="mia-platform-table-cell mia-platform-table-cell-ellipsis"
+                      title="Value 2"
+                    >
+                      Value 2
+                    </td>
+                    <td
+                      class="mia-platform-table-cell mia-platform-table-cell-ellipsis"
+                      title="Value 2"
+                    >
+                      Value 2
+                    </td>
+                    <td
+                      class="mia-platform-table-cell mia-platform-table-cell-ellipsis"
+                      title="Value 2"
+                    >
+                      Value 2
+                    </td>
+                  </tr>
+                  <tr
+                    class="mia-platform-table-row mia-platform-table-row-level-0"
+                    data-row-key="Value 3"
+                  >
+                    <td
+                      class="mia-platform-table-cell mia-platform-table-cell-ellipsis"
+                      title="Value 3"
+                    >
+                      Value 3
+                    </td>
+                    <td
+                      class="mia-platform-table-cell mia-platform-table-cell-ellipsis"
+                      title="Value 3"
+                    >
+                      Value 3
+                    </td>
+                    <td
+                      class="mia-platform-table-cell mia-platform-table-cell-ellipsis"
+                      title="Value 3"
+                    >
+                      Value 3
+                    </td>
+                    <td
+                      class="mia-platform-table-cell mia-platform-table-cell-ellipsis"
+                      title="Value 3"
+                    >
+                      Value 3
+                    </td>
+                  </tr>
+                  <tr
+                    class="mia-platform-table-row mia-platform-table-row-level-0"
+                    data-row-key="Value 4"
+                  >
+                    <td
+                      class="mia-platform-table-cell mia-platform-table-cell-ellipsis"
+                      title="Value 4"
+                    >
+                      Value 4
+                    </td>
+                    <td
+                      class="mia-platform-table-cell mia-platform-table-cell-ellipsis"
+                      title="Value 4"
+                    >
+                      Value 4
+                    </td>
+                    <td
+                      class="mia-platform-table-cell mia-platform-table-cell-ellipsis"
+                      title="Value 4"
+                    >
+                      Value 4
+                    </td>
+                    <td
+                      class="mia-platform-table-cell mia-platform-table-cell-ellipsis"
+                      title="Value 4"
+                    >
+                      Value 4
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </DocumentFragment>


### PR DESCRIPTION
### Description

This PR introduces a new flag for the Table component that prevents it from being remounted for `isLoading` prop change.

The remount is due to the Skeleton that is currently wrapping the table.

Removing the Skeleton altogether would be a breaking change and since there are many tables impacted I preferred not to risk and break anything.

We can make the breaking change later on.

### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g. enhancement, new component, bug).

    > **NOTE**  
    > Some labels are used to generate release note entries: you can find the complete mapping between PR labels and release note categories [here](https://github.com/mia-platform/design-system/blob/main/.github/release.yml).  
    For a more detailed overview of PR labels, please refer to the [dedicated CONTRIBUTING section](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md#pull-request-labels).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [ ] Changes are covered by tests 
- [ ] Changes to components are accessible and documented in the Storybook
- [x] Typings have been updated
- [ ] New components are exported from the `src/index.ts` file
- [ ] New files include the Apache 2.0 License disclaimer
- [ ] The browser console does not contain errors
