### PR TITLE
changed(): description color to checkbox, radio and switch

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -22,6 +22,7 @@ import classnames from 'classnames'
 
 import { BodyS } from '../Typography/BodyX/BodyS'
 import { CheckboxProps } from './props'
+import { Hierarchy } from '../Typography/BodyX/BodyX.types'
 import styles from './checkbox.module.css'
 
 export const defaults = {
@@ -68,7 +69,7 @@ export const Checkbox = <T = never, >({
           <BodyS>{children}</BodyS>
         )}
         {description && (
-          <BodyS>{description}</BodyS>
+          <BodyS hierarchy={Hierarchy.Subtle}>{description}</BodyS>
         )}
       </div>
     </AntCheckbox>

--- a/src/components/CheckboxGroup/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/src/components/CheckboxGroup/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -243,7 +243,7 @@ exports[`CheckboxGroup renders correctly with descriptions 1`] = `
               checkbox 1
             </div>
             <div
-              class="ant-typography bodyS css-dev-only-do-not-override-5wsri9"
+              class="ant-typography bodyS subtle css-dev-only-do-not-override-5wsri9"
               role="paragraph"
             >
               description 1
@@ -277,7 +277,7 @@ exports[`CheckboxGroup renders correctly with descriptions 1`] = `
               checkbox 1
             </div>
             <div
-              class="ant-typography bodyS css-dev-only-do-not-override-5wsri9"
+              class="ant-typography bodyS subtle css-dev-only-do-not-override-5wsri9"
               role="paragraph"
             >
               description 2
@@ -325,7 +325,7 @@ exports[`CheckboxGroup renders correctly with partially disabled options 1`] = `
               checkbox 1
             </div>
             <div
-              class="ant-typography bodyS css-dev-only-do-not-override-5wsri9"
+              class="ant-typography bodyS subtle css-dev-only-do-not-override-5wsri9"
               role="paragraph"
             >
               description 1
@@ -359,7 +359,7 @@ exports[`CheckboxGroup renders correctly with partially disabled options 1`] = `
               checkbox 1
             </div>
             <div
-              class="ant-typography bodyS css-dev-only-do-not-override-5wsri9"
+              class="ant-typography bodyS subtle css-dev-only-do-not-override-5wsri9"
               role="paragraph"
             >
               description 2

--- a/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -247,7 +247,7 @@ exports[`RadioGroup renders correctly with descriptions 1`] = `
               option 1
             </div>
             <div
-              class="ant-typography bodyS css-dev-only-do-not-override-5wsri9"
+              class="ant-typography bodyS subtle css-dev-only-do-not-override-5wsri9"
               role="paragraph"
             >
               description 1
@@ -281,7 +281,7 @@ exports[`RadioGroup renders correctly with descriptions 1`] = `
               option 2
             </div>
             <div
-              class="ant-typography bodyS css-dev-only-do-not-override-5wsri9"
+              class="ant-typography bodyS subtle css-dev-only-do-not-override-5wsri9"
               role="paragraph"
             >
               description 2

--- a/src/components/RadioGroup/components/Radio/__snapshots__/index.test.tsx.snap
+++ b/src/components/RadioGroup/components/Radio/__snapshots__/index.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`Radio renders correctly with label, value and description props 1`] = `
           label test
         </div>
         <div
-          class="ant-typography bodyS css-dev-only-do-not-override-5wsri9"
+          class="ant-typography bodyS subtle css-dev-only-do-not-override-5wsri9"
           role="paragraph"
         >
           description test

--- a/src/components/RadioGroup/components/Radio/index.tsx
+++ b/src/components/RadioGroup/components/Radio/index.tsx
@@ -21,6 +21,7 @@ import { ReactElement } from 'react'
 import classNames from 'classnames'
 
 import { BodyS } from '../../../Typography/BodyX/BodyS'
+import { Hierarchy } from '../../../Typography/BodyX/BodyX.types'
 import { RadioProps } from '../../props'
 import styles from './index.module.css'
 
@@ -56,7 +57,7 @@ export const Radio = <T, >({
           <BodyS>{children}</BodyS>
         )}
         {description && (
-          <BodyS>{description}</BodyS>
+          <BodyS hierarchy={Hierarchy.Subtle}>{description}</BodyS>
         )}
       </div>
     </AntRadio>

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -22,6 +22,7 @@ import type { SwitchSize } from 'antd/es/switch'
 import classNames from 'classnames'
 
 import { BodyS } from '../Typography/BodyX/BodyS'
+import { Hierarchy } from '../Typography/BodyX/BodyX.types'
 import { Size } from './Switch.types'
 import { SwitchProps } from './Switch.props'
 import styles from './Switch.module.css'
@@ -82,7 +83,7 @@ export const Switch = ({
       {
         text && description && (
           <div className={descriptionClassName}>
-            <BodyS>{description}</BodyS>
+            <BodyS hierarchy={Hierarchy.Subtle}>{description}</BodyS>
           </div>
         )
       }

--- a/src/components/Typography/BodyX/BodyX.types.ts
+++ b/src/components/Typography/BodyX/BodyX.types.ts
@@ -36,5 +36,5 @@ export type BodyXSize = {
 
 export enum Hierarchy {
   Bold = 'bold',
-  Subtle = 'subtle'
+  Subtle = 'subtle',
 }


### PR DESCRIPTION
### Description

CHanged the color of descriptions inside components checkbox, radio and switch, using the new prop "hierarchy" with value "subtle"

### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [ ] The PR has been labeled according to the type of changes (e.g. enhancement, new component, bug).

    > **NOTE**  
    > Some labels are used to generate release note entries: you can find the complete mapping between PR labels and release note categories [here](https://github.com/mia-platform/design-system/blob/main/.github/release.yml).  
    For a more detailed overview of PR labels, please refer to the [dedicated CONTRIBUTING section](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md#pull-request-labels).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [x] Changes are covered by tests 
- [x] Changes to components are accessible and documented in the Storybook
- [ ] Typings have been updated
- [ ] New components are exported from the `src/index.ts` file
- [ ] New files include the Apache 2.0 License disclaimer
- [ ] The browser console does not contain errors
