### PR TITLE
fix(badge): custom icon can be a react node

### DIFF
--- a/src/components/Badge/Badge.props.ts
+++ b/src/components/Badge/Badge.props.ts
@@ -35,7 +35,7 @@ export type BadgeProps = {
   /**
    * The icon component to render within the badge.
    */
-  icon: IconComponent;
+  icon: IconComponent | ReactNode;
 
   /**
    * The main title text, it displays formatted text or customized content within the badge.

--- a/src/components/Badge/Badge.test.tsx
+++ b/src/components/Badge/Badge.test.tsx
@@ -37,7 +37,6 @@ describe('Badge Component', () => {
   test('renders a badge with custom icon and title', () => {
     const { asFragment } = render(<Badge icon={<img src="https://www.w3schools.com/images/lamp.jpg" />} title="Title" />)
 
-    screen.logTestingPlaygroundURL()
     expect(screen.getByText('Title')).toBeVisible()
     expect(asFragment()).toMatchSnapshot()
   })

--- a/src/components/Badge/Badge.test.tsx
+++ b/src/components/Badge/Badge.test.tsx
@@ -34,6 +34,14 @@ describe('Badge Component', () => {
     expect(asFragment()).toMatchSnapshot()
   })
 
+  test('renders a badge with custom icon and title', () => {
+    const { asFragment } = render(<Badge icon={<img src="https://www.w3schools.com/images/lamp.jpg" />} title="Title" />)
+
+    screen.logTestingPlaygroundURL()
+    expect(screen.getByText('Title')).toBeVisible()
+    expect(asFragment()).toMatchSnapshot()
+  })
+
   test('renders a badge with description', () => {
     const { asFragment } = render(
       <Badge

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -38,11 +38,17 @@ export const Badge = ({
 }: BadgeProps): ReactElement => {
   const { palette } = useTheme()
 
-  const icon = useMemo(() => (
-    <div className={styles.icon} data-testid="badge-icon">
-      <Icon color={palette.text.neutral.subtle} component={customIcon} size={48} />
-    </div>
-  ), [customIcon, palette.text.neutral.subtle])
+  const icon = useMemo(() => {
+    if (typeof customIcon === 'function') {
+      return (
+        <div className={styles.icon} data-testid="badge-icon">
+          <Icon color={palette.text.neutral.subtle} component={customIcon} size={48} />
+        </div>
+      )
+    }
+
+    return customIcon
+  }, [customIcon, palette.text.neutral.subtle])
 
   const title = useMemo(() => (
     <div className={styles.title}>

--- a/src/components/Badge/__snapshots__/Badge.test.tsx.snap
+++ b/src/components/Badge/__snapshots__/Badge.test.tsx.snap
@@ -65,6 +65,33 @@ exports[`Badge Component renders a badge with an extra 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Badge Component renders a badge with custom icon and title 1`] = `
+<DocumentFragment>
+  <div
+    class="badge"
+  >
+    <img
+      src="https://www.w3schools.com/images/lamp.jpg"
+    />
+    <div
+      class="content"
+    >
+      <div
+        class="title"
+      >
+        <h3
+          aria-label="Title"
+          class="mia-platform-typography mia-platform-typography-ellipsis mia-platform-typography-ellipsis-single-line h3"
+          role="h3"
+        >
+          Title
+        </h3>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Badge Component renders a badge with description 1`] = `
 <DocumentFragment>
   <div


### PR DESCRIPTION
### Description

##### Badge component
- icon prop accepts IconComponent and React.Node so that is possible to use a custom icon or image in the icon section of the Badge

### Addressed issue

Closes #1015 

### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g. enhancement, new component, bug).

    > **NOTE**  
    > Some labels are used to generate release note entries: you can find the complete mapping between PR labels and release note categories [here](https://github.com/mia-platform/design-system/blob/main/.github/release.yml).  
    For a more detailed overview of PR labels, please refer to the [dedicated CONTRIBUTING section](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md#pull-request-labels).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [x] Changes are covered by tests 
- [x] Changes to components are accessible and documented in the Storybook
- [x] Typings have been updated
- [ ] New components are exported from the `src/index.ts` file
- [ ] New files include the Apache 2.0 License disclaimer
- [ ] The browser console does not contain errors
