### PR TITLE
feat(Select): add optionRender props to select component

### DIFF
--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -19,6 +19,7 @@
 import { Meta, StoryObj } from '@storybook/react'
 import { FaDiamond } from 'react-icons/fa6'
 import { Flex } from 'antd'
+import { ReactNode } from 'react'
 
 import { Icon } from '../Icon'
 import { Select } from '.'
@@ -40,6 +41,7 @@ const options = [
   ...Array(5).keys(),
 ].map((id) => ({
   value: `value ${id + 1}`,
+  description: 'A description',
 }))
 
 export const Default: Story = {
@@ -138,5 +140,20 @@ export const MultipleDisabled: Story = {
     options,
     isMultiple: true,
     isDisabled: true,
+  },
+}
+
+export const CustomOptionRenderInDropdown: Story = {
+  args: {
+    defaultValue: options[0].value,
+    options,
+    optionRender: (option: {value?: ReactNode, description?: string}) => {
+      return (
+        <Flex align="center" gap={8}>
+          <Icon component={FaDiamond} size={16} />
+          <Typography.BodyM isBold>{option.value}</Typography.BodyM>
+        </Flex>
+      )
+    },
   },
 }

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { ReactNode } from 'react'
 import { within } from '@testing-library/react'
 
 import { render, screen, userEvent } from '../../test-utils'
@@ -166,5 +167,45 @@ describe('Input Component', () => {
 
     const placeholder = screen.getByText(`number of collapsed tag: ${options.length - 1}`)
     expect(placeholder).toBeVisible()
+  })
+
+  test('Should use option render opening the select dropdown', async() => {
+    const optionsWithDescription = [
+      ...Array(5).keys(),
+    ].map((id) => ({
+      value: `Custom value ${id + 1}`,
+      id: `value ${id + 1}`,
+      description: `description ${id + 1}`,
+    }))
+    render(
+      <Select
+        defaultValue={optionsWithDescription[0].id}
+        optionRender={(option) => (
+          <span>
+            {option.data.value}
+            {' - '}
+            {option.data.description as ReactNode}
+          </span>
+        )}
+        options={optionsWithDescription}
+      />
+    )
+
+    const defaultSelection = screen.getByTitle('value 1')
+    expect(defaultSelection).toBeInTheDocument()
+
+    const input = screen.getByRole<HTMLInputElement>('combobox')
+    await userEvent.click(input)
+
+    expect(screen.getByTitle('Custom value 1')).toBeInTheDocument()
+    expect(screen.getByText(/description 1/i)).toBeInTheDocument()
+    expect(screen.getByTitle('Custom value 2')).toBeInTheDocument()
+    expect(screen.getByText(/description 2/i)).toBeInTheDocument()
+    expect(screen.getByTitle('Custom value 3')).toBeInTheDocument()
+    expect(screen.getByText(/description 3/i)).toBeInTheDocument()
+    expect(screen.getByTitle('Custom value 4')).toBeInTheDocument()
+    expect(screen.getByText(/description 4/i)).toBeInTheDocument()
+    expect(screen.getByTitle('Custom value 5')).toBeInTheDocument()
+    expect(screen.getByText(/description 5/i)).toBeInTheDocument()
   })
 })

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -77,6 +77,7 @@ export const Select = <ValueType, >(
     onSelect,
     onDeselect,
     isMultiple,
+    optionRender,
   }: SelectProps<ValueType>) : ReactElement => {
   const [open, setOpen] = useState(false)
 
@@ -110,6 +111,7 @@ export const Select = <ValueType, >(
       maxTagPlaceholder={maxTagPlaceholder}
       menuItemSelectedIcon={menuItemSelectedIcon}
       mode={isMultiple ? 'multiple' : undefined}
+      optionRender={optionRender}
       options={options}
       placeholder={placeholder}
       popupMatchSelectWidth={false}

--- a/src/components/Select/props.ts
+++ b/src/components/Select/props.ts
@@ -17,6 +17,7 @@
  */
 
 import type { SelectProps as AntdSelectProps } from 'antd'
+import { FlattenOptionData } from 'rc-select/lib/interface'
 import { ReactNode } from 'react'
 
 import { BaseInputProps } from '../BaseInput/props'
@@ -25,6 +26,7 @@ import { SearchSelectHandler } from '../Search/props'
 export type SelectItem<ValueType> = {
   value: ValueType
   label?: ReactNode
+  [name: string]: unknown;
 }
 
 export type SelectChangeHandler<ValueType> = (
@@ -36,6 +38,11 @@ export type SelectSelectHandler<ValueType> = (
     value: ValueType extends (infer E)[] ? E : ValueType,
     option: SelectItem<ValueType>
   ) => void
+
+export type OptionRender<ValueType> = (
+  option: FlattenOptionData<SelectItem<ValueType>>,
+  info: {index: number}
+) => ReactNode
 
 export type SelectProps<ValueType = unknown> = BaseInputProps & {
 
@@ -50,7 +57,7 @@ export type SelectProps<ValueType = unknown> = BaseInputProps & {
   value?: ValueType
 
   /**
-   * The default valute for the input.
+   * The default value for the input.
    */
   defaultValue?: ValueType
 
@@ -99,4 +106,8 @@ export type SelectProps<ValueType = unknown> = BaseInputProps & {
    */
   isMultiple?: boolean
 
+  /**
+   * Customize the rendering dropdown options.
+   */
+  optionRender?: OptionRender<ValueType>
 }


### PR DESCRIPTION
### Description

In this PR, I add the support to the `optionRender` to possibly add some information in the dropdown. For example, a description which can help to choose the correct option.

### Select

### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g. enhancement, new component, bug).

    > **NOTE**  
    > Some labels are used to generate release note entries: you can find the complete mapping between PR labels and release note categories [here](https://github.com/mia-platform/design-system/blob/main/.github/release.yml).  
    For a more detailed overview of PR labels, please refer to the [dedicated CONTRIBUTING section](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md#pull-request-labels).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [x] Changes are covered by tests 
- [x] Changes to components are accessible and documented in the Storybook
- [x] Typings have been updated
- [ ] New components are exported from the `src/index.ts` file
- [ ] New files include the Apache 2.0 License disclaimer
- [x] The browser console does not contain errors
