### PR TITLE
change(select): dropdown take select input width for long labels options

### DIFF
--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -22,6 +22,7 @@ import { FaDiamond } from 'react-icons/fa6'
 import { Flex } from 'antd'
 import { action } from '@storybook/addon-actions'
 
+import { Card } from '../Card'
 import { Dropdown } from '../Dropdown'
 import { Icon } from '../Icon'
 import { Select } from '.'
@@ -230,3 +231,30 @@ export const WithFilter: Story = {
     filterOption: true,
   },
 }
+
+export const WithLongLabelsInCard: Story = {
+  args: {
+    options: [
+      { value: 'short1', label: 'Short option' },
+      { value: 'short2', label: 'Another short' },
+      {
+        value: 'long',
+        label: 'This is a very long option label that should test how the select component handles text that exceeds the normal width and potentially wraps or truncates in the dropdown menu interface',
+      },
+      { value: 'short3', label: 'Normal option' },
+      {
+        value: 'long2',
+        label: 'Another extremely long option label with even more text to demonstrate various edge cases and ensure proper rendering behavior across different screen sizes and container widths',
+      },
+    ],
+    placeholder: 'Select an option',
+  },
+  decorators: [
+    (Story) => (
+      <Card>
+        <Story />
+      </Card>
+    ),
+  ],
+}
+

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -83,6 +83,7 @@ export const Select = <ValueType, >(
     filterOption,
     optionFilterProp,
     dropdownRender,
+    popupMatchSelectWidth,
   }: SelectProps<ValueType>) : ReactElement => {
   const [open, setOpen] = useState(false)
 
@@ -122,7 +123,7 @@ export const Select = <ValueType, >(
       optionRender={optionRender}
       options={options}
       placeholder={placeholder}
-      popupMatchSelectWidth={false}
+      popupMatchSelectWidth={popupMatchSelectWidth}
       showSearch={Boolean(onSearch || filterOption)}
       suffixIcon={suffixIcon}
       tagRender={tagRender}

--- a/src/components/Select/props.ts
+++ b/src/components/Select/props.ts
@@ -135,4 +135,9 @@ export type SelectProps<ValueType = unknown> = BaseInputProps & {
    * Customize the rendering of the dropdown.
    */
   dropdownRender?: (menu: ReactNode) => ReactElement
+
+  /**
+   * Whether dropdown's width should match the select's width. Defaults to true.
+   */
+  popupMatchSelectWidth?: boolean
 }


### PR DESCRIPTION

### Description

Exposed prop `popupMatchSelectWidth` that was set always to false. Now has default value true.
This helps to show correctly dropdown and options with labels that exceed the select width

##### <Changed component name>
    - Select


### Addressed issue

<!-- Link to the issue, if present. E.g. 
    Closes #XYZ
-->

### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g. enhancement, new component, bug).

    > **NOTE**  
    > Some labels are used to generate release note entries: you can find the complete mapping between PR labels and release note categories [here](https://github.com/mia-platform/design-system/blob/main/.github/release.yml).  
    For a more detailed overview of PR labels, please refer to the [dedicated CONTRIBUTING section](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md#pull-request-labels).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [x] Changes are covered by tests 
- [x] Changes to components are accessible and documented in the Storybook
- [x] Typings have been updated
- [x] New components are exported from the `src/index.ts` file
- [x] New files include the Apache 2.0 License disclaimer
- [x] The browser console does not contain errors
