### PR TITLE
feat(select): fix select virtualization, configuring popup width

### DIFF
--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -39,7 +39,7 @@ type Story = StoryObj<typeof meta>
 const selectOptions = [
   ...Array(5).keys(),
 ].map((id) => ({
-  value: `value ${id + 1}`,
+  value: `value very very long ${id + 1}`,
 }))
 
 export const Default: Story = {

--- a/src/components/Input/InputAddon.tsx
+++ b/src/components/Input/InputAddon.tsx
@@ -79,6 +79,7 @@ export const InputAddon = ({
         <Select
           isDisabled={isDisabled}
           isFullWidth={false}
+          popupMatchSelectWidth={false}
           onChange={onChange}
           {...props}
         />

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -17,7 +17,7 @@
  */
 
 import { Meta, StoryObj } from '@storybook/react'
-import { ReactNode, useCallback, useState } from 'react'
+import { ReactElement, ReactNode, useCallback, useState } from 'react'
 import { FaDiamond } from 'react-icons/fa6'
 import { Flex } from 'antd'
 import { action } from '@storybook/addon-actions'
@@ -28,8 +28,20 @@ import { Select } from '.'
 import { SelectProps } from './props'
 import { Typography } from '../Typography'
 
+const { Hierarchy } = Typography.BodyS
+
+const WrappedSelect = (props: SelectProps): ReactElement => {
+  return (
+    <div style={{ width: '50%' }}>
+      <Select
+        {...props}
+      />
+    </div>
+  )
+}
+
 const meta = {
-  component: Select,
+  component: WrappedSelect,
   args: {
     placeholder: 'Placeholder...',
   },
@@ -44,7 +56,7 @@ const options = [
   ...Array(5).keys(),
 ].map((id) => ({
   value: `value ${id + 1}`,
-  description: 'A description',
+  description: `A very ${'long '.repeat(120)} description`,
 }))
 
 export const Default: Story = {
@@ -150,11 +162,21 @@ export const CustomOptionRenderInDropdown: Story = {
   args: {
     defaultValue: options[0].value,
     options,
-    optionRender: (option: {value?: ReactNode, description?: string}) => {
+    optionRender: (option) => {
+      const optionData = option.data as { description?: string }
       return (
-        <Flex align="center" gap={8}>
-          <Icon component={FaDiamond} size={16} />
-          <Typography.BodyM isBold>{option.value}</Typography.BodyM>
+        <Flex
+          gap={8}
+          vertical
+          wrap
+        >
+          <Flex gap={8}>
+            <Icon component={FaDiamond} size={16} />
+            <Typography.BodyM isBold>{option.value}</Typography.BodyM>
+          </Flex>
+          {optionData.description
+            ? <Typography.BodyS ellipsis={{ rows: 4, tooltip: true }} hierarchy={Hierarchy.Subtle}><span style={{ minWidth: 0, wordBreak: 'break-word', whiteSpace: 'normal' }}>{optionData.description}</span></Typography.BodyS>
+            : null}
         </Flex>
       )
     },

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -83,6 +83,7 @@ export const Select = <ValueType, >(
     filterOption,
     optionFilterProp,
     dropdownRender,
+    popupMatchSelectWidth,
   }: SelectProps<ValueType>) : ReactElement => {
   const [open, setOpen] = useState(false)
 
@@ -122,7 +123,7 @@ export const Select = <ValueType, >(
       optionRender={optionRender}
       options={options}
       placeholder={placeholder}
-      popupMatchSelectWidth={false}
+      popupMatchSelectWidth={popupMatchSelectWidth}
       showSearch={Boolean(onSearch || filterOption)}
       suffixIcon={suffixIcon}
       tagRender={tagRender}

--- a/src/components/Select/props.ts
+++ b/src/components/Select/props.ts
@@ -135,4 +135,11 @@ export type SelectProps<ValueType = unknown> = BaseInputProps & {
    * Customize the rendering of the dropdown.
    */
   dropdownRender?: (menu: ReactNode) => ReactElement
+
+  /**
+   * Determine whether the popup menu and the select input are the same width.
+   * Default set min-width same as input. Will ignore when value less than select width.
+   * false will disable virtual scroll
+   */
+  popupMatchSelectWidth?: boolean | number
 }

--- a/src/components/Select/props.ts
+++ b/src/components/Select/props.ts
@@ -138,7 +138,7 @@ export type SelectProps<ValueType = unknown> = BaseInputProps & {
 
   /**
    * Determine whether the popup menu and the select input should have the same width.
-   * Default set `min-width` of the popup to match the input. 
+   * Default set `min-width` of the popup to match the input.
    * This is ignored when the value is less than the select input's width.
    * Setting this to `false` will disable the virtual scroll
    */

--- a/src/components/Select/props.ts
+++ b/src/components/Select/props.ts
@@ -137,9 +137,10 @@ export type SelectProps<ValueType = unknown> = BaseInputProps & {
   dropdownRender?: (menu: ReactNode) => ReactElement
 
   /**
-   * Determine whether the popup menu and the select input are the same width.
-   * Default set min-width same as input. Will ignore when value less than select width.
-   * false will disable virtual scroll
+   * Determine whether the popup menu and the select input should have the same width.
+   * Default set `min-width` of the popup to match the input. 
+   * This is ignored when the value is less than the select input's width.
+   * Setting this to `false` will disable the virtual scroll
    */
   popupMatchSelectWidth?: boolean | number
 }


### PR DESCRIPTION
### Description

In this PR, resolve issues when the popup content is longer than the width.

Also, resolves #763 using select virtualization by default.

##### Select

### Addressed issue

Resolves #763

### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g. enhancement, new component, bug).

    > **NOTE**  
    > Some labels are used to generate release note entries: you can find the complete mapping between PR labels and release note categories [here](https://github.com/mia-platform/design-system/blob/main/.github/release.yml).  
    For a more detailed overview of PR labels, please refer to the [dedicated CONTRIBUTING section](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md#pull-request-labels).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [ ] Changes are covered by tests 
- [x] Changes to components are accessible and documented in the Storybook
- [x] Typings have been updated
- [ ] New components are exported from the `src/index.ts` file
- [ ] New files include the Apache 2.0 License disclaimer
- [x] The browser console does not contain errors
