### PR TITLE
fixed: css cardSelection, feat: export Form.useForm

### DIFF
--- a/src/components/CardSelection/CardSelection.module.css
+++ b/src/components/CardSelection/CardSelection.module.css
@@ -21,7 +21,7 @@
   flex-direction: row;
   flex-wrap: nowrap;
   & > .card {
-    flex-grow: 1;
+    flex: 1;
   }
 }
 
@@ -29,7 +29,7 @@
   position: relative;
   display: flex;
   & > span, .content {
-    flex-grow: 1;
+    flex: 1;
   }
   &:after {
     display: none;

--- a/src/components/Form/Form.stories.tsx
+++ b/src/components/Form/Form.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-multi-comp */
 /**
  * Copyright 2024 Mia srl
  *
@@ -16,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Fragment, ReactElement } from 'react'
+import { Fragment, ReactElement, useState } from 'react'
 import { Meta, type StoryObj } from '@storybook/react'
 import { Flex } from 'antd'
 import dayjs from 'dayjs'
@@ -149,6 +150,47 @@ export const WithValidation: Story = {
       </Form.Item>
     ),
   },
+}
+
+export const UseFormInstance = (): ReactElement => {
+  const [formValues, setFormValues] = useState()
+  const [formValuesError, setFormValuesError] = useState()
+  const [form] = Form.useForm()
+
+  return (
+    <>
+      <code>{JSON.stringify(formValues || formValuesError, null, 2)}</code>
+      <br />
+      <br />
+      <Card>
+        <Form form={form} id="my-form" submitButton={false}>
+          <Form.Item isRequired name="firstName">
+            <Input />
+          </Form.Item>
+          <Form.Item isRequired name="lastName">
+            <Input />
+          </Form.Item>
+        </Form>
+      </Card>
+      <br />
+      <Button
+        hierarchy={Button.Hierarchy.Primary}
+        onClick={() => {
+          form.validateFields()
+            .then((values) => {
+              setFormValuesError(undefined)
+              setFormValues(values)
+            })
+            .catch(({ errorFields }) => {
+              setFormValues(undefined)
+              setFormValuesError(errorFields)
+            })
+        }}
+      >
+        {'Save from the form instance method'}
+      </Button>
+    </>
+  )
 }
 
 export const ComplexForm: Story = {

--- a/src/components/Form/Form.test.tsx
+++ b/src/components/Form/Form.test.tsx
@@ -135,10 +135,10 @@ describe('Form Component', () => {
             id={id}
             submitButton={false}
           >
-            <Form.Item isRequired name="firstName">
+            <Form.Item name="firstName" rules={[Form.Validators.required()]}>
               <Input />
             </Form.Item>
-            <Form.Item isRequired name="lastName">
+            <Form.Item name="lastName" rules={[Form.Validators.required()]}>
               <Input />
             </Form.Item>
           </Form>

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -38,6 +38,7 @@ export const Form = <Values extends Record<string, unknown>, >({
   submitButton: submitButtonProp = defaults.submitButton,
   layout = defaults.layout,
   columns = defaults.columns,
+  form,
   gap = defaults.gap,
   id,
   initialValues,
@@ -55,6 +56,7 @@ export const Form = <Values extends Record<string, unknown>, >({
 
   return (
     <AntForm<Values>
+      form={form}
       id={id}
       initialValues={initialValues}
       layout={layout}
@@ -80,3 +82,4 @@ Form.Layout = Layout
 Form.Item = FormItem
 Form.SubmitButton = SubmitButton
 Form.Validators = Validators
+Form.useForm = AntForm.useForm

--- a/src/components/Form/FormItem/FormItem.tsx
+++ b/src/components/Form/FormItem/FormItem.tsx
@@ -22,6 +22,7 @@ import { PiBookOpen } from 'react-icons/pi'
 
 import { Button } from '../../Button'
 import { Checkbox } from '../../Checkbox'
+import { Form } from '../Form.tsx'
 import { FormItemProps } from '../props.ts'
 import ICircleFilled from '../../../assets/icons/ICircleFilled.svg'
 import { Icon } from '../../Icon'
@@ -36,6 +37,7 @@ import { Tooltip } from '../../Tooltip'
 import { Typography } from '../../Typography/index.ts'
 import log from '../../../utils/log.ts'
 import styles from './FormItem.module.css'
+
 const defaults = {
   span: 1,
   isFullWidth: false,
@@ -204,6 +206,13 @@ export const FormItem = (
     }
   }, [extraIconProp, extraProp])
 
+  const customizedRules = useMemo(() => {
+    if (isRequired) {
+      return [Form.Validators.required(), ...rules || []]
+    }
+    return rules || []
+  }, [isRequired, rules])
+
   return (
     <AntForm.Item
       {...defaultFormItemProps}
@@ -215,7 +224,7 @@ export const FormItem = (
       label={label}
       name={name}
       required={isRequired}
-      rules={rules}
+      rules={customizedRules}
       style={style}
     >
       {inputElement}

--- a/src/components/Form/FormItem/FormItem.tsx
+++ b/src/components/Form/FormItem/FormItem.tsx
@@ -22,7 +22,6 @@ import { PiBookOpen } from 'react-icons/pi'
 
 import { Button } from '../../Button'
 import { Checkbox } from '../../Checkbox'
-import { Form } from '../Form.tsx'
 import { FormItemProps } from '../props.ts'
 import ICircleFilled from '../../../assets/icons/ICircleFilled.svg'
 import { Icon } from '../../Icon'
@@ -206,13 +205,6 @@ export const FormItem = (
     }
   }, [extraIconProp, extraProp])
 
-  const customizedRules = useMemo(() => {
-    if (isRequired) {
-      return [Form.Validators.required(), ...rules || []]
-    }
-    return rules || []
-  }, [isRequired, rules])
-
   return (
     <AntForm.Item
       {...defaultFormItemProps}
@@ -224,7 +216,7 @@ export const FormItem = (
       label={label}
       name={name}
       required={isRequired}
-      rules={customizedRules}
+      rules={rules}
       style={style}
     >
       {inputElement}

--- a/src/components/Form/props.ts
+++ b/src/components/Form/props.ts
@@ -32,6 +32,11 @@ export type RenderProps = {
 export type FormProps<Values extends Record<string, unknown>> = {
 
   /**
+   * See how to use https://ant.design/components/form#formuseforminstance
+   */
+  form?: FormInstance;
+
+  /**
    * A unique identifier for the form.
    */
   id?: string;


### PR DESCRIPTION
### Description

##### CardSelection

From this:

- <img width="301" alt="Screenshot 2025-03-20 alle 14 50 15" src="https://github.com/user-attachments/assets/7a6ad5ff-7b6d-4ef5-bc4a-9ecfa4e21ddc" />

To this:

-  <img width="306" alt="Screenshot 2025-03-20 alle 14 50 23" src="https://github.com/user-attachments/assets/74da7b19-7cfe-4a64-85ee-364a64d38998" />


##### Form & FormItem

- now it is possible to use FormInstance to handle form method

### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g. enhancement, new component, bug).

    > **NOTE**  
    > Some labels are used to generate release note entries: you can find the complete mapping between PR labels and release note categories [here](https://github.com/mia-platform/design-system/blob/main/.github/release.yml).  
    For a more detailed overview of PR labels, please refer to the [dedicated CONTRIBUTING section](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md#pull-request-labels).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [x] Changes are covered by tests 
- [x] Changes to components are accessible and documented in the Storybook
- [ ] Typings have been updated
- [ ] New components are exported from the `src/index.ts` file
- [ ] New files include the Apache 2.0 License disclaimer
- [ ] The browser console does not contain errors
