### PR TITLE
add dropdown header; reset search on dropdown close

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -209,23 +209,11 @@ export const Searchable: Story = {
   },
 }
 
-export const WithSearchAndFooter: Story = {
-  args: {
-    isSearchable: true,
-    footer: {
-      top: <Typography.BodyM>{'Top description'}</Typography.BodyM>,
-      bottom: <Typography.BodyM>{'Bottom description'}</Typography.BodyM>,
-      actions: [{
-        icon: <Icon component={PiAcorn} size={16} />,
-        label: 'OK',
-        onClick: action('footer button click'),
-      }, {
-        icon: <Icon component={PiNut} size={16} />,
-        label: 'NOT OK',
-        onClick: action('footer button 2 click'),
-      }],
-    },
-  },
+const header = {
+  bottom: <div style={{ marginTop: '4px', display: 'flex', flexDirection: 'column', gap: '4px' }}>
+    <div style={{ width: '100%', height: '1px', background: '#F2F2F2' }} />
+    <div style={{ color: '#898989', fontSize: '14px' }}>Latest 20 conversations (86 total)</div>
+  </div>,
 }
 
 export const SerchPerformedByExternalComponent: Story = {
@@ -260,7 +248,7 @@ export const SerchPerformedByExternalComponent: Story = {
         label: 'Orange',
       },
       {
-        id: 'conversation-7',
+        id: 'conversation-8',
         label: 'Apple',
       },
       {
@@ -293,7 +281,7 @@ export const SerchPerformedByExternalComponent: Story = {
         const res = args.items.filter(
           (item) => {
             return !search
-              || (item
+            || (item
               && (item.label as string).toLowerCase().includes(search.toLowerCase()))
           }
         )
@@ -329,6 +317,35 @@ export const SerchPerformedByExternalComponent: Story = {
         </Dropdown>
       </div>
     )
+  },
+}
+
+export const WithHeader: Story = {
+  args: {
+    header: { top: <div>custom header</div> },
+  },
+}
+
+export const WithSearchAndBottomHeader: Story = {
+  args: {
+    isSearchable: true,
+    header: {
+      bottom: <div style={{ marginTop: '4px', display: 'flex', flexDirection: 'column', gap: '4px' }}>
+        <div style={{ width: '100%', height: '1px', background: '#F2F2F2' }} />
+        <div style={{ color: '#898989' }}>Custom bottom header</div>
+      </div>,
+    },
+  },
+}
+
+export const WithSearchAndTopHeader: Story = {
+  args: {
+    isSearchable: true,
+    header: {
+      top: <div style={{ marginBottom: '4px', display: 'flex', flexDirection: 'column', gap: '4px' }}>
+        <div style={{ color: '#898989' }}>Custom top header</div>
+      </div>,
+    },
   },
 }
 

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -209,13 +209,6 @@ export const Searchable: Story = {
   },
 }
 
-const header = {
-  bottom: <div style={{ marginTop: '4px', display: 'flex', flexDirection: 'column', gap: '4px' }}>
-    <div style={{ width: '100%', height: '1px', background: '#F2F2F2' }} />
-    <div style={{ color: '#898989', fontSize: '14px' }}>Latest 20 conversations (86 total)</div>
-  </div>,
-}
-
 export const SerchPerformedByExternalComponent: Story = {
   args: {
     items: [

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -405,6 +405,62 @@ describe('Dropdown Component', () => {
     })
   })
 
+  describe('with header', () => {
+    it('renders top header', async() => {
+      const props: DropdownProps = {
+        ...defaultProps,
+        header: {
+          top: <div data-testid="header-top-id">{'some custom header top description'}</div>,
+        },
+      }
+      renderDropdown({ props })
+
+      const button = screen.getByText('test-trigger-button')
+      await userEvent.click(button)
+
+      const header = await screen.findByTestId('header-top-id')
+      expect(header).toBeInTheDocument()
+    })
+
+    it('renders bottom header', async() => {
+      const props: DropdownProps = {
+        ...defaultProps,
+        header: {
+          bottom: <div data-testid="header-bottom-id">{'some custom header bottom description'}</div>,
+        },
+      }
+      renderDropdown({ props })
+
+      const button = screen.getByText('test-trigger-button')
+      await userEvent.click(button)
+
+      const header = await screen.findByTestId('header-bottom-id')
+      expect(header).toBeInTheDocument()
+    })
+
+    it('renders top and bottom header and search input', async() => {
+      const props: DropdownProps = {
+        ...defaultProps,
+        isSearchable: true,
+        header: {
+          top: <div data-testid="header-top-id">{'some custom header top description'}</div>,
+          bottom: <div data-testid="header-bottom-id">{'some custom header bottom description'}</div>,
+        },
+      }
+      renderDropdown({ props })
+
+      const button = screen.getByText('test-trigger-button')
+      await userEvent.click(button)
+
+      const searchInput = screen.getByRole('textbox')
+      expect(searchInput).toBeInTheDocument()
+      const headerTop = await screen.findByTestId('header-top-id')
+      expect(headerTop).toBeInTheDocument()
+      const headerBottom = await screen.findByTestId('header-bottom-id')
+      expect(headerBottom).toBeInTheDocument()
+    })
+  })
+
   describe('with footer', () => {
     it('renders footer', async() => {
       const props: DropdownProps = {

--- a/src/components/Dropdown/props.ts
+++ b/src/components/Dropdown/props.ts
@@ -101,6 +101,21 @@ export type FooterAction = {
   onClick: () => void
 }
 
+export type DropdownHeader = {
+
+  /**
+   * Content displayed **above** the search input (if visible via `isSerchable` prop).
+   * if the search input is not visible should be provided only one of `top` or `bottom` props.
+   */
+  top?: ReactNode
+
+  /**
+   * Content displayed **below** the search input (if visible via `isSerchable` prop).
+   * if the search input is not visible should be provided only one of `top` or `bottom` props.
+   */
+  bottom?: ReactNode
+}
+
 export type DropdownFooter = {
 
   /**
@@ -162,6 +177,11 @@ export type DropdownProps = {
    * The ReactElement used as anchor to trigger the Dropdown visibility.
    */
   children?: ReactElement
+
+  /**
+   * Optional header configuration.
+   */
+  header?: DropdownHeader
 
   /**
    * Optional footer configuration.


### PR DESCRIPTION
### Dropdown header + clear search on dropdown close

- Added prop `header` to add a custom header component to the dropdown. It contains two fields (`top`, and `bottom`) as the header can be placed both above and below the search input (when visible)

- Reset of search input when the dropdown is closed

<img width="435" height="426" alt="Screenshot 2025-09-30 alle 14 36 19" src="https://github.com/user-attachments/assets/c039f093-d49e-4cb3-9ed1-2d29d5567bbf" />

### [IMPORTANT] PR Checklist

- [x] I am aware of standards and conventions adopted in this repository, defined in the [CONTRIBUTING.md file](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md)

#### PR conventions

Please make sure your PR complies with the following rules before submitting it.

- [x] PR title follows the `<type>(<scope>): <subject>` structure
- [x] The PR has been labeled according to the type of changes (e.g. enhancement, new component, bug).

    > **NOTE**  
    > Some labels are used to generate release note entries: you can find the complete mapping between PR labels and release note categories [here](https://github.com/mia-platform/design-system/blob/main/.github/release.yml).  
    For a more detailed overview of PR labels, please refer to the [dedicated CONTRIBUTING section](https://github.com/mia-platform/design-system/blob/main/CONTRIBUTING.md#pull-request-labels).

#### Additional code checks

Based on your changes, some of these checks may not apply. Please make sure to check the relevant items in the list.

- [x] Changes are covered by tests 
- [x] Changes to components are accessible and documented in the Storybook
- [x] Typings have been updated
- [x] New components are exported from the `src/index.ts` file
- [x] New files include the Apache 2.0 License disclaimer
- [x] The browser console does not contain errors
