### PR TITLE
feat(Modal): added modal onAfterClose prop

### DIFF
--- a/src/components/Modal/Modal.props.ts
+++ b/src/components/Modal/Modal.props.ts
@@ -78,6 +78,11 @@ export type ModalProps = {
   isVisible?: boolean,
 
   /**
+   * Specify a function that will be called when modal is closed completely.
+   */
+  afterClose?: () => void,
+
+  /**
    * Function performed at the click of the modal close (X) button. Typically one of the actions performed by
    * this function will be the `closeModal` of the `useModal` hook to ensure the effective closure of the modal.
    */

--- a/src/components/Modal/Modal.props.ts
+++ b/src/components/Modal/Modal.props.ts
@@ -80,7 +80,7 @@ export type ModalProps = {
   /**
    * Specify a function that will be called when modal is closed completely.
    */
-  afterClose?: () => void,
+  onAfterClose?: () => void,
 
   /**
    * Function performed at the click of the modal close (X) button. Typically one of the actions performed by

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -100,16 +100,16 @@ describe('Modal Component', () => {
     expect(baseElement).toMatchSnapshot()
   })
 
-  test('calls afterClose on modal hiding', async() => {
+  test('calls onAfterClose on modal hiding', async() => {
     const afterClose = jest.fn()
     const containerWithModalVisible = (isVisible: boolean): ReactNode => (
       <>
         <div data-testid="container-div-test-id" id="container-div" style={{ padding: 24 }} />
         <Modal
           {...props}
-          afterClose={afterClose}
           getContainer={() => document.getElementById('container-div') || document.body}
           isVisible={isVisible}
+          onAfterClose={afterClose}
         />
       </>
     )

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { ReactNode } from 'react'
+
 import { asideFixed, asideOpenable, docLink, footer, footerCustom, title } from './Modal.mocks'
 import { fireEvent, render, screen, waitFor, within } from '../../test-utils'
 import { Modal } from '.'
@@ -96,6 +98,27 @@ describe('Modal Component', () => {
     expect(screen.queryByRole('button', { name: /Close/i })).not.toBeInTheDocument()
 
     expect(baseElement).toMatchSnapshot()
+  })
+
+  test('calls afterClose on modal hiding', async() => {
+    const afterClose = jest.fn()
+    const containerWithModalVisible = (isVisible: boolean): ReactNode => (
+      <>
+        <div data-testid="container-div-test-id" id="container-div" style={{ padding: 24 }} />
+        <Modal
+          {...props}
+          afterClose={afterClose}
+          getContainer={() => document.getElementById('container-div') || document.body}
+          isVisible={isVisible}
+        />
+      </>
+    )
+    const { rerender } = render(containerWithModalVisible(true))
+    rerender(containerWithModalVisible(false))
+
+    await waitFor(() => {
+      expect(afterClose).toHaveBeenCalled()
+    })
   })
 
   test('renders modal with body full width', async() => {

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -61,6 +61,7 @@ export const Modal = ({
   isClosable = defaults.isClosable,
   isMaskClosable = defaults.isMaskClosable,
   isVisible = defaults.isVisible,
+  afterClose,
   onCloseClick,
   size = defaults.size,
   title,
@@ -80,6 +81,7 @@ export const Modal = ({
 
   return (
     <AntModal
+      afterClose={afterClose}
       centered
       className={modalClassNames}
       closable={isClosable}

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -61,7 +61,7 @@ export const Modal = ({
   isClosable = defaults.isClosable,
   isMaskClosable = defaults.isMaskClosable,
   isVisible = defaults.isVisible,
-  afterClose,
+  onAfterClose,
   onCloseClick,
   size = defaults.size,
   title,
@@ -81,7 +81,7 @@ export const Modal = ({
 
   return (
     <AntModal
-      afterClose={afterClose}
+      afterClose={onAfterClose}
       centered
       className={modalClassNames}
       closable={isClosable}


### PR DESCRIPTION
### Description

Added afterClose callback to intercept the modal closing. At the time the only way possible is using the onCloseClick callback, but this gets fired only on the x button press (not the backdrop click or the cancel button press).


### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g. enhancement, new component, bug).

    > **NOTE**  
    > Some labels are used to generate release note entries: you can find the complete mapping between PR labels and release note categories [here](https://github.com/mia-platform/design-system/blob/main/.github/release.yml).  
    For a more detailed overview of PR labels, please refer to the [dedicated CONTRIBUTING section](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md#pull-request-labels).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [x] Changes are covered by tests 
- [x] Changes to components are accessible and documented in the Storybook
- [x] Typings have been updated
- [x] New components are exported from the `src/index.ts` file
- [x] New files include the Apache 2.0 License disclaimer
- [x] The browser console does not contain errors
